### PR TITLE
IGraphicsWin.cpp: Prompt for File file-extension longer than 16 chars

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1610,7 +1610,7 @@ void IGraphicsWin::PromptForFile(WDL_String& fileName, WDL_String& path, EFileAc
   if (CStringHasContents(ext))
   {
     wchar_t extStr[256];
-    wchar_t defExtStr[16];
+    wchar_t defExtStr[256];
     int i, p, n = strlen(ext);
     bool separator = true;
         


### PR DESCRIPTION
This commit updates the PromptForFile function in IGraphicsWin.cpp to handle file extensions longer than 16 characters. The key change is increasing the size of the buffer used for the default file extension from 16 to 256 characters.

Changes:

    Increased the buffer size of defExtStr from 16 to 256 characters to accommodate longer file extensions.

Reason:

    The previous implementation used a buffer size of 16 characters for file extensions, which was insufficient for handling longer extensions, leading to potential truncation or incorrect behavior.

Impact:

    This change ensures that the function can properly handle file extensions longer than 16 characters, improving robustness and compatibility with a wider range of file types.