### PR TITLE
Add zIndex Feature to IGraphics::AttachControl

### DIFF
--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -298,21 +298,31 @@ void IGraphics::AttachPanelBackground(const IPattern& color)
   mControls.Insert(0, pBG);
 }
 
-IControl* IGraphics::AttachControl(IControl* pControl, int ctrlTag, const char* group)
+IControl* IGraphics::AttachControl(IControl* pControl, int ctrlTag, const char* group, int zIndex)
 {
-  if(ctrlTag > kNoTag)
+  if (ctrlTag > kNoTag)
   {
     auto result = mCtrlTags.insert(std::make_pair(ctrlTag, pControl));
     assert(result.second && "AttachControl failed: ctrl tags must be unique");
-    
+
     if (!result.second)
       return nullptr;
   }
-  
+
   pControl->SetDelegate(*GetDelegate());
   pControl->SetGroup(group);
-  mControls.Add(pControl);
-    
+
+  if (zIndex < 0)
+  {
+    mControls.Add(pControl);
+  }
+  else
+  {
+    int nControls = mControls.GetSize();
+    int zIdx = std::clamp(zIndex, 0, nControls);
+    mControls.Insert(zIdx, pControl);
+  }
+
   pControl->OnAttached();
   return pControl;
 }

--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -1341,12 +1341,13 @@ public:
   /** @return \c true if performance display is shown */
   bool ShowingFPSDisplay() { return mPerfDisplay != nullptr; }
   
-  /** Attach an IControl to the graphics context and add it to the top of the control stack. The control is owned by the graphics context and will be deleted when the context is deleted.
+ /** Attach an IControl to the graphics context and add it to the control stack. The control is owned by the graphics context and will be deleted when the context is deleted.
    * @param pControl A pointer to an IControl to attach.
    * @param ctrlTag An integer tag that you can use to identify the control
    * @param group A CString that you can use to address controlled by group
-   * @return The index of the control (and the number of controls in the stack) */
-  IControl* AttachControl(IControl* pControl, int ctrlTag = kNoTag, const char* group = "");
+   * @param zIndex The position in the control stack to insert the control. Use a negative value to add to the top of the stack.
+   * @return The control that was attached */
+  IControl* AttachControl(IControl* pControl, int ctrlTag = kNoTag, const char* group = "", int zIndex = -1);
 
   /** Get the control at a certain index in the control stack
    * @param idx The index of the control to get


### PR DESCRIPTION
This pull request introduces a `zIndex` feature to the `IGraphics::AttachControl` function. The `zIndex` parameter allows specifying the insertion position of the control within the control stack, giving greater control over the order of controls.

### Changes:
- Updated the `AttachControl` function in `IGraphics.cpp` to include the `zIndex` parameter.
- Modified the function to insert the control at the specified `zIndex` if `zIndex` is non-negative.
- Added `std::clamp` to ensure `zIndex` is within the valid range [0, nControls].
- Retained existing behavior of adding the control to the top of the stack if `zIndex` is negative.
- Updated the `IGraphics.h` file to reflect the new parameter and updated documentation.

### Testing:
- Verified that controls are correctly added at the specified `zIndex`.
- Ensured that the existing functionality remains unaffected when `zIndex` is negative.

Please review the changes and provide feedback.
