### PR TITLE
Drawing Quality Improvement for Skia

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -510,11 +510,7 @@ void IGraphicsSkia::DrawBitmap(const IBitmap& bitmap, const IRECT& dest, int src
   mCanvas->scale(scale1, scale1);
   mCanvas->translate(-srcX * scale2, -srcY * scale2);
   
-#ifdef IGRAPHICS_CPU
-  auto samplingOptions = SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone);
-#else
-  auto samplingOptions = SkSamplingOptions(SkCubicResampler::Mitchell());
-#endif
+  auto samplingOptions = SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kLinear);
     
   if (image->mIsSurface)
     image->mSurface->draw(mCanvas, 0.0, 0.0, samplingOptions, &p);


### PR DESCRIPTION
Related Issue: https://github.com/iPlug2/iPlug2/issues/795

Better Drawing Quality for SKIA by switching to SkFilterMode::kLinear with SkMipmapMode::kLinear. This PR updates the DrawBitmap function to enhance image downscaling quality, providing more consistent results, reduced aliasing, and a better balance between performance and quality compared to the previous use of the Mitchell cubic resampler. Practical tests confirm that this approach results in smoother and higher-quality downscaled images. Please review and approve if it meets the requirements.

before:
![image](https://github.com/janhase88/iPlug2/assets/46456607/0f4c9e83-edab-4a30-b92b-2ddb780073ae)

after:
![image](https://github.com/janhase88/iPlug2/assets/46456607/8c998494-0c8a-4aad-8330-e59049d0cce0)

