### PR TITLE
faster AntiAliasing

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -958,7 +958,11 @@ APIBitmap* IGraphicsSkia::CreateAPIBitmap(int width, int height, float scale, do
   }
   else
   {
-    surface = SkSurfaces::RenderTarget(mGrContext.get(), skgpu::Budgeted::kYes, info);
+    SkSurfaceProps surfaceProps(0, kUnknown_SkPixelGeometry);
+    int sampleCount = 2; //AntiAliasing
+    surface = SkSurfaces::RenderTarget(mGrContext.get(), skgpu::Budgeted::kNo, info,
+                                       sampleCount, 
+                                       kTopLeft_GrSurfaceOrigin, &surfaceProps);
   }
   #else
   surface = SkSurfaces::Raster(info);


### PR DESCRIPTION
This PR improves rendering quality and performance for dynamic GPU bitmaps in the Skia backend by:

    Switching non-cacheable surfaces to skgpu::Budgeted::kNo

    Adding SkSurfaceProps(0, kUnknown_SkPixelGeometry)

    Enabling 2× MSAA via sampleCount = 2

    Explicitly setting kTopLeft_GrSurfaceOrigin

The CPU/Raster path under IGRAPHICS_CPU is unchanged.