### PR TITLE
Refine Win text entry: hidden creation, precise sizing, and flexible …

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1486,53 +1486,73 @@ void IGraphicsWin::CreatePlatformTextEntry(int paramIdx, const IText& text, cons
   if (mParamEditWnd)
     return;
 
-  DWORD editStyle;
-
-  switch (text.mAlign)
-  {
-    case EAlign::Near:    editStyle = ES_LEFT;   break;
-    case EAlign::Far:     editStyle = ES_RIGHT;  break;
-    case EAlign::Center:
-    default:              editStyle = ES_CENTER; break;
-  }
+  // Initial style without WS_VISIBLE
+  DWORD initialEditStyle = ES_LEFT | ES_MULTILINE | ES_AUTOHSCROLL | WS_CHILD | WS_CLIPCHILDREN | WS_CLIPSIBLINGS; // *** REMOVED WS_VISIBLE ***
 
   const float scale = GetTotalScale();
   IRECT scaledBounds = bounds.GetScaled(scale);
 
-  mParamEditWnd = CreateWindowW(L"EDIT", UTF8AsUTF16(str).Get(), ES_AUTOHSCROLL /*only works for left aligned text*/ | WS_CHILD | WS_CLIPCHILDREN | WS_CLIPSIBLINGS | WS_VISIBLE | ES_MULTILINE | editStyle,
-    scaledBounds.L, scaledBounds.T, scaledBounds.W()+1, scaledBounds.H()+1,
-    mPlugWnd, (HMENU) PARAM_EDIT_ID, mHInstance, 0);
+  mParamEditWnd = CreateWindowW(L"EDIT", UTF8AsUTF16(str).Get(),
+                                initialEditStyle, // Create initially hidden
+                                scaledBounds.L, scaledBounds.T,
+                                scaledBounds.W(), // Use exact scaled width
+                                scaledBounds.H(), // Use exact scaled height
+                                mPlugWnd, (HMENU)PARAM_EDIT_ID, mHInstance, nullptr);
+
+  if (!mParamEditWnd)
+    return;
 
   StaticStorage<HFontHolder>::Accessor hfontStorage(sHFontCache);
-
-  LOGFONTW lFont = { 0 };
+  LOGFONTW lFont = {0};
   HFontHolder* hfontHolder = hfontStorage.Find(text.mFont);
+  assert(hfontHolder && "font not found - did you forget to load it?");
   GetObjectW(hfontHolder->mHFont, sizeof(LOGFONTW), &lFont);
   lFont.lfHeight = text.mSize * scale;
   mEditFont = CreateFontIndirectW(&lFont);
-
-  assert(hfontHolder && "font not found - did you forget to load it?");
 
   mEditParam = paramIdx > kNoParameter ? GetDelegate()->GetParam(paramIdx) : nullptr;
   mEditText = text;
   mEditRECT = bounds;
 
-  SendMessageW(mParamEditWnd, EM_LIMITTEXT, (WPARAM) length, 0);
-  SendMessageW(mParamEditWnd, WM_SETFONT, (WPARAM) mEditFont, 0);
+  SendMessageW(mParamEditWnd, EM_LIMITTEXT, (WPARAM)length, 0);
+  SendMessageW(mParamEditWnd, WM_SETFONT, (WPARAM)mEditFont, TRUE);
   SendMessageW(mParamEditWnd, EM_SETSEL, 0, -1);
 
   if (text.mVAlign == EVAlign::Middle)
   {
     double size = text.mSize * scale;
     double offset = (scaledBounds.H() - size) / 2.0;
-    RECT formatRect{0, (LONG) offset, (LONG) scaledBounds.W() + 1, (LONG) scaledBounds.H() + 1};
-    SendMessageW(mParamEditWnd, EM_SETRECT, 0, (LPARAM) &formatRect);
+    RECT formatRect = {0, (LONG)offset, (LONG)scaledBounds.W(), (LONG)scaledBounds.H()};
+    SendMessageW(mParamEditWnd, EM_SETRECT, 0, (LPARAM)&formatRect);
   }
 
-  SetFocus(mParamEditWnd);
+  SetFocus(mParamEditWnd); 
 
-  mDefEditProc = (WNDPROC) SetWindowLongPtrW(mParamEditWnd, GWLP_WNDPROC, (LONG_PTR) ParamEditProc);
+  mDefEditProc = (WNDPROC)SetWindowLongPtrW(mParamEditWnd, GWLP_WNDPROC, (LONG_PTR)ParamEditProc);
   SetWindowLongPtrW(mParamEditWnd, GWLP_USERDATA, 0xdeadf00b);
+
+  // --- Adjust alignment before showing ---
+  DWORD dwStyle = GetWindowLong(mParamEditWnd, GWL_STYLE);
+  dwStyle &= ~(ES_LEFT | ES_CENTER | ES_RIGHT);
+
+  switch (text.mAlign)
+  {
+  case EAlign::Near:
+    dwStyle |= ES_LEFT;
+    break;
+  case EAlign::Far:
+    dwStyle |= ES_RIGHT;
+    break;
+  case EAlign::Center:
+  default:
+    dwStyle |= ES_CENTER;
+    break;
+  }
+
+  SetWindowLong(mParamEditWnd, GWL_STYLE, dwStyle);
+
+  // --- Show window *after* all styles are set ---
+  SetWindowPos(mParamEditWnd, NULL, 0, 0, 0, 0, SWP_NOSIZE | SWP_NOMOVE | SWP_NOZORDER | SWP_FRAMECHANGED | SWP_SHOWWINDOW); // *** ADDED SWP_SHOWWINDOW ***
 }
 
 bool IGraphicsWin::RevealPathInExplorerOrFinder(WDL_String& path, bool select)


### PR DESCRIPTION
Summary
Improve the Windows text-entry control by delaying visibility until after all styles and fonts are applied, using exact bounds, and enabling consistent scrolling and alignment.

Details

    Hidden initial creation

        Remove WS_VISIBLE on CreateWindowW to prevent flicker

        Show only after calling SetWindowPos(... | SWP_SHOWWINDOW | SWP_FRAMECHANGED)

    Exact sizing

        Drop the magic +1 on width/height and use scaledBounds.W()/H() for pixel-perfect layout

    Flexible alignment & scrolling

        Always include ES_AUTOHSCROLL so even center/right-aligned edits scroll horizontally

        After creation, flip only the low-level ES_LEFT/ES_CENTER/ES_RIGHT bits via Get/SetWindowLong

    Immediate font application

        Pass TRUE to WM_SETFONT for an immediate redraw

    Cleaner maintenance

        Split into distinct phases—create hidden, configure, then show—to avoid subtle order-of-operations bugs and improve readability

This change yields smoother, flicker-free text entry with correct alignment, scrolling, and sizing on Windows.