### PR TITLE
SKIA: clearer gui drawing, smoother edges for bitmaps, better gpu per…

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -607,12 +607,8 @@ void IGraphicsSkia::DrawBitmap(const IBitmap& bitmap, const IRECT& dest, int src
   mCanvas->scale(scale1, scale1);
   mCanvas->translate(-srcX * scale2, -srcY * scale2);
   
-#ifdef IGRAPHICS_CPU
-  auto samplingOptions = SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone);
-#else
-  auto samplingOptions = SkSamplingOptions(SkCubicResampler::Mitchell());
-#endif
-    
+  auto samplingOptions = SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kLinear);
+   
   if (image->mIsSurface)
     image->mSurface->draw(mCanvas, 0.0, 0.0, samplingOptions, &p);
   else


### PR DESCRIPTION
Use linear mipmap sampling for all bitmaps and remove CPU/GPU branch

Description

    Unconditional mipmap‐enabled linear sampling

        Old:

            CPU path: SkFilterMode::kLinear with no mipmaps

            GPU path: SkCubicResampler::Mitchell()

        New:

            Always uses SkFilterMode::kLinear with SkMipmapMode::kLinear

    Remove #ifdef IGRAPHICS_CPU

        Treat CPU and GPU draws identically, simplifying the codebase

Why it’s better

    Consistent quality: smooth downscaling everywhere, avoiding aliasing artifacts without mipmaps

    Improved GPU performance: leverages hardware mipmap filtering

    Easier maintenance: single code path reduces complexity and testing surface