### PR TITLE
Studio One Window Close crash fix

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1188,13 +1188,24 @@ void IGraphicsWin::CloseWindow()
     else
       KillTimer(mPlugWnd, IPLUG_TIMER_ID);
 
-    {
-      ScopedGLContext scopedGLCtx {this};
-      OnViewDestroyed();
-    }
-    
 #ifdef IGRAPHICS_GL
+    HDC currentDC = wglGetCurrentDC();
+    HGLRC currentContext = wglGetCurrentContext();
+
+    if (currentContext != mHGLRC)
+    {
+      ActivateGLContext();
+    }
+#endif
+
+    OnViewDestroyed();
+
+#ifdef IGRAPHICS_GL
+
+    DeactivateGLContext();
+
     DestroyGLContext();
+
 #endif
 
     SetPlatformContext(nullptr);


### PR DESCRIPTION
prevents plugin crash in studio one on window close on some integrated graphics (intel uhd 730 for example)

