### PR TITLE
Update IPlugVST3_ProcessorBase.cpp - setbypassed(false)

### DIFF
--- a/IPlug/VST3/IPlugVST3_ProcessorBase.cpp
+++ b/IPlug/VST3/IPlugVST3_ProcessorBase.cpp
@@ -279,6 +279,8 @@ void IPlugVST3ProcessorBase::ProcessParameterChanges(ProcessData& data, IPlugQue
   {
     int32 numParamsChanged = paramChanges->getParameterCount();
     
+    SetBypassed(false); //fix for Bitwig
+    
     for (int32 i = 0; i < numParamsChanged; i++)
     {
       IParamValueQueue* paramQueue = paramChanges->getParameterData(i);


### PR DESCRIPTION
in bitwig, when audio engine was deactivated and reactivated vst3 was set to bypassed = true

