### PR TITLE
Implemented a COM IDropTarget (inbound DnD) so hosts that don’t send WM_DROPFILES still work (Fruity Loops)

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -16,9 +16,16 @@
 
 #include "IGraphics_select.h"
 #include "IGraphicsWinFonts.h"
+#include <vector>
+#include <string>
+
 
 BEGIN_IPLUG_NAMESPACE
 BEGIN_IGRAPHICS_NAMESPACE
+
+// Forward declare the OLE drop target helper (defined in IGraphicsWin_dnd.h)
+namespace DragAndDropHelpers { class DropTarget; }
+
 
 /** IGraphics platform class for Windows
 * @ingroup PlatformClasses */
@@ -76,6 +83,10 @@ public:
 
   bool InitiateExternalFileDragDrop(const char* path, const IRECT& iconBounds) override;
 
+  // Modern inbound drag & drop via OLE (IDropTarget)
+  void OnOLEDropFiles(const std::vector<std::wstring>& filesW, LONG xScreen, LONG yScreen);
+
+
   bool PlatformSupportsMultiTouch() const override;
 
   static LRESULT CALLBACK WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
@@ -96,6 +107,10 @@ protected:
   IRECT GetWindowRECT();
 
 private:
+
+  // OLE drag & drop
+  DragAndDropHelpers::DropTarget* mDropTarget = nullptr;
+  bool mOLEInited = false;
 
   /** Called either in response to WM_TIMER tick or user message WM_VBLANK, triggered by VSYNC thread
     * @param vBlankCount will allow redraws to get paced by the vblank message. Passing 0 is a WM_TIMER fallback. */


### PR DESCRIPTION
What changed (high-level)

Implemented a COM IDropTarget (inbound DnD) so hosts that don’t send WM_DROPFILES still work.

Registered the drop target in OpenWindow() and unregistered it (and uninitialized OLE) in CloseWindow().

Kept the old WM_DROPFILES path as a fallback — so legacy hosts continue to work.

Added a small helper OnOLEDropFiles(...) that converts the OLE drop into the existing OnDrop / OnDropMultiple calls (with proper screen→client coordinate mapping and DPI scaling).

This directly addresses the issue: your current tree only supported outbound DnD via DoDragDrop and inbound via WM_DROPFILES, which some hosts (notably FL Studio) don’t deliver to plugin child windows. You can see the old paths here, for reference: outbound DoDragDrop in InitiateExternalFileDragDrop and inbound WM_DROPFILES handling in WndProc. 