### PR TITLE
Allow disabling of Windows autoscaling

### DIFF
--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -1120,6 +1120,12 @@ public:
     * @return The scale factor of the display on which this graphics context is currently located */
   float GetScreenScale() const { return mScreenScale; }
 
+  /** Enable or disable automatic scaling when the window moves between monitors */
+  void EnableAutoScale(bool enable) { mAutoScale = enable; }
+
+  /** @return True if the graphics context adjusts automatically to the monitor scale */
+  bool AutoScale() const { return mAutoScale; }
+
   /** Gets the screen/display scaling factor, rounded up
   * @return The scale factor of the screen/display on which this graphics context is currently located */
   int GetRoundedScreenScale() const { return static_cast<int>(std::ceil(GetScreenScale())); }
@@ -1828,6 +1834,7 @@ private:
   int mFPS;
   float mScreenScale = 1.f; // the scaling of the display that the UI is currently on e.g. 2 for retina
   float mDrawScale = 1.f; // scale deviation from  default width and height i.e stretching the UI by dragging bottom right hand corner
+  bool mAutoScale = true; // determines if platform window scale should follow the monitor scale
 
   int mIdleTicks = 0;
   

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -10,7 +10,7 @@
 
 //#define IGRAPHICS_DISABLE_VSYNC
 
-#include <Shlobj.h>
+#include <ShlObj.h>
 #include <commctrl.h>
 
 #include "heapbuf.h"
@@ -158,7 +158,7 @@ void IGraphicsWin::OnDisplayTimer(int vBlankCount)
   }
 
   // TODO: move this... listen to the right messages in windows for screen resolution changes, etc.
-  if (!GetCapture()) // workaround Windows issues with window sizing during mouse move
+  if (!GetCapture() && AutoScale()) // workaround Windows issues with window sizing during mouse move
   {
     float scale = GetScaleForHWND(mPlugWnd);
     if (scale != GetScreenScale())
@@ -1036,7 +1036,9 @@ EMsgBoxResult IGraphicsWin::ShowMessageBox(const char* str, const char* title, E
 void* IGraphicsWin::OpenWindow(void* pParent)
 {
   mParentWnd = (HWND) pParent;
-  int screenScale = GetScaleForHWND(mParentWnd);
+  int screenScale = 1;
+  if (AutoScale())
+    screenScale = GetScaleForHWND(mParentWnd);
   int x = 0, y = 0, w = WindowWidth() * screenScale, h = WindowHeight() * screenScale;
 
   if (mPlugWnd)
@@ -1069,7 +1071,8 @@ void* IGraphicsWin::OpenWindow(void* pParent)
 
   OnViewInitialized((void*) dc);
 
-  SetScreenScale(screenScale); // resizes draw context
+  if (AutoScale())
+    SetScreenScale(screenScale); // resizes draw context
 
   GetDelegate()->LayoutUI(this);
 

--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -42,7 +42,7 @@ public:
   void* GetWinModuleHandle() override { return mHInstance; }
 
   void ForceEndUserEdit() override;
-  float GetPlatformWindowScale() const override { return GetScreenScale(); }
+  float GetPlatformWindowScale() const override { return AutoScale() ? GetScreenScale() : 1.f; }
 
   void PlatformResize(bool parentHasResized) override;
 


### PR DESCRIPTION
## Summary
- add `EnableAutoScale` and `AutoScale` helpers with `mAutoScale` flag in `IGraphics`
- guard DPI queries in `IGraphicsWin` so screen scale is only applied when autoscaling is enabled
- return unity from `GetPlatformWindowScale` when autoscaling is off
- fix Windows shell header casing for case-sensitive builds

## Testing
- `x86_64-w64-mingw32-g++ -std=c++17 -DIGRAPHICS_SKIA -I WDL -I IPlug -I IGraphics -I IGraphics/Drawing -I Dependencies/IGraphics/NanoSVG/src -fsyntax-only IGraphics/Platforms/IGraphicsWin.cpp` *(fails: modules/svg/include/SkSVGDOM.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c34798da6083298e979ba8aeae1d99