### PR TITLE
Allow configuring VBlank thread priority

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -10,7 +10,7 @@
 
 //#define IGRAPHICS_DISABLE_VSYNC
 
-#include <Shlobj.h>
+#include <shlobj.h>
 #include <commctrl.h>
 
 #include "heapbuf.h"
@@ -59,6 +59,7 @@ typedef HGLRC(WINAPI* PFNWGLCREATECONTEXTATTRIBSARBPROC) (HDC hDC, HGLRC hShareC
 
 StaticStorage<IGraphicsWin::InstalledFont> IGraphicsWin::sPlatformFontCache;
 StaticStorage<HFontHolder> IGraphicsWin::sHFontCache;
+int IGraphicsWin::sVBlankThreadPriority = THREAD_PRIORITY_ABOVE_NORMAL;
 
 #pragma mark - Mouse and tablet helpers
 
@@ -2150,6 +2151,11 @@ DWORD WINAPI VBlankRun(LPVOID lpParam)
   return pGraphics->OnVBlankRun();
 }
 
+void IGraphicsWin::SetVBlankThreadPriority(int priority)
+{
+  sVBlankThreadPriority = priority;
+}
+
 void IGraphicsWin::StartVBlankThread(HWND hWnd)
 {
   mVBlankWindow = hWnd;
@@ -2210,7 +2216,7 @@ typedef NTSTATUS(WINAPI* D3DKMTWaitForVerticalBlankEvent)(const D3DKMT_WAITFORVE
 
 DWORD IGraphicsWin::OnVBlankRun()
 {
-  SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL);
+  SetThreadPriority(GetCurrentThread(), sVBlankThreadPriority);
 
   // TODO: get expected vsync value.  For now we will use a fallback
   // of 60Hz

--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -94,6 +94,8 @@ public:
   static BOOL CALLBACK FindMainWindow(HWND hWnd, LPARAM lParam);
 
   DWORD OnVBlankRun();
+  /** Set the thread priority used by the VBlank thread (default THREAD_PRIORITY_ABOVE_NORMAL) */
+  static void SetVBlankThreadPriority(int priority);
 
 protected:
   IPopupMenu* CreatePlatformPopupMenu(IPopupMenu& menu, const IRECT bounds, bool& isAsync) override;
@@ -176,9 +178,10 @@ private:
   int mTooltipIdx = -1;
 
   WDL_String mMainWndClassName;
-    
+
   static StaticStorage<InstalledFont> sPlatformFontCache;
   static StaticStorage<HFontHolder> sHFontCache;
+  static int sVBlankThreadPriority;
 
   std::unordered_map<ITouchID, IMouseInfo> mDeltaCapture; // associative array of touch id pointers to IMouseInfo structs, so that we can get deltas
 };


### PR DESCRIPTION
## Summary
- make VBlank thread priority configurable on Windows and default to THREAD_PRIORITY_ABOVE_NORMAL
- expose `SetVBlankThreadPriority` for adjusting priority
- use lowercase `shlobj.h` for MinGW compatibility

## Testing
- `x86_64-w64-mingw32-g++ -c IGraphics/Platforms/IGraphicsWin.cpp -std=c++17 -I .` *(fails: heapbuf.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c347b5f2a08329b73aeb317e3ee83d