### PR TITLE
Default VBlank thread priority to normal

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -59,7 +59,7 @@ typedef HGLRC(WINAPI* PFNWGLCREATECONTEXTATTRIBSARBPROC) (HDC hDC, HGLRC hShareC
 
 StaticStorage<IGraphicsWin::InstalledFont> IGraphicsWin::sPlatformFontCache;
 StaticStorage<HFontHolder> IGraphicsWin::sHFontCache;
-int IGraphicsWin::sVBlankThreadPriority = THREAD_PRIORITY_ABOVE_NORMAL;
+int IGraphicsWin::sVBlankThreadPriority = THREAD_PRIORITY_NORMAL; // Default priority; hosts needing higher responsiveness can raise it via SetVBlankThreadPriority
 
 #pragma mark - Mouse and tablet helpers
 

--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -94,7 +94,8 @@ public:
   static BOOL CALLBACK FindMainWindow(HWND hWnd, LPARAM lParam);
 
   DWORD OnVBlankRun();
-  /** Set the thread priority used by the VBlank thread (default THREAD_PRIORITY_ABOVE_NORMAL) */
+  /** Set the thread priority used by the VBlank thread (default THREAD_PRIORITY_NORMAL).
+   *  Hosts needing higher responsiveness may increase it with SetVBlankThreadPriority. */
   static void SetVBlankThreadPriority(int priority);
 
 protected:
@@ -181,6 +182,7 @@ private:
 
   static StaticStorage<InstalledFont> sPlatformFontCache;
   static StaticStorage<HFontHolder> sHFontCache;
+  /** Current VBlank thread priority, defaults to THREAD_PRIORITY_NORMAL. */
   static int sVBlankThreadPriority;
 
   std::unordered_map<ITouchID, IMouseInfo> mDeltaCapture; // associative array of touch id pointers to IMouseInfo structs, so that we can get deltas


### PR DESCRIPTION
## Summary
- set Windows VBlank thread priority default to `THREAD_PRIORITY_NORMAL`
- note `SetVBlankThreadPriority` can increase priority for responsive hosts

## Testing
- `g++ -std=c++14 -fsyntax-only IGraphics/Platforms/IGraphicsWin.cpp` *(fails: ShlObj.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c355fe8f908329be41db968e0ece85