### PR TITLE
Place VBlankThreadManager in correct namespace

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -63,6 +63,9 @@ StaticStorage<IGraphicsWin::InstalledFont> IGraphicsWin::sPlatformFontCache;
 StaticStorage<HFontHolder> IGraphicsWin::sHFontCache;
 int IGraphicsWin::sVBlankThreadPriority = THREAD_PRIORITY_NORMAL; // Default priority; hosts needing higher responsiveness can raise it via SetVBlankThreadPriority
 
+namespace iplug {
+namespace igraphics {
+
 class VBlankThreadManager
 {
 public:
@@ -136,6 +139,12 @@ private:
   HANDLE mThread = INVALID_HANDLE_VALUE;
   bool mShutdown = false;
 };
+
+} // namespace igraphics
+} // namespace iplug
+
+using namespace iplug;
+using namespace igraphics;
 
 #pragma mark - Mouse and tablet helpers
 


### PR DESCRIPTION
## Summary
- move VBlankThreadManager into the `iplug::igraphics` namespace
- expose namespace to file scope with `using` directives

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c35aaeff888329b44d127c37543558