### PR TITLE
Handle lost mouse capture on Windows

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -465,6 +465,13 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
       pGraphics->OnMouseUp(list);
       return 0;
     }
+    case WM_CAPTURECHANGED:
+    {
+      // Ensure any outstanding mouse capture is released if the host takes it
+      ReleaseCapture();
+      pGraphics->ReleaseMouseCapture();
+      return 0;
+    }
     case WM_LBUTTONDBLCLK:
     case WM_RBUTTONDBLCLK:
     {
@@ -1291,6 +1298,10 @@ void IGraphicsWin::CloseWindow()
 {
   if (mPlugWnd)
   {
+    // Ensure the window releases any mouse capture before destruction
+    ReleaseCapture();
+    ReleaseMouseCapture();
+
     if (mVSYNCEnabled)
       StopVBlankThread();
     else


### PR DESCRIPTION
## Summary
- release mouse capture on WM_CAPTURECHANGED so plug-ins can't lock Bitwig's UI
- drop any pending capture when closing the editor window

## Testing
- `clang-format -n -lines=452:467 -lines=1297:1315 IGraphics/Platforms/IGraphicsWin.cpp` *(warnings: code should be clang-formatted)*

------
https://chatgpt.com/codex/tasks/task_e_68c3768ee95083299bdc80551061408b