### PR TITLE
Release mouse capture on Windows focus loss

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -386,10 +386,12 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
       pGraphics->OnMouseDown(list);
       return 0;
     }
-    case WM_SETCURSOR:
-    {
+    case WM_SETCURSOR: {
       pGraphics->OnSetCursor();
       return 0;
+    }
+    case WM_MOUSEACTIVATE: {
+      return MA_ACTIVATE;
     }
     case WM_MOUSEMOVE:
     {
@@ -733,8 +735,10 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
     {
       return 0;
     }
-    case WM_KILLFOCUS:
-    {
+    case WM_CANCELMODE:
+    case WM_KILLFOCUS: {
+      ReleaseCapture();
+      pGraphics->ReleaseMouseCapture();
       return 0;
     }
   }


### PR DESCRIPTION
## Summary
- Drop lingering mouse capture when the window loses focus or receives `WM_CANCELMODE`
- Ensure `WM_MOUSEACTIVATE` returns `MA_ACTIVATE` so the host regains focus

## Testing
- `clang-format -i -lines=389:397 -lines=740:745 IGraphics/Platforms/IGraphicsWin.cpp`
- `x86_64-w64-mingw32-g++ -c IGraphics/Platforms/IGraphicsWin.cpp -std=c++17 -I. -I./IGraphics -I./IPlug -I./WDL -IDependencies/IGraphics/NanoSVG/src -DUNICODE -DWDL_NO_SUPPORT_UTF8 -Wno-attributes -DIGRAPHICS_GDI -o /tmp/IGraphicsWin.o` *(fails: NO IGRAPHICS_MODE defined; Ole2.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c37ed19a0483299aaf2bf951ff1898