### PR TITLE
Ensure mouse up fires when capture is released

### DIFF
--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -1303,6 +1303,23 @@ void IGraphics::OnDropMultiple(const std::vector<const char*>& paths, float x, f
 
 void IGraphics::ReleaseMouseCapture()
 {
+  if (ControlIsCaptured())
+  {
+    std::vector<IMouseInfo> points;
+    points.reserve(mCapturedMap.size());
+
+    for (auto& entry : mCapturedMap)
+    {
+      IMouseInfo info;
+      info.x = mCursorX;
+      info.y = mCursorY;
+      info.ms = IMouseMod(false, false, false, false, false, entry.first);
+      points.push_back(info);
+    }
+
+    OnMouseUp(points);
+  }
+
   mCapturedMap.clear();
   if (mCursorHidden)
     HideMouseCursor(false);


### PR DESCRIPTION
## Summary
- Trigger `OnMouseUp` for any captured controls when mouse capture is released
- Prevent stuck mouse states when focus loss or other events drop capture

## Testing
- `g++ -std=c++17 -I. -c IGraphics/IGraphics.cpp` *(fails: IPlugConstants.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c3a08d58cc832982d563817aa74c89