### PR TITLE
Fix corner resizer drag handling

### DIFF
--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -1543,14 +1543,14 @@ void IGraphics::OnDragResize(float x, float y)
 {
   if(mGUISizeMode == EUIResizerMode::Scale)
   {
-    float scaleX = (x * GetDrawScale()) / mMouseDownX;
-    float scaleY = (y * GetDrawScale()) / mMouseDownY;
+    float scaleX = ((x + mMouseDownX) * GetDrawScale()) / GetBounds().R;
+    float scaleY = ((y + mMouseDownY) * GetDrawScale()) / GetBounds().B;
 
     Resize(Width(), Height(), std::min(scaleX, scaleY));
   }
   else
   {
-    Resize(static_cast<int>(x), static_cast<int>(y), GetDrawScale());
+    Resize(static_cast<int>(x + mMouseDownX), static_cast<int>(y + mMouseDownY), GetDrawScale());
   }
 }
 

--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -1273,12 +1273,12 @@ private:
   {
     mResizingInProcess = true;
 
-    // Record the current graphics bounds so that drag resizing computes deltas
-    // from the window's bottom-right corner rather than the mouse pointer
-    // location. This ensures responsive resizing even when the resizer control
-    // is smaller than the full bounds or the drawing is scaled.
-    mMouseDownX = GetBounds().R() * GetDrawScale();
-    mMouseDownY = GetBounds().B() * GetDrawScale();
+    // OnMouseDown() has already stored the mouse position in mMouseDownX/Y.
+    // Convert these into offsets from the window's bottom-right corner so that
+    // subsequent drag events can resize relative to the actual graphics bounds
+    // rather than the position within the resizer control.
+    mMouseDownX = GetBounds().R - mMouseDownX;
+    mMouseDownY = GetBounds().B - mMouseDownY;
   }
   
   /** Called when drag resize ends */

--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -1269,7 +1269,17 @@ private:
   void DoCreatePopupMenu(IControl& control, IPopupMenu& menu, const IRECT& bounds, int valIdx, bool isContext);
   
   /** Called by ICornerResizer when drag resize commences */
-  void StartDragResize() { mResizingInProcess = true; }
+  void StartDragResize()
+  {
+    mResizingInProcess = true;
+
+    // Record the current graphics bounds so that drag resizing computes deltas
+    // from the window's bottom-right corner rather than the mouse pointer
+    // location. This ensures responsive resizing even when the resizer control
+    // is smaller than the full bounds or the drawing is scaled.
+    mMouseDownX = GetBounds().R() * GetDrawScale();
+    mMouseDownY = GetBounds().B() * GetDrawScale();
+  }
   
   /** Called when drag resize ends */
   void EndDragResize();


### PR DESCRIPTION
## Summary
- ensure drag resizing uses graphics bounds rather than mouse position

## Testing
- `g++ -fsyntax-only IGraphics/IGraphics.cpp -DIGRAPHICS_NANOVG -std=c++17 -I. -IIGraphics -IIGraphics/Controls -IWDL -I./IPlug -IDependencies/IGraphics/NanoSVG/src -IDependencies/IGraphics/NanoVG/src`


------
https://chatgpt.com/codex/tasks/task_e_68c3a27ed36083299fab0c1a96980ea9