### PR TITLE
Respect host content scale factor to avoid oversized UI

### DIFF
--- a/IPlug/VST3/IPlugVST3_View.h
+++ b/IPlug/VST3/IPlugVST3_View.h
@@ -14,6 +14,7 @@
 #include "pluginterfaces/base/keycodes.h"
 
 #include "IPlugStructs.h"
+#include "IGraphics/IGraphics.h"
 
 /** IPlug VST3 View  */
 template <class T>
@@ -136,6 +137,9 @@ public:
 
   Steinberg::tresult PLUGIN_API setContentScaleFactor(ScaleFactor factor) override
   {
+    if (auto* pGraphics = mOwner.GetUI())
+      pGraphics->EnableAutoScale(false);
+
     mOwner.SetScreenScale(factor);
 
     return Steinberg::kResultOk;


### PR DESCRIPTION
## Summary
- Disable IGraphics auto scaling when VST3 host supplies explicit content scale factor
- Include IGraphics header for access to auto-scaling controls

## Testing
- `clang-format -n IPlug/VST3/IPlugVST3_View.h` *(warnings: code should be clang-formatted)*

------
https://chatgpt.com/codex/tasks/task_e_68c3b049d0f083298ec23ef80c92a08a