### PR TITLE
Fix Windows screen scaling reset in IGraphics

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1168,8 +1168,7 @@ void* IGraphicsWin::OpenWindow(void* pParent)
 
   OnViewInitialized((void*) dc);
 
-  if (AutoScale())
-    SetScreenScale(screenScale); // resizes draw context
+  SetScreenScale(screenScale); // resize draw context regardless of auto-scaling so mScreenScale resets to 1.f when needed
 
   GetDelegate()->LayoutUI(this);
 


### PR DESCRIPTION
## Summary
- Always call `SetScreenScale` in `IGraphicsWin::OpenWindow` so the draw context resizes even when auto-scaling is disabled

## Testing
- `bash Scripts/run_clang_format.sh` *(fails: failed to find clang-format)*
- `g++ -c IGraphics/Platforms/IGraphicsWin.cpp -I .` *(fails: ShlObj.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c42b772cb88329809d8da4855ec018