### PR TITLE
Include missing cassert and fix IGraphics header path

### DIFF
--- a/IPlug/IPlugTimer.cpp
+++ b/IPlug/IPlugTimer.cpp
@@ -14,6 +14,7 @@
  */
 
 #include "IPlugTimer.h"
+#include <cassert>
 
 using namespace iplug;
 

--- a/IPlug/VST3/IPlugVST3_View.h
+++ b/IPlug/VST3/IPlugVST3_View.h
@@ -14,7 +14,7 @@
 #include "pluginterfaces/base/keycodes.h"
 
 #include "IPlugStructs.h"
-#include "IGraphics/IGraphics.h"
+#include "IGraphics.h"
 
 /** IPlug VST3 View  */
 template <class T>


### PR DESCRIPTION
## Summary
- ensure Timer uses `<cassert>` for assert macro
- correct VST3 view to include `IGraphics.h` directly

## Testing
- `clang-format -n IPlug/IPlugTimer.cpp IPlug/VST3/IPlugVST3_View.h` *(warnings: code should be clang-formatted)*

------
https://chatgpt.com/codex/tasks/task_e_68c42df012dc832999090da52f0b9233