### PR TITLE
Restore default scaling for VST3 plug-in views

### DIFF
--- a/IGraphics/IGraphicsEditorDelegate.cpp
+++ b/IGraphics/IGraphicsEditorDelegate.cpp
@@ -29,8 +29,6 @@ void* IGEditorDelegate::OpenWindow(void* pParent)
   if(!mGraphics)
   {
     mGraphics = std::unique_ptr<IGraphics>(CreateGraphics());
-    mGraphics->EnableAutoScale(false);
-    mGraphics->SetScreenScale(1.f);
     if (mLastWidth && mLastHeight && mLastScale)
       GetUI()->Resize(mLastWidth, mLastHeight, mLastScale);
   }

--- a/IPlug/VST3/IPlugVST3_View.h
+++ b/IPlug/VST3/IPlugVST3_View.h
@@ -14,7 +14,6 @@
 #include "pluginterfaces/base/keycodes.h"
 
 #include "IPlugStructs.h"
-#include "IGraphics.h"
 
 /** IPlug VST3 View  */
 template <class T>
@@ -137,9 +136,6 @@ public:
 
   Steinberg::tresult PLUGIN_API setContentScaleFactor(ScaleFactor factor) override
   {
-    if (auto* pGraphics = mOwner.GetUI())
-      pGraphics->EnableAutoScale(false);
-
     mOwner.SetScreenScale(factor);
 
     return Steinberg::kResultOk;


### PR DESCRIPTION
## Summary
- stop forcing auto-scale off in `IGEditorDelegate` so plug-ins can resize to host DPI
- simplify VST3 view `setContentScaleFactor` to just forward host scale

## Testing
- `g++ -std=c++17 -DOS_WIN -I. -I./IPlug -I./IGraphics -I./WDL -c -x c++ IPlug/VST3/IPlugVST3_View.h -o /tmp/IPlugVST3_View.o` *(fails: base/source/fstring.h: No such file or directory)*
- `g++ -std=c++17 -DIGRAPHICS_NANOVG -I. -I./IGraphics -I./IPlug -I./WDL -I./Dependencies/IGraphics/NanoSVG/src -c IGraphics/IGraphicsEditorDelegate.cpp -o /tmp/IGraphicsEditorDelegate.o` *(fails: 'free' was not declared in this scope)*

------
https://chatgpt.com/codex/tasks/task_e_68c42f86f7cc8329b1f28266aa0a9c4b