### PR TITLE
Manage timer window class per instance

### DIFF
--- a/IPlug/IPlugTimer.h
+++ b/IPlug/IPlugTimer.h
@@ -82,7 +82,7 @@ private:
   HWND mMsgWnd = nullptr;
   ITimerFunction mTimerFunc;
   uint32_t mIntervalMs;
-  static ATOM sWindowClass;
+  ATOM mWindowClass = 0;
 };
 #elif defined OS_WEB
 class Timer_impl : public Timer


### PR DESCRIPTION
## Summary
- Track timer window class atom per instance instead of using a static.
- Register the window class on construction and unregister it on destruction.
- Create message window via the stored atom.

## Testing
- `x86_64-w64-mingw32-g++ -std=c++17 -DOS_WIN -DUNICODE -D_UNICODE -I./IPlug -I./WDL IPlug/IPlugTimer.cpp -c -o /tmp/IPlugTimer.o`


------
https://chatgpt.com/codex/tasks/task_e_68c44576369883298299d6714deff460