### PR TITLE
refactor: move static graphics state into members

### DIFF
--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -1827,6 +1827,7 @@ private:
   // Order (front-to-back) ToolTip / PopUp / TextEntry / LiveEdit / Corner / PerfDisplay
   std::unique_ptr<ICornerResizerControl> mCornerResizer;
   WDL_PtrList<IBubbleControl> mBubbleControls;
+  int mNextBubbleControl = 0;
   std::unique_ptr<IPopupMenuControl> mPopupControl;
   std::unique_ptr<IFPSDisplayControl> mPerfDisplay;
   std::unique_ptr<ITextEntryControl> mTextEntryControl;
@@ -1881,7 +1882,9 @@ private:
   IKeyHandlerFunc mKeyHandlerFunc = nullptr;
   IDisplayTickFunc mDisplayTickFunc = nullptr;
   IUIAppearanceChangedFunc mAppearanceChangedFunc = nullptr;
-  
+  int mQwertyKeyBase = 48;
+  bool mKeysDown[128] = {};
+
 protected:
   IGEditorDelegate* mDelegate;
   bool mCursorHidden = false;


### PR DESCRIPTION
## Summary
- add instance members for bubble control index and QWERTY key tracking
- replace static locals with new members and reset per instance

## Testing
- `clang++ -std=c++17 -IIGraphics -I. -I./IPlug -I./WDL -c IGraphics/IGraphics.cpp -o /tmp/ig.o` *(fails: Either NO_IGRAPHICS or one and only one choice of graphics library must be defined; 'nanosvg.h' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c44578a7d083299d7682977a9f4061