### PR TITLE
Fix Unicode build errors in Windows utilities

### DIFF
--- a/WDL/eel2/eel_lice.h
+++ b/WDL/eel2/eel_lice.h
@@ -2340,7 +2340,7 @@ HWND eel_lice_state::create_wnd(HWND par, int isChild)
 {
   if (hwnd_standalone) return hwnd_standalone;
 #ifdef _WIN32
-  return CreateWindowEx(WS_EX_ACCEPTFILES,eel_lice_standalone_classname,"",
+  return CreateWindowExA(WS_EX_ACCEPTFILES,eel_lice_standalone_classname,"",
                         isChild ? (WS_CHILD|WS_TABSTOP) : (WS_POPUP|WS_CAPTION|WS_THICKFRAME|WS_SYSMENU),CW_USEDEFAULT,CW_USEDEFAULT,100,100,par,NULL,eel_lice_hinstance,this);
 #else
   HWND h = SWELL_CreateDialog(NULL,isChild ? NULL : ((const char *)(INT_PTR)0x400001),par,(DLGPROC)eel_lice_wndproc,(LPARAM)this);

--- a/WDL/win32_curses/curses_win32.cpp
+++ b/WDL/win32_curses/curses_win32.cpp
@@ -891,7 +891,7 @@ void curses_unregisterChildClass(HINSTANCE hInstance)
 {
 #ifdef _WIN32
   if (!--m_regcnt)
-    UnregisterClass(WIN32CURSES_CLASS_NAME,hInstance);
+    UnregisterClassA(WIN32CURSES_CLASS_NAME,hInstance);
 #endif
 }
 
@@ -900,13 +900,13 @@ void curses_registerChildClass(HINSTANCE hInstance)
 #ifdef _WIN32
   if (!m_regcnt++)
   {
-    WNDCLASSW wc={CS_DBLCLKS,};
+    WNDCLASSA wc={CS_DBLCLKS,};
     wc.lpfnWndProc = cursesWindowProc;
     wc.hInstance = hInstance;
     wc.hCursor = LoadCursor(NULL,IDC_ARROW);
-    wc.lpszClassName = LWIN32CURSES_CLASS_NAME;
+    wc.lpszClassName = WIN32CURSES_CLASS_NAME;
 
-    RegisterClassW(&wc);
+    RegisterClassA(&wc);
   }
 #endif
 }
@@ -938,7 +938,7 @@ HWND curses_CreateWindow(HINSTANCE hInstance, win32CursesCtx *ctx, const char *t
 {
   if (!ctx) return NULL;
 #ifdef _WIN32
- ctx->m_hwnd = CreateWindowEx(0,WIN32CURSES_CLASS_NAME, title,WS_CAPTION|WS_MAXIMIZEBOX|WS_MINIMIZEBOX|WS_SIZEBOX|WS_SYSMENU,
+ ctx->m_hwnd = CreateWindowExA(0,WIN32CURSES_CLASS_NAME, title,WS_CAPTION|WS_MAXIMIZEBOX|WS_MINIMIZEBOX|WS_SIZEBOX|WS_SYSMENU,
           CW_USEDEFAULT,CW_USEDEFAULT,640,480,
           NULL, NULL,hInstance,NULL);
 #else

--- a/WDL/win32_curses/eel_edit.cpp
+++ b/WDL/win32_curses/eel_edit.cpp
@@ -2076,13 +2076,13 @@ run_suggest:
                 if (inst != last_inst)
                 {
                   last_inst = inst;
-                  WNDCLASS wc={CS_DBLCLKS,suggestionProc,};
+                  WNDCLASSA wc={CS_DBLCLKS,suggestionProc,};
                   wc.lpszClassName=classname;
                   wc.hInstance=inst;
                   wc.hCursor=LoadCursor(NULL,IDC_ARROW);
-                  RegisterClass(&wc);
+                  RegisterClassA(&wc);
                 }
-                m_suggestion_hwnd = CreateWindowEx(0,classname,"", WS_CHILD, 0,0,0,0, ctx->m_hwnd, NULL, inst, NULL);
+                m_suggestion_hwnd = CreateWindowExA(0,classname,"", WS_CHILD, 0,0,0,0, ctx->m_hwnd, NULL, inst, NULL);
 #else
                 m_suggestion_hwnd = CreateDialogParam(NULL,NULL,ctx->m_hwnd, suggestionProc, 0);
 #endif


### PR DESCRIPTION
## Summary
- Avoid implicit Unicode conversions in WDL window helpers
- Use explicit ANSI Win32 APIs for hidden window helpers

## Testing
- `clang-format --dry-run --Werror WDL/win32_curses/eel_edit.cpp WDL/win32_curses/curses_win32.cpp WDL/eel2/eel_lice.h` *(fails: code should be clang-formatted)*

------
https://chatgpt.com/codex/tasks/task_e_68c4475ad8d0832985058b90838d0536