### PR TITLE
Make color picker history instance-specific

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -825,6 +825,9 @@ IGraphicsWin::IGraphicsWin(IGEditorDelegate& dlg, int w, int h, int fps, float s
   if (mVSYNCEnabled)
     mVBlankThread = std::make_unique<VBlankThread>(*this);
 #endif
+  const COLORREF w = RGB(255, 255, 255);
+  for (int i = 0; i < 16; ++i)
+    mCustomColorStorage[i] = w;
 }
 
 IGraphicsWin::~IGraphicsWin()
@@ -1841,15 +1844,12 @@ bool IGraphicsWin::PromptForColor(IColor& color, const char* prompt, IColorPicke
 
   UTF8AsUTF16 promptWide(prompt);
 
-  const COLORREF w = RGB(255, 255, 255);
-  static COLORREF customColorStorage[16] = { w, w, w, w, w, w, w, w, w, w, w, w, w, w, w, w };
-  
   CHOOSECOLORW cc;
   memset(&cc, 0, sizeof(CHOOSECOLORW));
   cc.lStructSize = sizeof(CHOOSECOLORW);
   cc.hwndOwner = mPlugWnd;
   cc.rgbResult = RGB(color.R, color.G, color.B);
-  cc.lpCustColors = customColorStorage;
+  cc.lpCustColors = mCustomColorStorage;
   cc.lCustData = (LPARAM) promptWide.Get();
   cc.lpfnHook = CCHookProc;
   cc.Flags = CC_RGBINIT | CC_ANYCOLOR | CC_FULLOPEN | CC_SOLIDCOLOR | CC_ENABLEHOOK;

--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -182,6 +182,8 @@ private:
   float mHiddenCursorY = 0.f;
   int mTooltipIdx = -1;
 
+  COLORREF mCustomColorStorage[16] = {};
+
   WDL_String mMainWndClassName;
 
   StaticStorage<InstalledFont> mPlatformFontCache;


### PR DESCRIPTION
## Summary
- move Windows color picker custom color storage to an instance member so each plugin instance keeps its own history

## Testing
- `cmake -S . -B build` *(fails: The source directory does not appear to contain CMakeLists.txt)*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68c44ddd0a0483298f253e744557b5fd