### PR TITLE
Use shared font cache lifetime management on Windows

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -117,6 +117,11 @@ private:
 using namespace iplug;
 using namespace igraphics;
 
+#pragma mark - Shared font caches
+
+StaticStorage<InstalledFont> IGraphicsWin::mPlatformFontCache;
+StaticStorage<HFontHolder> IGraphicsWin::mHFontCache;
+
 #pragma mark - Mouse and tablet helpers
 
 extern float GetScaleForHWND(HWND hWnd);
@@ -820,6 +825,10 @@ LRESULT CALLBACK IGraphicsWin::ParamEditProc(HWND hWnd, UINT msg, WPARAM wParam,
 IGraphicsWin::IGraphicsWin(IGEditorDelegate& dlg, int w, int h, int fps, float scale)
   : IGRAPHICS_DRAW_CLASS(dlg, w, h, fps, scale)
 {
+  StaticStorage<InstalledFont>::Accessor fontStorage(mPlatformFontCache);
+  fontStorage.Retain();
+  StaticStorage<HFontHolder>::Accessor hfontStorage(mHFontCache);
+  hfontStorage.Retain();
 #ifndef IGRAPHICS_DISABLE_VSYNC
   mVSYNCEnabled = IsWindows8OrGreater();
   if (mVSYNCEnabled)
@@ -829,6 +838,10 @@ IGraphicsWin::IGraphicsWin(IGEditorDelegate& dlg, int w, int h, int fps, float s
 
 IGraphicsWin::~IGraphicsWin()
 {
+  StaticStorage<InstalledFont>::Accessor fontStorage(mPlatformFontCache);
+  fontStorage.Release();
+  StaticStorage<HFontHolder>::Accessor hfontStorage(mHFontCache);
+  hfontStorage.Release();
   DestroyEditWindow();
   CloseWindow();
   mVBlankThread.reset();

--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -183,9 +183,8 @@ private:
   int mTooltipIdx = -1;
 
   WDL_String mMainWndClassName;
-
-  StaticStorage<InstalledFont> mPlatformFontCache;
-  StaticStorage<HFontHolder> mHFontCache;
+  static StaticStorage<InstalledFont> mPlatformFontCache;
+  static StaticStorage<HFontHolder> mHFontCache;
   /** Current VBlank thread priority, defaults to THREAD_PRIORITY_NORMAL. */
   int mVBlankThreadPriority = THREAD_PRIORITY_NORMAL;
   double mFPS = 0.0;


### PR DESCRIPTION
## Summary
- Make Windows font caches static so they're shared across instances
- Retain and release font caches in the Windows graphics constructor/destructor

## Testing
- `g++ -fsyntax-only -std=c++17 IGraphics/Platforms/IGraphicsWin.cpp` *(fails: ShlObj.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c44dde1e38832998b691549cdc37f4