### PR TITLE
Respect host scale factor in VST3 view

### DIFF
--- a/IGraphics/IGraphicsEditorDelegate.cpp
+++ b/IGraphics/IGraphicsEditorDelegate.cpp
@@ -74,6 +74,12 @@ void IGEditorDelegate::SetScreenScale(float scale)
     mGraphics->SetScreenScale(scale);
 }
 
+void IGEditorDelegate::EnableAutoScale(bool enable)
+{
+  if (GetUI())
+    mGraphics->EnableAutoScale(enable);
+}
+
 void IGEditorDelegate::SendControlValueFromDelegate(int ctrlTag, double normalizedValue)
 {
   if(!mGraphics)

--- a/IGraphics/IGraphicsEditorDelegate.h
+++ b/IGraphics/IGraphicsEditorDelegate.h
@@ -39,10 +39,11 @@ public:
   IGEditorDelegate& operator=(const IGEditorDelegate&) = delete;
     
   //IEditorDelegate
-  void* OpenWindow(void* pHandle) final;
-  void CloseWindow() final;
-  void SetScreenScale(float scale) final;
-  void OnParentWindowResize(int width, int height) override;
+    void* OpenWindow(void* pHandle) final;
+    void CloseWindow() final;
+    void SetScreenScale(float scale) final;
+    void EnableAutoScale(bool enable) final;
+    void OnParentWindowResize(int width, int height) override;
 
   bool OnKeyDown(const IKeyPress& key) override;
   bool OnKeyUp(const IKeyPress& key) override;

--- a/IPlug/IPlugEditorDelegate.h
+++ b/IPlug/IPlugEditorDelegate.h
@@ -344,9 +344,13 @@ public:
    * @return The new chunk position (endPos) */
   virtual int UnserializeEditorState(const IByteChunk& chunk, int startPos)  { return startPos; }
   
-  /** Can be used by a host API to inform the editor of screen scale changes
-   * @param scale The new screen scale*/
-  virtual void SetScreenScale(float scale) {}
+   /** Can be used by a host API to inform the editor of screen scale changes
+    * @param scale The new screen scale*/
+   virtual void SetScreenScale(float scale) {}
+
+   /** Enable or disable automatic scaling driven by the operating system
+    * @param enable Set to \c true to allow IGraphics to automatically adjust the scale */
+   virtual void EnableAutoScale(bool enable) {}
 
   friend class IPlugAPP;
   friend class IPlugAAX;

--- a/IPlug/VST3/IPlugVST3_View.h
+++ b/IPlug/VST3/IPlugVST3_View.h
@@ -136,6 +136,7 @@ public:
 
   Steinberg::tresult PLUGIN_API setContentScaleFactor(ScaleFactor factor) override
   {
+    mOwner.EnableAutoScale(false);
     mOwner.SetScreenScale(factor);
 
     return Steinberg::kResultOk;


### PR DESCRIPTION
## Summary
- Disable auto scaling when VST3 host provides a scale factor
- Expose `EnableAutoScale` through editor delegate and forward to IGraphics

## Testing
- `g++ -std=c++17 -fsyntax-only IPlug/VST3/IPlugVST3_View.h` *(fails: base/source/fstring.h: No such file or directory)*
- `g++ -std=c++17 -fsyntax-only IGraphics/IGraphicsEditorDelegate.cpp` *(fails: IPlugEditorDelegate.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c44fe3973483299cad1f048a26b5db