### PR TITLE
Fix Windows font cache compilation error

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -118,7 +118,7 @@ using namespace igraphics;
 
 #pragma mark - Shared font caches
 
-StaticStorage<InstalledFont> IGraphicsWin::mPlatformFontCache;
+StaticStorage<IGraphicsWin::InstalledFont> IGraphicsWin::mPlatformFontCache;
 StaticStorage<HFontHolder> IGraphicsWin::mHFontCache;
 
 #pragma mark - Mouse and tablet helpers
@@ -833,9 +833,9 @@ IGraphicsWin::IGraphicsWin(IGEditorDelegate& dlg, int w, int h, int fps, float s
   if (mVSYNCEnabled)
     mVBlankThread = std::make_unique<VBlankThread>(*this);
 #endif
-  const COLORREF w = RGB(255, 255, 255);
+  const COLORREF white = RGB(255, 255, 255);
   for (int i = 0; i < 16; ++i)
-    mCustomColorStorage[i] = w;
+    mCustomColorStorage[i] = white;
 }
 
 IGraphicsWin::~IGraphicsWin()


### PR DESCRIPTION
## Summary
- ensure IGraphicsWin static font cache uses nested InstalledFont type
- avoid constructor parameter shadowing in IGraphicsWin

## Testing
- `clang++ -fsyntax-only IGraphics/Platforms/IGraphicsWin.cpp` *(fails: 'ShlObj.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c451fc586c8329a3971d87859dce4d