### PR TITLE
Ensure Windows font caches are per-instance

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -116,11 +116,6 @@ private:
 using namespace iplug;
 using namespace igraphics;
 
-#pragma mark - Shared font caches
-
-StaticStorage<IGraphicsWin::InstalledFont> IGraphicsWin::mPlatformFontCache;
-StaticStorage<HFontHolder> IGraphicsWin::mHFontCache;
-
 #pragma mark - Mouse and tablet helpers
 
 extern float GetScaleForHWND(HWND hWnd);

--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -185,8 +185,8 @@ private:
   COLORREF mCustomColorStorage[16] = {};
 
   WDL_String mMainWndClassName;
-  static StaticStorage<InstalledFont> mPlatformFontCache;
-  static StaticStorage<HFontHolder> mHFontCache;
+  StaticStorage<InstalledFont> mPlatformFontCache; // per-instance font cache
+  StaticStorage<HFontHolder> mHFontCache;          // per-instance HFONT cache
   /** Current VBlank thread priority, defaults to THREAD_PRIORITY_NORMAL. */
   int mVBlankThreadPriority = THREAD_PRIORITY_NORMAL;
   double mFPS = 0.0;


### PR DESCRIPTION
## Summary
- keep Windows font caches per instance rather than static shared objects

## Testing
- `clang-format --dry-run IGraphics/Platforms/IGraphicsWin.h IGraphics/Platforms/IGraphicsWin.cpp`
- `g++ -std=c++17 -I. -c IGraphics/Platforms/IGraphicsWin.cpp` *(fails: ShlObj.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c453b0a12083299ef9f9b47260aaec