### PR TITLE
Refactor Windows platform caches to instance members

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -176,9 +176,12 @@ private:
   int mTooltipIdx = -1;
 
   WDL_String mMainWndClassName;
-    
-  static StaticStorage<InstalledFont> sPlatformFontCache;
-  static StaticStorage<HFontHolder> sHFontCache;
+
+  StaticStorage<InstalledFont> mPlatformFontCache;
+  StaticStorage<HFontHolder> mHFontCache;
+  int mWndClassReg = 0;
+  const wchar_t* mWndClassName = L"IPlugWndClass";
+  COLORREF mCustomColorStorage[16];
 
   std::unordered_map<ITouchID, IMouseInfo> mDeltaCapture; // associative array of touch id pointers to IMouseInfo structs, so that we can get deltas
 };


### PR DESCRIPTION
## Summary
- Replace static Windows font caches with per-instance members
- Manage window class registration per `IGraphicsWin` instance
- Store custom color picker colors per instance

## Testing
- `make -C Tests/IGraphicsTest` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4666f0e1c8329b7c8cfc47462b983