### PR TITLE
Use instance-scoped bitmap and SVG caches on Windows

### DIFF
--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -39,9 +39,10 @@ using VST3_API_BASE = iplug::IPlugVST3Controller;
 
 using namespace iplug;
 using namespace igraphics;
-
+#ifndef OS_WIN
 static StaticStorage<APIBitmap> sBitmapCache;
 static StaticStorage<SVGHolder> sSVGCache;
+#endif
 
 IGraphics::IGraphics(IGEditorDelegate& dlg, int w, int h, int fps, float scale)
 : mWidth(w)
@@ -52,9 +53,17 @@ IGraphics::IGraphics(IGEditorDelegate& dlg, int w, int h, int fps, float scale)
 , mMaxScale(DEFAULT_MAX_DRAW_SCALE)
 , mDelegate(&dlg)
 {
+#ifdef OS_WIN
+  StaticStorage<APIBitmap>::Accessor bitmapStorage(mBitmapCache);
+#else
   StaticStorage<APIBitmap>::Accessor bitmapStorage(sBitmapCache);
+#endif
   bitmapStorage.Retain();
+#ifdef OS_WIN
+  StaticStorage<SVGHolder>::Accessor svgStorage(mSVGCache);
+#else
   StaticStorage<SVGHolder>::Accessor svgStorage(sSVGCache);
+#endif
   svgStorage.Retain();
 }
 
@@ -65,10 +74,17 @@ IGraphics::~IGraphics()
     
   mCursorHidden = false;
   RemoveAllControls();
-    
+#ifdef OS_WIN
+  StaticStorage<APIBitmap>::Accessor bitmapStorage(mBitmapCache);
+#else
   StaticStorage<APIBitmap>::Accessor bitmapStorage(sBitmapCache);
+#endif
   bitmapStorage.Release();
+#ifdef OS_WIN
+  StaticStorage<SVGHolder>::Accessor svgStorage(mSVGCache);
+#else
   StaticStorage<SVGHolder>::Accessor svgStorage(sSVGCache);
+#endif
   svgStorage.Release();
 }
 
@@ -1583,7 +1599,11 @@ void IGraphics::EnableLiveEdit(bool enable)
 #ifdef SVG_USE_SKIA
 ISVG IGraphics::LoadSVG(const char* fileName, const char* units, float dpi)
 {
+#ifdef OS_WIN
+  StaticStorage<SVGHolder>::Accessor storage(mSVGCache);
+#else
   StaticStorage<SVGHolder>::Accessor storage(sSVGCache);
+#endif
   SVGHolder* pHolder = storage.Find(fileName);
   
   if(!pHolder)
@@ -1604,7 +1624,11 @@ ISVG IGraphics::LoadSVG(const char* fileName, const char* units, float dpi)
 
 ISVG IGraphics::LoadSVG(const char* name, const void* pData, int dataSize, const char* units, float dpi)
 {
+#ifdef OS_WIN
+  StaticStorage<SVGHolder>::Accessor storage(mSVGCache);
+#else
   StaticStorage<SVGHolder>::Accessor storage(sSVGCache);
+#endif
   SVGHolder* pHolder = storage.Find(name);
 
   if (!pHolder)
@@ -1645,7 +1669,11 @@ ISVG IGraphics::LoadSVG(const char* name, const void* pData, int dataSize, const
 #else
 ISVG IGraphics::LoadSVG(const char* fileName, const char* units, float dpi)
 {
+#ifdef OS_WIN
+  StaticStorage<SVGHolder>::Accessor storage(mSVGCache);
+#else
   StaticStorage<SVGHolder>::Accessor storage(sSVGCache);
+#endif
   SVGHolder* pHolder = storage.Find(fileName);
 
   if(!pHolder)
@@ -1666,7 +1694,11 @@ ISVG IGraphics::LoadSVG(const char* fileName, const char* units, float dpi)
 
 ISVG IGraphics::LoadSVG(const char* name, const void* pData, int dataSize, const char* units, float dpi)
 {
+#ifdef OS_WIN
+  StaticStorage<SVGHolder>::Accessor storage(mSVGCache);
+#else
   StaticStorage<SVGHolder>::Accessor storage(sSVGCache);
+#endif
   SVGHolder* pHolder = storage.Find(name);
 
   if (!pHolder)
@@ -1748,8 +1780,11 @@ IBitmap IGraphics::LoadBitmap(const char* name, int nStates, bool framesAreHoriz
 {
   if (targetScale == 0)
     targetScale = GetRoundedScreenScale();
-
+#ifdef OS_WIN
+  StaticStorage<APIBitmap>::Accessor storage(mBitmapCache);
+#else
   StaticStorage<APIBitmap>::Accessor storage(sBitmapCache);
+#endif
   APIBitmap* pAPIBitmap = storage.Find(name, targetScale);
 
   // If the bitmap is not already cached at the targetScale
@@ -1810,8 +1845,11 @@ IBitmap IGraphics::LoadBitmap(const char *name, const void *pData, int dataSize,
 {
   if (targetScale == 0)
     targetScale = GetRoundedScreenScale();
-
+#ifdef OS_WIN
+  StaticStorage<APIBitmap>::Accessor storage(mBitmapCache);
+#else
   StaticStorage<APIBitmap>::Accessor storage(sBitmapCache);
+#endif
   APIBitmap* pAPIBitmap = storage.Find(name, targetScale);
 
   // If the bitmap is not already cached at the targetScale
@@ -1859,13 +1897,21 @@ IBitmap IGraphics::LoadBitmap(const char *name, const void *pData, int dataSize,
 
 void IGraphics::ReleaseBitmap(const IBitmap &bitmap)
 {
+#ifdef OS_WIN
+  StaticStorage<APIBitmap>::Accessor storage(mBitmapCache);
+#else
   StaticStorage<APIBitmap>::Accessor storage(sBitmapCache);
+#endif
   storage.Remove(bitmap.GetAPIBitmap());
 }
 
 void IGraphics::RetainBitmap(const IBitmap& bitmap, const char* cacheName)
 {
+#ifdef OS_WIN
+  StaticStorage<APIBitmap>::Accessor storage(mBitmapCache);
+#else
   StaticStorage<APIBitmap>::Accessor storage(sBitmapCache);
+#endif
   storage.Add(bitmap.GetAPIBitmap(), cacheName, bitmap.GetScale());
 }
 
@@ -1923,8 +1969,12 @@ EResourceLocation IGraphics::SearchImageResource(const char* name, const char* t
 
 APIBitmap* IGraphics::SearchBitmapInCache(const char* name, int targetScale, int& sourceScale)
 {
+#ifdef OS_WIN
+  StaticStorage<APIBitmap>::Accessor storage(mBitmapCache);
+#else
   StaticStorage<APIBitmap>::Accessor storage(sBitmapCache);
-    
+#endif
+
   for (sourceScale = targetScale; sourceScale > 0; SearchNextScale(sourceScale, targetScale))
   {
     APIBitmap* pBitmap = storage.Find(name, sourceScale);

--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -1861,7 +1861,12 @@ private:
   IKeyHandlerFunc mKeyHandlerFunc = nullptr;
   IDisplayTickFunc mDisplayTickFunc = nullptr;
   IUIAppearanceChangedFunc mAppearanceChangedFunc = nullptr;
-  
+
+#ifdef OS_WIN
+  StaticStorage<APIBitmap> mBitmapCache;
+  StaticStorage<SVGHolder> mSVGCache;
+#endif
+
 protected:
   IGEditorDelegate* mDelegate;
   bool mCursorHidden = false;


### PR DESCRIPTION
## Summary
- Replace global bitmap/SVG caches with per-instance members on Windows
- Update constructor, destructor, and cache helpers to reference the new members

## Testing
- `g++ -std=c++17 -DIGRAPHICS_NANOVG -DNO_IGRAPHICS=0 -DOS_LINUX -fsyntax-only IGraphics/IGraphics.cpp -I. -IIGraphics -I./IGraphics/Drawing -I./IGraphics/Platforms -I./IGraphics/Controls -I./IPlug -I./IPlug/Extras -I./WDL -IDependencies/IGraphics/NanoSVG/src -IDependencies/IGraphics/NanoVG/src -IDependencies/IGraphics/STB` *(fails: FONT_DESCRIPTOR_TYPE not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c467cf68408329897380089ca7cbd2