### PR TITLE
Make Skia font resources instance scoped

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.h
+++ b/IGraphics/Drawing/IGraphicsSkia.h
@@ -24,6 +24,7 @@
 #if !defined IGRAPHICS_NO_SKIA_SKPARAGRAPH
   #include "modules/skparagraph/include/FontCollection.h"
   #include "modules/skparagraph/include/TypefaceFontProvider.h" // <-- ADD THIS LINE
+  #include "modules/skunicode/include/SkUnicode.h"
 #endif
 
 namespace skia::textlayout
@@ -132,7 +133,6 @@ public:
   void DrawMultiLineText(const IText& text, const char* str, const IRECT& bounds, const IBlend* pBlend) override;
 
 protected:
-  void CleanUpSkiaStatics();
   float DoMeasureText(const IText& text, const char* str, IRECT& bounds) const override;
   void DoDrawText(const IText& text, const char* str, const IRECT& bounds, const IBlend* pBlend) override;
 
@@ -168,9 +168,10 @@ private:
 #if !defined IGRAPHICS_NO_SKIA_SKPARAGRAPH
   sk_sp<skia::textlayout::FontCollection> mFontCollection;
   sk_sp<skia::textlayout::TypefaceFontProvider> mTypefaceProvider;
-  sk_sp<SkFontMgr> mFontMgr;
-  static sk_sp<SkFontMgr> SParagraphFontMgr();
+  sk_sp<SkUnicode> mUnicode;
 #endif
+
+  sk_sp<SkFontMgr> mFontMgr;
 
 #ifdef IGRAPHICS_METAL
   void* mMTLDevice;
@@ -179,7 +180,7 @@ private:
   void* mMTLLayer;
 #endif
 
-  static StaticStorage<Font> sFontCache;
+  StaticStorage<Font> mFontCache;
 };
 
 END_IGRAPHICS_NAMESPACE


### PR DESCRIPTION
## Summary
- replace global Skia font cache with per-instance cache and managers
- create and destroy Skia font manager and unicode objects per `IGraphicsSkia`
- update text drawing to use instance-specific font resources

## Testing
- `./Scripts/run_clang_format.sh`
- `cmake -S . -B build` *(fails: The source directory "/workspace/iPlug2" does not appear to contain CMakeLists.txt.)*

------
https://chatgpt.com/codex/tasks/task_e_68c46950a0848329b63702ec8e459fd1