### PR TITLE
Fix Skia font cache cleanup

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -354,7 +354,8 @@ IGraphicsSkia::~IGraphicsSkia()
   mUnicode.reset();
 #endif
 
-  mFontCache.Clear();
+  StaticStorage<Font>::Accessor storage(mFontCache);
+  storage.Clear();
   mFontMgr.reset();
 }
 


### PR DESCRIPTION
## Summary
- use `StaticStorage` accessor when clearing Skia font cache

## Testing
- `g++ -IIGraphics -IIPlug -DIGRAPHICS_SKIA -c IGraphics/Drawing/IGraphicsSkia.cpp` *(fails: wdlstring.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c46c6f476483299eeed0cb1acc5b55