### PR TITLE
Make Skia font cache mutable

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.h
+++ b/IGraphics/Drawing/IGraphicsSkia.h
@@ -180,7 +180,7 @@ private:
   void* mMTLLayer;
 #endif
 
-  StaticStorage<Font> mFontCache;
+  mutable StaticStorage<Font> mFontCache;
 };
 
 END_IGRAPHICS_NAMESPACE


### PR DESCRIPTION
## Summary
- mark the Skia font cache member mutable so `StaticStorage<Font>::Accessor` can be used from const functions

## Testing
- `g++ -std=c++17 -IIGraphics -IIPlug -IWDL -I. -DIGRAPHICS_SKIA -DOS_LINUX -c IGraphics/Drawing/IGraphicsSkia.cpp` *(fails: modules/svg/include/SkSVGDOM.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c46c7078508329a24cae723d256ab6