### PR TITLE
Generate unique window class names for Win32

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -179,8 +179,8 @@ private:
 
   StaticStorage<InstalledFont> mPlatformFontCache;
   StaticStorage<HFontHolder> mHFontCache;
-  int mWndClassReg = 0;
-  const wchar_t* mWndClassName = L"IPlugWndClass";
+  std::wstring mWndClassName;
+  bool mWndClassRegistered = false;
   COLORREF mCustomColorStorage[16];
 
   std::unordered_map<ITouchID, IMouseInfo> mDeltaCapture; // associative array of touch id pointers to IMouseInfo structs, so that we can get deltas


### PR DESCRIPTION
## Summary
- Track window class registration per instance with a mutable name
- Register/unregister each Win32 window class using its unique identifier

## Testing
- `x86_64-w64-mingw32-g++ -std=c++17 -I. -c IGraphics/Platforms/IGraphicsWin.cpp` *(fails: Shlobj.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c474ae474483298b755b7e10a829d7