### PR TITLE
Refactor handle management to instance members

### DIFF
--- a/IGraphics/IGraphics_include_in_plug_src.h
+++ b/IGraphics/IGraphics_include_in_plug_src.h
@@ -34,7 +34,7 @@
   }
 
   #elif defined OS_WIN
-  extern HINSTANCE gHINSTANCE;
+  #include "IPlugAPIBase.h"
   #endif
 
   BEGIN_IPLUG_NAMESPACE
@@ -44,7 +44,8 @@
   IGraphics* MakeGraphics(IGEditorDelegate& dlg, int w, int h, int fps = 0, float scale = 1.)
   {
     IGraphicsWin* pGraphics = new IGraphicsWin(dlg, w, h, fps, scale);
-    pGraphics->SetWinModuleHandle(gHINSTANCE);
+    auto* pAPI = static_cast<IPlugAPIBase*>(&dlg);
+    pGraphics->SetWinModuleHandle(pAPI->GetWinModuleHandle());
     return pGraphics;
   }
   #elif defined OS_MAC

--- a/IPlug/APP/IPlugAPP.cpp
+++ b/IPlug/APP/IPlugAPP.cpp
@@ -19,13 +19,13 @@ extern float GetScaleForHWND(HWND hWnd);
 
 using namespace iplug;
 
-extern HWND gHWND;
 
 IPlugAPP::IPlugAPP(const InstanceInfo& info, const Config& config)
 : IPlugAPIBase(config, kAPIAPP)
 , IPlugProcessor(config, kAPIAPP)
 {
   mAppHost = (IPlugAPPHost*) info.pAppHost;
+  SetWinModuleHandle(info.pAppInstance);
   
   Trace(TRACELOC, "%s%s", config.pluginName, config.channelIOStr);
 
@@ -47,8 +47,9 @@ bool IPlugAPP::EditorResize(int viewWidth, int viewHeight)
     RECT rcClient, rcWindow;
     POINT ptDiff;
     
-    GetClientRect(gHWND, &rcClient);
-    GetWindowRect(gHWND, &rcWindow);
+    HWND hwnd = (HWND) mAppHost->GetMainWnd();
+    GetClientRect(hwnd, &rcClient);
+    GetWindowRect(hwnd, &rcWindow);
     
     ptDiff.x = (rcWindow.right - rcWindow.left) - rcClient.right;
     ptDiff.y = (rcWindow.bottom - rcWindow.top) - rcClient.bottom;
@@ -57,12 +58,12 @@ bool IPlugAPP::EditorResize(int viewWidth, int viewHeight)
     
     #ifdef OS_WIN
     flags = SWP_NOMOVE;
-    float ss = GetScaleForHWND(gHWND);
+    float ss = GetScaleForHWND(hwnd);
     #else
     float ss = 1.f;
     #endif
     
-    SetWindowPos(gHWND, 0,
+    SetWindowPos(hwnd, 0,
                  static_cast<LONG>(rcWindow.left * ss),
                  static_cast<LONG>((rcWindow.bottom - viewHeight - ptDiff.y) * ss),
                  static_cast<LONG>((viewWidth + ptDiff.x) * ss),

--- a/IPlug/APP/IPlugAPP.h
+++ b/IPlug/APP/IPlugAPP.h
@@ -26,6 +26,7 @@ BEGIN_IPLUG_NAMESPACE
 struct InstanceInfo
 {
   void* pAppHost;
+  void* pAppInstance;
 };
 
 class IPlugAPPHost;

--- a/IPlug/APP/IPlugAPP_dialog.cpp
+++ b/IPlug/APP/IPlugAPP_dialog.cpp
@@ -15,7 +15,7 @@
 #ifdef OS_WIN
 #include "asio.h"
 extern float GetScaleForHWND(HWND hWnd);
-#define GET_MENU() GetMenu(gHWND)
+#define GET_MENU() GetMenu(pAppHost->GetMainWnd())
 #elif defined OS_MAC
 #define GET_MENU() SWELL_GetCurrentMenu()
 #endif
@@ -545,10 +545,10 @@ WDL_DLGRET IPlugAPPHost::MainDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPA
   {
     case WM_INITDIALOG:
     {
-      gHWND = hwndDlg;
+      pAppHost->SetMainWnd(hwndDlg);
       IPlugAPP* pPlug = pAppHost->GetPlug();
 
-      if (!pAppHost->OpenWindow(gHWND))
+      if (!pAppHost->OpenWindow(hwndDlg))
       {
         DBGMSG("couldn't attach gui\n");
       }
@@ -560,7 +560,7 @@ WDL_DLGRET IPlugAPPHost::MainDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPA
     }
     case WM_DESTROY:
       pAppHost->CloseWindow();
-      gHWND = NULL;
+      pAppHost->SetMainWnd(NULL);
       IPlugAPPHost::sInstance = nullptr;
       
       #ifdef OS_WIN
@@ -610,7 +610,7 @@ WDL_DLGRET IPlugAPPHost::MainDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPA
         }
         case ID_PREFERENCES:
         {
-          INT_PTR ret = DialogBox(gHINSTANCE, MAKEINTRESOURCE(IDD_DIALOG_PREF), hwndDlg, IPlugAPPHost::PreferencesDlgProc);
+          INT_PTR ret = DialogBox(pAppHost->GetInstance(), MAKEINTRESOURCE(IDD_DIALOG_PREF), hwndDlg, IPlugAPPHost::PreferencesDlgProc);
 
           if(ret == IDOK)
             pAppHost->UpdateINI();

--- a/IPlug/APP/IPlugAPP_host.cpp
+++ b/IPlug/APP/IPlugAPP_host.cpp
@@ -27,8 +27,9 @@ using namespace iplug;
 std::unique_ptr<IPlugAPPHost> IPlugAPPHost::sInstance;
 UINT gSCROLLMSG;
 
-IPlugAPPHost::IPlugAPPHost()
-: mIPlug(MakePlug(InstanceInfo{this}))
+IPlugAPPHost::IPlugAPPHost(HINSTANCE hInstance)
+: mHInstance(hInstance)
+, mIPlug(MakePlug(InstanceInfo{this, hInstance}))
 {
 }
 
@@ -46,9 +47,9 @@ IPlugAPPHost::~IPlugAPPHost()
 }
 
 //static
-IPlugAPPHost* IPlugAPPHost::Create()
+IPlugAPPHost* IPlugAPPHost::Create(HINSTANCE hInstance)
 {
-  sInstance = std::make_unique<IPlugAPPHost>();
+  sInstance = std::make_unique<IPlugAPPHost>(hInstance);
   return sInstance.get();
 }
 
@@ -448,7 +449,7 @@ bool IPlugAPPHost::TryToChangeAudio()
   }
 
   if (failedToFindDevice)
-    MessageBox(gHWND, "Please check your soundcard settings in Preferences", "Error", MB_OK);
+    MessageBox(mMainWnd, "Please check your soundcard settings in Preferences", "Error", MB_OK);
 
   if (inputID != -1 && outputID != -1)
   {

--- a/IPlug/APP/IPlugAPP_host.h
+++ b/IPlug/APP/IPlugAPP_host.h
@@ -64,8 +64,6 @@
 
 #define OFF_TEXT "off"
 
-extern HWND gHWND;
-extern HINSTANCE gHINSTANCE;
 
 BEGIN_IPLUG_NAMESPACE
 
@@ -157,7 +155,7 @@ public:
     bool operator!=(const AppState& rhs) const { return !operator==(rhs); }
   };
   
-  static IPlugAPPHost* Create();
+  static IPlugAPPHost* Create(HINSTANCE hInstance = nullptr);
   static std::unique_ptr<IPlugAPPHost> sInstance;
   
   void PopulateSampleRateList(HWND hwndDlg, RtAudio::DeviceInfo* pInputDevInfo, RtAudio::DeviceInfo* pOutputDevInfo);
@@ -168,11 +166,15 @@ public:
   bool PopulateMidiDialogs(HWND hwndDlg);
   void PopulatePreferencesDialog(HWND hwndDlg);
   
-  IPlugAPPHost();
+  IPlugAPPHost(HINSTANCE hInstance = nullptr);
   ~IPlugAPPHost();
   
   bool OpenWindow(HWND pParent);
   void CloseWindow();
+
+  HINSTANCE GetInstance() const { return mHInstance; }
+  HWND GetMainWnd() const { return mMainWnd; }
+  void SetMainWnd(HWND wnd) { mMainWnd = wnd; }
 
   bool Init();
   bool InitState();
@@ -216,6 +218,8 @@ public:
 
   IPlugAPP* GetPlug() { return mIPlug.get(); }
 private:
+  HINSTANCE mHInstance = nullptr;
+  HWND mMainWnd = nullptr;
   std::unique_ptr<IPlugAPP> mIPlug = nullptr;
   std::unique_ptr<RtAudio> mDAC = nullptr;
   std::unique_ptr<RtMidiIn> mMidiIn = nullptr;

--- a/IPlug/IPlugAPIBase.h
+++ b/IPlug/IPlugAPIBase.h
@@ -45,9 +45,14 @@ class IPlugAPIBase : public IPluginBase
 public:
   IPlugAPIBase(Config config, EAPI plugAPI);
   virtual ~IPlugAPIBase();
-  
+
   IPlugAPIBase(const IPlugAPIBase&) = delete;
   IPlugAPIBase& operator=(const IPlugAPIBase&) = delete;
+
+  void SetWinModuleHandle(void* pInstance) { mHInstance = pInstance; }
+  void* GetWinModuleHandle() const { return mHInstance; }
+  void SetWinWindowHandle(void* pWnd) { mHWND = pWnd; }
+  void* GetWinWindowHandle() const { return mHWND; }
   
 #pragma mark - Methods you can implement/override in your plug-in class - you do not call these methods
 
@@ -224,6 +229,8 @@ private:
   friend class IPlugWEB;
 
 private:
+  void* mHInstance = nullptr;
+  void* mHWND = nullptr;
   WDL_String mParamDisplayStr;
   std::unique_ptr<Timer> mTimer;
   

--- a/IPlug/ReaperExt/ReaperExtBase.cpp
+++ b/IPlug/ReaperExt/ReaperExtBase.cpp
@@ -41,8 +41,8 @@ bool ReaperExtBase::EditorResizeFromUI(int viewWidth, int viewHeight, bool needs
 #ifdef OS_MAC
 #define TITLEBAR_BODGE 22 //TODO: sort this out
     RECT r;
-    GetWindowRect(gHWND, &r);
-    SetWindowPos(gHWND, 0, r.left, r.bottom - viewHeight - TITLEBAR_BODGE, viewWidth, viewHeight + TITLEBAR_BODGE, 0);
+    GetWindowRect(mHWND, &r);
+    SetWindowPos(mHWND, 0, r.left, r.bottom - viewHeight - TITLEBAR_BODGE, viewWidth, viewHeight + TITLEBAR_BODGE, 0);
 #endif
 
     return true;
@@ -53,12 +53,12 @@ bool ReaperExtBase::EditorResizeFromUI(int viewWidth, int viewHeight, bool needs
 
 void ReaperExtBase::ShowHideMainWindow()
 {
-  if(gHWND == NULL)
+  if(mHWND == NULL)
   {
-    gHWND = CreateDialog(gHINSTANCE, MAKEINTRESOURCE(IDD_DIALOG_MAIN), gParent, ReaperExtBase::MainDlgProc);
+    mHWND = CreateDialog(mHInstance, MAKEINTRESOURCE(IDD_DIALOG_MAIN), gParent, ReaperExtBase::MainDlgProc);
   }
   else
-    DestroyWindow(gHWND);
+    DestroyWindow(mHWND);
 }
 
 void ReaperExtBase::ToggleDocking()
@@ -66,13 +66,13 @@ void ReaperExtBase::ToggleDocking()
   if (!mDocked)
   {
     mDocked = true;
-    ShowWindow(gHWND, SW_HIDE);
-    DockWindowAdd(gHWND, (char*) "TEST", 0, false);
-    DockWindowActivate(gHWND);
+    ShowWindow(mHWND, SW_HIDE);
+    DockWindowAdd(mHWND, (char*) "TEST", 0, false);
+    DockWindowActivate(mHWND);
   }
   else
   {
-    DestroyWindow(gHWND);
+    DestroyWindow(mHWND);
     mDocked = false;
 //    Show(false, true);
   }
@@ -146,6 +146,7 @@ WDL_DLGRET ReaperExtBase::MainDlgProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARA
     case WM_INITDIALOG:
     {
       AttachWindowTopmostButton(hwnd);
+      gPlug->SetMainWnd(hwnd);
       gPlug->OpenWindow(hwnd);
       auto scale = GetScaleForHWND(hwnd);
       ClientResize(hwnd, PLUG_WIDTH * scale, PLUG_HEIGHT * scale);
@@ -155,7 +156,7 @@ WDL_DLGRET ReaperExtBase::MainDlgProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARA
       return 0;
     }
     case WM_DESTROY:
-      gHWND = NULL;
+      gPlug->SetMainWnd(NULL);
       return 0;
     case WM_CLOSE:
       gPlug->CloseWindow();

--- a/IPlug/ReaperExt/ReaperExtBase.h
+++ b/IPlug/ReaperExt/ReaperExtBase.h
@@ -18,6 +18,7 @@
 
 #include "IPlugTimer.h"
 #include "IPlugDelegate_select.h"
+#include "IPlugPlatform.h"
 
 struct reaper_plugin_info_t;
 
@@ -51,6 +52,11 @@ public:
   
   void ToggleDocking();
 
+  void SetWinModuleHandle(void* pInstance) { mHInstance = (HINSTANCE) pInstance; }
+  void* GetWinModuleHandle() const { return mHInstance; }
+  void SetMainWnd(HWND wnd) { mHWND = wnd; }
+  HWND GetMainWnd() const { return mHWND; }
+
 public:
   // Reaper calls back to this when it wants to execute an action registered by the extension plugin
   static bool HookCommandProc(int command, int flag);
@@ -66,6 +72,8 @@ private:
   reaper_plugin_info_t* mRec = nullptr;
   std::unique_ptr<Timer> mTimer;
   bool mDocked = false;
+  HINSTANCE mHInstance = nullptr;
+  HWND mHWND = nullptr;
 };
 
 END_IPLUG_NAMESPACE

--- a/IPlug/ReaperExt/ReaperExt_include_in_plug_src.h
+++ b/IPlug/ReaperExt/ReaperExt_include_in_plug_src.h
@@ -13,9 +13,7 @@ void (*AttachWindowTopmostButton)(HWND hwnd);
 #include <vector>
 #include <map>
 
-REAPER_PLUGIN_HINSTANCE gHINSTANCE;
 HWND gParent;
-HWND gHWND = NULL;
 std::unique_ptr<PLUG_CLASS_NAME> gPlug;
 RECT gPrevBounds;
 int gErrorCount = 0;
@@ -42,14 +40,13 @@ extern "C"
 {
   REAPER_PLUGIN_DLL_EXPORT int REAPER_PLUGIN_ENTRYPOINT(REAPER_PLUGIN_HINSTANCE hInstance, reaper_plugin_info_t* pRec)
   {
-    gHINSTANCE = hInstance;
-    
     if (pRec)
     {
       if (pRec->caller_version != REAPER_PLUGIN_VERSION || !pRec->GetFunc)
         return 0;
-      
+
       gPlug = std::make_unique<PLUG_CLASS_NAME>(pRec);
+      gPlug->SetWinModuleHandle(hInstance);
 
       // initialize API function pointers from Reaper
       IMPAPI(Main_OnCommand);


### PR DESCRIPTION
## Summary
- remove global gHINSTANCE/gHWND usage in plug and host code
- store module and window handles per instance across APIs
- wire constructors and dialogs to use instance-based handles
- fix SWELL dialog to use instance-specific module handle
- drop leftover gHINSTANCE/gHWND stubs from Linux example

## Testing
- `cmake -S . -B build` *(fails: The source directory "/workspace/iPlug2" does not appear to contain CMakeLists.txt)*
- `./Scripts/run_clang_format.sh` *(fails: ../IPlug is not a directory)*
- `clang++ -c IPlug/APP/IPlugAPP_main.cpp -I . -I WDL` *(fails: 'IPlugPlatform.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c47674e5dc8329aa90b42f84e8c8c7