### PR TITLE
Remove fmt dependency from IGraphicsPrivate

### DIFF
--- a/IGraphics/IGraphicsPrivate.h
+++ b/IGraphics/IGraphicsPrivate.h
@@ -16,10 +16,11 @@
  */
 
 #include <codecvt>
-#include <fmt/format.h>
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <sstream>
+#include <iomanip>
 
 #include "heapbuf.h"
 #include "mutex.h"
@@ -538,7 +539,12 @@ private:
    * @param str \todo
    * @param scale \todo
    * @return std::string \todo */
-  std::string Hash(const char* str, double scale) { return fmt::format("{}-{:.1f}x", str, scale); }
+  std::string Hash(const char* str, double scale)
+  {
+    std::ostringstream ss;
+    ss << str << "-" << std::fixed << std::setprecision(1) << scale << "x";
+    return ss.str();
+  }
 
   /** \todo
    * @param str \todo


### PR DESCRIPTION
## Summary
- drop fmt::format usage from IGraphicsPrivate
- implement Hash helper with std::ostringstream to avoid missing fmt header

## Testing
- `g++ -std=c++17 -U__linux -U__linux__ -Ulinux -DEMSCRIPTEN -I. -IIPlug -IWDL -IDependencies/IGraphics/NanoSVG/src /tmp/test.cpp -o /tmp/test`
- `ls -l /tmp/test`


------
https://chatgpt.com/codex/tasks/task_e_68c48cdbe58883298a9a35887339f44b