### PR TITLE
Use shared font caches with reference counting on Windows

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -177,8 +177,8 @@ private:
 
   WDL_String mMainWndClassName;
 
-  StaticStorage<InstalledFont> mPlatformFontCache;
-  StaticStorage<HFontHolder> mHFontCache;
+  static StaticStorage<InstalledFont> sPlatformFontCache;
+  static StaticStorage<HFontHolder> sHFontCache;
   std::wstring mWndClassName;
   bool mWndClassRegistered = false;
   COLORREF mCustomColorStorage[16];


### PR DESCRIPTION
## Summary
- make Windows font caches static so they are shared across instances
- retain caches on construction and release them on destruction
- clear font data only when the last instance releases the cache

## Testing
- `bash Tests/IGraphicsTest/scripts/makedist-web.sh` *(fails: can't open file `/upstream/emscripten/tools/file_packager.py`)*
- `g++ -fsyntax-only IGraphics/Platforms/IGraphicsWin.cpp` *(fails: fatal error: Shlobj.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c492b207988329a937f7ba5f6a28d4