### PR TITLE
Share Windows font caches across instances

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -39,6 +39,7 @@ using namespace igraphics;
 
 static double sFPS = 0.0;
 StaticStorage<InstalledFont> IGraphicsWin::sPlatformFontCache;
+StaticStorage<HFontHolder> IGraphicsWin::sHFontCache;
 
 #define PARAM_EDIT_ID 99
 #define IPLUG_TIMER_ID 2
@@ -741,6 +742,11 @@ IGraphicsWin::IGraphicsWin(IGEditorDelegate& dlg, int w, int h, int fps, float s
 #ifndef IGRAPHICS_DISABLE_VSYNC
   mVSYNCEnabled = IsWindows8OrGreater();
 #endif
+
+  StaticStorage<InstalledFont>::Accessor fontStorage(sPlatformFontCache);
+  fontStorage.Retain();
+  StaticStorage<HFontHolder>::Accessor hfontStorage(sHFontCache);
+  hfontStorage.Retain();
 }
 
 IGraphicsWin::~IGraphicsWin()
@@ -751,8 +757,9 @@ IGraphicsWin::~IGraphicsWin()
     if (font->Release() == 0)
       fontStorage.Remove(font);
   }
-  StaticStorage<HFontHolder>::Accessor hfontStorage(mHFontCache);
-  hfontStorage.Clear();
+  fontStorage.Release();
+  StaticStorage<HFontHolder>::Accessor hfontStorage(sHFontCache);
+  hfontStorage.Release();
   DestroyEditWindow();
   CloseWindow();
 }
@@ -1524,7 +1531,7 @@ void IGraphicsWin::CreatePlatformTextEntry(int paramIdx, const IText& text, cons
     return;
   }
 
-  StaticStorage<HFontHolder>::Accessor hfontStorage(mHFontCache);
+  StaticStorage<HFontHolder>::Accessor hfontStorage(sHFontCache);
 
   LOGFONTW lFont = {0};
   HFontHolder* hfontHolder = hfontStorage.Find(text.mFont);
@@ -2159,7 +2166,7 @@ PlatformFontPtr IGraphicsWin::LoadPlatformFont(const char* fontID, void* pData, 
 
 void IGraphicsWin::CachePlatformFont(const char* fontID, const PlatformFontPtr& font)
 {
-  StaticStorage<HFontHolder>::Accessor hfontStorage(mHFontCache);
+  StaticStorage<HFontHolder>::Accessor hfontStorage(sHFontCache);
 
   HFONT hfont = font->GetDescriptor();
 

--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -180,8 +180,8 @@ private:
   WDL_String mMainWndClassName;
 
   static StaticStorage<InstalledFont> sPlatformFontCache;
+  static StaticStorage<HFontHolder> sHFontCache;
   std::vector<InstalledFont*> mInstalledFonts;
-  StaticStorage<HFontHolder> mHFontCache;
   std::wstring mWndClassName;
   bool mWndClassRegistered = false;
   COLORREF mCustomColorStorage[16];


### PR DESCRIPTION
## Summary
- make Windows font caches static so they are shared across instances
- retain caches on construction and release them on destruction
- clear font data only when the last instance releases the cache

## Testing
- `clang-format -i -style=file IGraphics/Platforms/IGraphicsWin.h IGraphics/Platforms/IGraphicsWin.cpp`
- `cmake -S Tests/IGraphicsTest -B /tmp/IGraphicsTest-build` *(fails: source directory does not contain CMakeLists.txt)*

------
https://chatgpt.com/codex/tasks/task_e_68c496ad55888329ba10c11b5514d974