### PR TITLE
Expose InstalledFont alias for Windows graphics

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -29,12 +29,12 @@ namespace DragAndDropHelpers
 class DropTarget;
 }
 
+using InstalledFont = InstalledWinFont;
 
 /** IGraphics platform class for Windows
  * @ingroup PlatformClasses */
 class IGraphicsWin final : public IGRAPHICS_DRAW_CLASS
 {
-  using InstalledFont = InstalledWinFont;
   using Font = WinFont;
 
 public:


### PR DESCRIPTION
## Summary
- expose InstalledFont alias outside of IGraphicsWin class
- fixes static font cache definition on Windows

## Testing
- `g++ -c IGraphics/Platforms/IGraphicsWin.cpp -I.` *(fails: Shlobj.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c49a1ff3708329822b7ae7cfd04fec