### PR TITLE
Associate timers with plugin instances and clean up

### DIFF
--- a/IPlug/Extras/OSC/IPlugOSC.cpp
+++ b/IPlug/Extras/OSC/IPlugOSC.cpp
@@ -7,9 +7,9 @@ int OSCInterface::sInstances = 0;
 WDL_PtrList<OSCDevice> gDevices;
 
 #ifdef OS_WIN
-#define XSleep Sleep
+  #define XSleep Sleep
 #else
-void XSleep(int ms) { usleep(ms?ms*1000:100); }
+void XSleep(int ms) { usleep(ms ? ms * 1000 : 100); }
 #endif
 
 OSCDevice::OSCDevice(const char* dest, int maxpacket, int sendsleep, sockaddr_in* listen_addr)
@@ -24,14 +24,14 @@ OSCDevice::OSCDevice(const char* dest, int maxpacket, int sendsleep, sockaddr_in
 
   if (mSendSocket == INVALID_SOCKET)
   {
-    //TODO:
+    // TODO:
   }
   else if (listen_addr)
   {
     mReceiveAddress = *listen_addr;
     int on = 1;
     setsockopt(mSendSocket, SOL_SOCKET, SO_BROADCAST, (char*)&on, sizeof(on));
-    if (!bind(mSendSocket, (struct sockaddr*) & mReceiveAddress, sizeof(struct sockaddr)))
+    if (!bind(mSendSocket, (struct sockaddr*)&mReceiveAddress, sizeof(struct sockaddr)))
     {
       SET_SOCK_BLOCK(mSendSocket, false);
     }
@@ -53,7 +53,8 @@ OSCDevice::OSCDevice(const char* dest, int maxpacket, int sendsleep, sockaddr_in
       *p++ = 0;
       sendport = atoi(p);
     }
-    if (!sendport) sendport = 8000;
+    if (!sendport)
+      sendport = 8000;
 
     mSendAddress.sin_family = AF_INET;
     mSendAddress.sin_addr.s_addr = inet_addr(tmp.Get());
@@ -80,7 +81,7 @@ void OSCDevice::RunInput()
   if (mSendSocket == INVALID_SOCKET)
     return;
 
-  struct sockaddr* p = mDestination.GetLength() ? nullptr : (struct sockaddr*) & mSendAddress;
+  struct sockaddr* p = mDestination.GetLength() ? nullptr : (struct sockaddr*)&mSendAddress;
 
   for (;;)
   {
@@ -98,12 +99,13 @@ void OSCDevice::RunInput()
 
 void OSCDevice::RunOutput()
 {
-  static char hdr[16] = { '#', 'b', 'u', 'n', 'd', 'l', 'e', 0, 0, 0, 0, 0, 1, 0, 0, 0 };
+  static char hdr[16] = {'#', 'b', 'u', 'n', 'd', 'l', 'e', 0, 0, 0, 0, 0, 1, 0, 0, 0};
 
   // send mSendQueue as UDP blocks
   if (mSendQueue.Available() <= 16)
   {
-    if (mSendQueue.Available() > 0) mSendQueue.Clear();
+    if (mSendQueue.Available() > 0)
+      mSendQueue.Clear();
     return;
   }
   // mSendQueue should begin with a 16 byte pad, then messages in OSC
@@ -120,7 +122,8 @@ void OSCDevice::RunOutput()
     int len = *(int*)mSendQueue.Get(); // not advancing
     OSC_MAKEINTMEM4BE((char*)&len);
 
-    if (len < 1 || len > MAX_OSC_MSG_LEN || len > mSendQueue.Available()) break;
+    if (len < 1 || len > MAX_OSC_MSG_LEN || len > mSendQueue.Available())
+      break;
 
     if (packetlen > 16 && packetlen + sizeof(int) + len > mMaxMacketSize)
     {
@@ -135,7 +138,7 @@ void OSCDevice::RunOutput()
         memcpy(packetstart, hdr, 16);
       }
 
-      sendto(mSendSocket, packetstart, packetlen, 0, (struct sockaddr*) & mSendAddress, sizeof(mSendAddress));
+      sendto(mSendSocket, packetstart, packetlen, 0, (struct sockaddr*)&mSendAddress, sizeof(mSendAddress));
       if (mSendSleep > 0)
         XSleep(mSendSleep);
 
@@ -144,7 +147,8 @@ void OSCDevice::RunOutput()
       hasbundle = false;
     }
 
-    if (packetlen > 16) hasbundle = true;
+    if (packetlen > 16)
+      hasbundle = true;
     mSendQueue.Advance(sizeof(int) + len);
     packetlen += sizeof(int) + len;
   }
@@ -160,7 +164,7 @@ void OSCDevice::RunOutput()
     {
       memcpy(packetstart, hdr, 16);
     }
-    sendto(mSendSocket, packetstart, packetlen, 0, (struct sockaddr*) & mSendAddress, sizeof(mSendAddress));
+    sendto(mSendSocket, packetstart, packetlen, 0, (struct sockaddr*)&mSendAddress, sizeof(mSendAddress));
     if (mSendSleep > 0)
       XSleep(mSendSleep);
   }
@@ -169,9 +173,9 @@ void OSCDevice::RunOutput()
   mSendQueue.Clear();
 }
 
-void OSCDevice::AddInstance(void(*callback)(void* d1, int dev_idx, int msglen, void* msg), void* d1, int dev_idx)
+void OSCDevice::AddInstance(void (*callback)(void* d1, int dev_idx, int msglen, void* msg), void* d1, int dev_idx)
 {
-  const rec r = { callback, d1, dev_idx };
+  const rec r = {callback, d1, dev_idx};
   mInstances.Add(r);
 }
 
@@ -180,7 +184,8 @@ void OSCDevice::OnMessage(char type, const unsigned char* msg, int len)
   const int n = mInstances.GetSize();
   const rec* r = mInstances.Get();
   for (int x = 0; x < n; x++)
-    if (r[x].callback) r[x].callback(r[x].data1, r[x].dev_idx, len, (void*)msg);
+    if (r[x].callback)
+      r[x].callback(r[x].data1, r[x].dev_idx, len, (void*)msg);
 }
 
 void OSCDevice::SendOSC(const char* src, int len)
@@ -194,7 +199,7 @@ void OSCDevice::SendOSC(const char* src, int len)
   mSendQueue.Add(src, len);
 }
 
-//static
+// static
 void OSCInterface::MessageCallback(void* d1, int dev_idx, int len, void* msg)
 {
   OSCInterface* _this = (OSCInterface*)d1;
@@ -249,7 +254,8 @@ void OSCInterface::OnTimer(Timer& timer)
 
       const int this_sz = ((sizeof(incomingEvent) + (evt->sz - 3)) + 7) & ~7;
 
-      if (pos + this_sz > endpos) break;
+      if (pos + this_sz > endpos)
+        break;
       pos += this_sz;
 
       int rd_pos = 0;
@@ -271,7 +277,8 @@ void OSCInterface::OnTimer(Timer& timer)
           OnOSCMessage(rmsg);
 
         rd_pos += rd_sz + 4;
-        if (rd_pos >= evt->sz) break;
+        if (rd_pos >= evt->sz)
+          break;
 
         rd_sz = *(int*)(evt->msg + rd_pos - 4);
         OSC_MAKEINTMEM4BE(&rd_sz);
@@ -283,24 +290,25 @@ void OSCInterface::OnTimer(Timer& timer)
   {
     auto* pDev = gDevices.Get(i);
     if (pDev->mHasOutput)
-      pDev->RunOutput();  // send queued messages
+      pDev->RunOutput(); // send queued messages
   }
 }
 
 OSCInterface::OSCInterface(OSCLogFunc logFunc)
-: mLogFunc(logFunc)
+  : mLogFunc(logFunc)
 {
   JNL::open_socketlib();
 
   if (!mTimer)
-    mTimer = std::unique_ptr<Timer>(Timer::Create(std::bind(&OSCInterface::OnTimer, this, std::placeholders::_1), OSC_TIMER_RATE));
+    mTimer = std::unique_ptr<Timer>(Timer::Create(this, std::bind(&OSCInterface::OnTimer, this, std::placeholders::_1), OSC_TIMER_RATE));
 
   sInstances++;
 }
 
 OSCInterface::~OSCInterface()
 {
-  if (--sInstances == 0) {
+  if (--sInstances == 0)
+  {
     mTimer = nullptr;
     gDevices.Empty(true);
   }
@@ -313,8 +321,10 @@ OSCDevice* OSCInterface::CreateReceiver(WDL_String& log, int port)
   struct sockaddr_in addr;
   addr.sin_addr.s_addr = INADDR_ANY;
   addr.sin_family = AF_INET;
-  if (buf[0] && buf[0] != '*') addr.sin_addr.s_addr = inet_addr(buf);
-  if (addr.sin_addr.s_addr == INADDR_NONE) addr.sin_addr.s_addr = INADDR_ANY;
+  if (buf[0] && buf[0] != '*')
+    addr.sin_addr.s_addr = inet_addr(buf);
+  if (addr.sin_addr.s_addr == INADDR_NONE)
+    addr.sin_addr.s_addr = INADDR_ANY;
   addr.sin_port = htons(port);
 
   int x;
@@ -413,8 +423,8 @@ OSCDevice* OSCInterface::CreateSender(WDL_String& log, const char* ip, int port)
 }
 
 OSCSender::OSCSender(const char* destIP, int port, OSCLogFunc logFunc)
-: OSCInterface(logFunc)
-, mDestIP("")
+  : OSCInterface(logFunc)
+  , mDestIP("")
 {
   SetDestination(destIP, port);
 }
@@ -425,7 +435,7 @@ void OSCSender::SetDestination(const char* ip, int port)
   {
     mDestIP.Set(ip);
     mPort = port;
-    
+
     if (mDevice != nullptr)
     {
       gDevices.DeletePtr(mDevice, true);
@@ -433,8 +443,8 @@ void OSCSender::SetDestination(const char* ip, int port)
 
     WDL_String log;
     mDevice = CreateSender(log, ip, port);
-    
-    if(mLogFunc)
+
+    if (mLogFunc)
       mLogFunc(log);
   }
 }
@@ -447,7 +457,7 @@ void OSCSender::SendOSCMessage(OscMessageWrite& msg)
 }
 
 OSCReceiver::OSCReceiver(int port, OSCLogFunc logFunc)
-: OSCInterface(logFunc)
+  : OSCInterface(logFunc)
 {
   SetReceivePort(port);
 }
@@ -464,8 +474,8 @@ void OSCReceiver::SetReceivePort(int port)
     WDL_String log;
     mDevice = CreateReceiver(log, port);
     mPort = port;
-    
-    if(mLogFunc)
+
+    if (mLogFunc)
       mLogFunc(log);
   }
 }

--- a/IPlug/IPlugAPIBase.cpp
+++ b/IPlug/IPlugAPIBase.cpp
@@ -1,10 +1,10 @@
 /*
  ==============================================================================
- 
- This file is part of the iPlug 2 library. Copyright (C) the iPlug 2 developers. 
- 
+
+ This file is part of the iPlug 2 library. Copyright (C) the iPlug 2 developers.
+
  See LICENSE.txt for  more info.
- 
+
  ==============================================================================
 */
 
@@ -13,10 +13,10 @@
  * @brief IPlugAPIBase implementation
  */
 
+#include <cassert>
 #include <cmath>
 #include <cstdio>
 #include <ctime>
-#include <cassert>
 
 #include "IPlugAPIBase.h"
 
@@ -41,13 +41,13 @@ IPlugAPIBase::IPlugAPIBase(Config c, EAPI plugAPI)
   mAppGroupID.Set(c.appGroupID);
 
   Trace(TRACELOC, "%s:%s", c.pluginName, CurrentTime());
-  
+
   mParamDisplayStr.Set("", MAX_PARAM_DISPLAY_LEN);
 }
 
 IPlugAPIBase::~IPlugAPIBase()
 {
-  if(mTimer)
+  if (mTimer)
   {
     mTimer->Stop();
   }
@@ -57,39 +57,36 @@ IPlugAPIBase::~IPlugAPIBase()
 
 void IPlugAPIBase::OnHostRequestingImportantParameters(int count, WDL_TypedBuf<int>& results)
 {
-  if(NParams() > count)
+  if (NParams() > count)
   {
     for (int i = 0; i < count; i++)
       results.Add(i);
   }
 }
 
-void IPlugAPIBase::CreateTimer()
-{
-  mTimer = std::unique_ptr<Timer>(Timer::Create(std::bind(&IPlugAPIBase::OnTimer, this, std::placeholders::_1), IDLE_TIMER_RATE));
-}
+void IPlugAPIBase::CreateTimer() { mTimer = std::unique_ptr<Timer>(Timer::Create(this, std::bind(&IPlugAPIBase::OnTimer, this, std::placeholders::_1), IDLE_TIMER_RATE)); }
 
 bool IPlugAPIBase::CompareState(const uint8_t* pIncomingState, int startPos) const
 {
   bool isEqual = true;
-  
-  const double* data = (const double*) pIncomingState + startPos;
-  
+
+  const double* data = (const double*)pIncomingState + startPos;
+
   // dirty hack here because protools treats param values as 32 bit int and in IPlug they are 64bit float
   // if we memcmp() the incoming state with the current they may have tiny differences due to the quantization
   for (int i = 0; i < NParams(); i++)
   {
-    float v = (float) GetParam(i)->Value();
-    float vi = (float) *(data++);
-    
+    float v = (float)GetParam(i)->Value();
+    float vi = (float)*(data++);
+
     isEqual &= (std::fabs(v - vi) < 0.00001);
   }
-  
+
   return isEqual;
 }
 
 bool IPlugAPIBase::EditorResizeFromUI(int viewWidth, int viewHeight, bool needsPlatformResize)
-{  
+{
   if (needsPlatformResize)
     return EditorResize(viewWidth, viewHeight);
   else
@@ -101,15 +98,15 @@ bool IPlugAPIBase::EditorResizeFromUI(int viewWidth, int viewHeight, bool needsP
 void IPlugAPIBase::SetHost(const char* host, int version)
 {
   assert(mHost == kHostUninit);
-  
+
   mRawHostNameStr.Set(host);
   mHost = LookUpHost(host);
   mHostVersion = version;
-  
+
   WDL_String vStr;
   GetVersionStr(version, vStr);
   Trace(TRACELOC, "host_%sknown:%s:%s", (mHost == kHostUnknown ? "un" : ""), host, vStr.Get());
-    
+
   HostSpecificInit();
   OnHostIdentified();
 }
@@ -135,13 +132,13 @@ void IPlugAPIBase::SendParameterValueFromAPI(int paramIdx, double value, bool no
 {
   if (normalized)
     value = GetParam(paramIdx)->FromNormalized(value);
-  
+
   mParamChangeFromProcessor.PushFromArgs(paramIdx, value);
 }
 
 void IPlugAPIBase::OnTimer(Timer& t)
 {
-  if(HasUI())
+  if (HasUI())
   {
 // VST3 ********************************************************************************
 #if defined VST3P_API || defined VST3_API
@@ -149,39 +146,39 @@ void IPlugAPIBase::OnTimer(Timer& t)
     {
       IMidiMsg msg;
       mMidiMsgsFromProcessor.Pop(msg);
-#ifdef VST3P_API // distributed
+  #ifdef VST3P_API // distributed
       TransmitMidiMsgFromProcessor(msg);
-#else
+  #else
       SendMidiMsgFromDelegate(msg);
-#endif
+  #endif
     }
 
     while (mSysExDataFromProcessor.ElementsAvailable())
     {
       SysExData msg;
       mSysExDataFromProcessor.Pop(msg);
-#ifdef VST3P_API // distributed
+  #ifdef VST3P_API // distributed
       TransmitSysExDataFromProcessor(msg);
-#else
+  #else
       SendSysexMsgFromDelegate({msg.mOffset, msg.mData, msg.mSize});
-#endif
+  #endif
     }
 // !VST3 ******************************************************************************
 #else
-    while(mParamChangeFromProcessor.ElementsAvailable())
+    while (mParamChangeFromProcessor.ElementsAvailable())
     {
       ParamTuple p;
       mParamChangeFromProcessor.Pop(p);
       SendParameterValueFromDelegate(p.idx, p.value, false);
     }
-    
+
     while (mMidiMsgsFromProcessor.ElementsAvailable())
     {
       IMidiMsg msg;
       mMidiMsgsFromProcessor.Pop(msg);
       SendMidiMsgFromDelegate(msg);
     }
-    
+
     while (mSysExDataFromProcessor.ElementsAvailable())
     {
       SysExData msg;
@@ -190,25 +187,25 @@ void IPlugAPIBase::OnTimer(Timer& t)
     }
 #endif
   }
-  
+
   OnIdle();
 }
 
 void IPlugAPIBase::SendMidiMsgFromUI(const IMidiMsg& msg)
 {
-  DeferMidiMsg(msg); // queue the message so that it will be handled by the processor
+  DeferMidiMsg(msg);                             // queue the message so that it will be handled by the processor
   EDITOR_DELEGATE_CLASS::SendMidiMsgFromUI(msg); // for remote editors
 }
 
 void IPlugAPIBase::SendSysexMsgFromUI(const ISysEx& msg)
 {
-  DeferSysexMsg(msg); // queue the message so that it will be handled by the processor
+  DeferSysexMsg(msg);                             // queue the message so that it will be handled by the processor
   EDITOR_DELEGATE_CLASS::SendSysexMsgFromUI(msg); // for remote editors
 }
 
 void IPlugAPIBase::SendArbitraryMsgFromUI(int msgTag, int ctrlTag, int dataSize, const void* pData)
 {
   OnMessage(msgTag, ctrlTag, dataSize, pData); // IPlugAPIBase implementation handles non distributed plug-ins - just call OnMessage() directly
-  
+
   EDITOR_DELEGATE_CLASS::SendArbitraryMsgFromUI(msgTag, ctrlTag, dataSize, pData);
 }

--- a/IPlug/ReaperExt/ReaperExtBase.cpp
+++ b/IPlug/ReaperExt/ReaperExtBase.cpp
@@ -1,36 +1,30 @@
 ReaperExtBase::ReaperExtBase(reaper_plugin_info_t* pRec)
-: EDITOR_DELEGATE_CLASS(0) // zero params
-, mRec(pRec)
+  : EDITOR_DELEGATE_CLASS(0) // zero params
+  , mRec(pRec)
 {
-  mTimer = std::unique_ptr<Timer>(Timer::Create(std::bind(&ReaperExtBase::OnTimer, this, std::placeholders::_1), IDLE_TIMER_RATE));
+  mTimer = std::unique_ptr<Timer>(Timer::Create(this, std::bind(&ReaperExtBase::OnTimer, this, std::placeholders::_1), IDLE_TIMER_RATE));
 }
 
-ReaperExtBase::~ReaperExtBase()
-{
-  mTimer->Stop();
-}
+ReaperExtBase::~ReaperExtBase() { mTimer->Stop(); }
 
-void ReaperExtBase::OnTimer(Timer& t)
-{
-  OnIdle();
-}
+void ReaperExtBase::OnTimer(Timer& t) { OnIdle(); }
 
 auto ClientResize = [](HWND hWnd, int nWidth, int nHeight) {
   RECT rcClient, rcWindow;
   POINT ptDiff;
   int screenwidth, screenheight;
   int x, y;
-  
+
   screenwidth = GetSystemMetrics(SM_CXSCREEN);
   screenheight = GetSystemMetrics(SM_CYSCREEN);
   x = (screenwidth / 2) - (nWidth / 2);
   y = (screenheight / 2) - (nHeight / 2);
-  
+
   GetClientRect(hWnd, &rcClient);
   GetWindowRect(hWnd, &rcWindow);
   ptDiff.x = (rcWindow.right - rcWindow.left) - rcClient.right;
   ptDiff.y = (rcWindow.bottom - rcWindow.top) - rcClient.bottom;
-  
+
   SetWindowPos(hWnd, 0, x, y, nWidth + ptDiff.x, nHeight + ptDiff.y, 0);
 };
 
@@ -39,7 +33,7 @@ bool ReaperExtBase::EditorResizeFromUI(int viewWidth, int viewHeight, bool needs
   if (viewWidth != GetEditorWidth() || viewHeight != GetEditorHeight())
   {
 #ifdef OS_MAC
-#define TITLEBAR_BODGE 22 //TODO: sort this out
+  #define TITLEBAR_BODGE 22 // TODO: sort this out
     RECT r;
     GetWindowRect(mHWND, &r);
     SetWindowPos(mHWND, 0, r.left, r.bottom - viewHeight - TITLEBAR_BODGE, viewWidth, viewHeight + TITLEBAR_BODGE, 0);
@@ -53,7 +47,7 @@ bool ReaperExtBase::EditorResizeFromUI(int viewWidth, int viewHeight, bool needs
 
 void ReaperExtBase::ShowHideMainWindow()
 {
-  if(mHWND == NULL)
+  if (mHWND == NULL)
   {
     mHWND = CreateDialog(mHInstance, MAKEINTRESOURCE(IDD_DIALOG_MAIN), gParent, ReaperExtBase::MainDlgProc);
   }
@@ -67,106 +61,105 @@ void ReaperExtBase::ToggleDocking()
   {
     mDocked = true;
     ShowWindow(mHWND, SW_HIDE);
-    DockWindowAdd(mHWND, (char*) "TEST", 0, false);
+    DockWindowAdd(mHWND, (char*)"TEST", 0, false);
     DockWindowActivate(mHWND);
   }
   else
   {
     DestroyWindow(mHWND);
     mDocked = false;
-//    Show(false, true);
+    //    Show(false, true);
   }
 }
 
-void ReaperExtBase::RegisterAction(const char* actionName, std::function<void()> func, bool addMenuItem, int* pToggle/*, IKeyPress keyCmd*/)
+void ReaperExtBase::RegisterAction(const char* actionName, std::function<void()> func, bool addMenuItem, int* pToggle /*, IKeyPress keyCmd*/)
 {
   ReaperAction action;
-  
-  int commandID = mRec->Register("command_id", (void*) actionName /* ?? */);
-  
+
+  int commandID = mRec->Register("command_id", (void*)actionName /* ?? */);
+
   assert(commandID);
-  
+
   action.func = func;
   action.accel.accel.cmd = commandID;
   action.accel.desc = actionName;
   action.addMenuItem = addMenuItem;
   action.pToggle = pToggle;
-  
+
   gActions.push_back(action);
-  
-  mRec->Register("gaccel", (void*) &gActions.back().accel);
+
+  mRec->Register("gaccel", (void*)&gActions.back().accel);
 }
 
-//static
+// static
 bool ReaperExtBase::HookCommandProc(int command, int flag)
 {
-  std::vector<ReaperAction>::iterator it = std::find_if (gActions.begin(), gActions.end(), [&](const auto& e) { return e.accel.accel.cmd == command; });
+  std::vector<ReaperAction>::iterator it = std::find_if(gActions.begin(), gActions.end(), [&](const auto& e) { return e.accel.accel.cmd == command; });
 
-  if(it != gActions.end())
+  if (it != gActions.end())
   {
     it->func();
   }
-  
+
   return false;
 }
 
-//static
+// static
 int ReaperExtBase::ToggleActionCallback(int command)
 {
-  std::vector<ReaperAction>::iterator it = std::find_if (gActions.begin(), gActions.end(), [&](const auto& e) { return e.accel.accel.cmd == command; });
-  
-  if(it != gActions.end())
+  std::vector<ReaperAction>::iterator it = std::find_if(gActions.begin(), gActions.end(), [&](const auto& e) { return e.accel.accel.cmd == command; });
+
+  if (it != gActions.end())
   {
-    if(it->pToggle == nullptr)
+    if (it->pToggle == nullptr)
       return -1;
     else
       return *it->pToggle;
   }
-  
+
   return 0;
 }
 
-//static
+// static
 WDL_DLGRET ReaperExtBase::MainDlgProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-//  auto Resize = [&]()
-//  {
-//    RECT r;
-//    GetWindowRect(hwnd, &r);
-//    if(memcmp((void*) &r, (void*) &gPrevBounds, sizeof(RECT)) > 0)
-//      gPlug->GetUI()->Resize(r.right-r.left, r.bottom-r.top, 1);
-//
-//    gPrevBounds = r;
-//  };
+  //  auto Resize = [&]()
+  //  {
+  //    RECT r;
+  //    GetWindowRect(hwnd, &r);
+  //    if(memcmp((void*) &r, (void*) &gPrevBounds, sizeof(RECT)) > 0)
+  //      gPlug->GetUI()->Resize(r.right-r.left, r.bottom-r.top, 1);
+  //
+  //    gPrevBounds = r;
+  //  };
 
   extern float GetScaleForHWND(HWND hWnd);
 
   switch (uMsg)
   {
-    case WM_INITDIALOG:
-    {
-      AttachWindowTopmostButton(hwnd);
-      gPlug->SetMainWnd(hwnd);
-      gPlug->OpenWindow(hwnd);
-      auto scale = GetScaleForHWND(hwnd);
-      ClientResize(hwnd, PLUG_WIDTH * scale, PLUG_HEIGHT * scale);
-      ShowWindow(hwnd, SW_SHOW);
-      GetWindowRect(hwnd, &gPrevBounds);
-      
-      return 0;
-    }
-    case WM_DESTROY:
-      gPlug->SetMainWnd(NULL);
-      return 0;
-    case WM_CLOSE:
-      gPlug->CloseWindow();
-      DestroyWindow(hwnd);
-      return 0;
-//    case WM_SIZE:
-//    {
-      //Resize();
-//      return 0;
-//    }
+  case WM_INITDIALOG: {
+    AttachWindowTopmostButton(hwnd);
+    gPlug->SetMainWnd(hwnd);
+    gPlug->OpenWindow(hwnd);
+    auto scale = GetScaleForHWND(hwnd);
+    ClientResize(hwnd, PLUG_WIDTH * scale, PLUG_HEIGHT * scale);
+    ShowWindow(hwnd, SW_SHOW);
+    GetWindowRect(hwnd, &gPrevBounds);
+
+    return 0;
+  }
+  case WM_DESTROY:
+    gPlug->SetMainWnd(NULL);
+    return 0;
+  case WM_CLOSE:
+    gPlug->CloseWindow();
+    DestroyWindow(hwnd);
+    return 0;
+    //    case WM_SIZE:
+    //    {
+    // Resize();
+    //      return 0;
+    //    }
   }
   return 0;
 }


### PR DESCRIPTION
## Summary
- attach timer instances to their owning plugin
- ensure Windows timers remove themselves from the global list when destroyed
- document global timer list to encourage per-instance management

## Testing
- `x86_64-w64-mingw32-g++ -std=c++17 -DOS_WIN -I. -IWDL -c IPlug/IPlugTimer.cpp -o /tmp/IPlugTimer.o`
- `x86_64-w64-mingw32-g++ -std=c++17 -DOS_WIN -I. -IIPlug -IIGraphics -IWDL -c IPlug/IPlugAPIBase.cpp -o /tmp/IPlugAPIBase.o`


------
https://chatgpt.com/codex/tasks/task_e_68c49e8dba388329a8a9a5e192a71330