### PR TITLE
Add idle diagnostics for resource cache counts

### DIFF
--- a/IGraphics/Drawing/IGraphicsNanoVG.cpp
+++ b/IGraphics/Drawing/IGraphicsNanoVG.cpp
@@ -991,3 +991,9 @@ void IGraphicsNanoVG::DrawMultiLineText(const IText& text, const char* str, cons
   
   nvgRestore(mVG);
 }
+
+int IGraphicsNanoVG::GetFontCacheCount() const
+{
+  StaticStorage<IFontData>::Accessor storage(sFontCache);
+  return storage.Size();
+}

--- a/IGraphics/Drawing/IGraphicsNanoVG.h
+++ b/IGraphics/Drawing/IGraphicsNanoVG.h
@@ -114,10 +114,11 @@ public:
   void PathSetWinding(bool clockwise) override;
   void PathStroke(const IPattern& pattern, float thickness, const IStrokeOptions& options, const IBlend* pBlend) override;
   void PathFill(const IPattern& pattern, const IFillOptions& options, const IBlend* pBlend) override;
-  
+
   IColor GetPoint(int x, int y) override;
   void* GetDrawContext() override { return (void*) mVG; }
-    
+  int GetFontCacheCount() const override;
+
   IBitmap LoadBitmap(const char* name, int nStates, bool framesAreHorizontal, int targetScale) override;
   void ReleaseBitmap(const IBitmap& bitmap) override { }; // NO-OP
   void RetainBitmap(const IBitmap& bitmap, const char * cacheName) override { }; // NO-OP

--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -372,6 +372,12 @@ bool IGraphicsSkia::BitmapExtSupported(const char* ext)
   return (strstr(extLower, "png") != nullptr) || (strstr(extLower, "jpg") != nullptr) || (strstr(extLower, "jpeg") != nullptr);
 }
 
+int IGraphicsSkia::GetFontCacheCount() const
+{
+  StaticStorage<Font>::Accessor storage(mFontCache);
+  return storage.Size();
+}
+
 APIBitmap* IGraphicsSkia::LoadAPIBitmap(const char* fileNameOrResID, int scale, EResourceLocation location, const char* ext)
 {
 // #ifdef OS_IOS

--- a/IGraphics/Drawing/IGraphicsSkia.h
+++ b/IGraphics/Drawing/IGraphicsSkia.h
@@ -117,6 +117,7 @@ public:
 
   IColor GetPoint(int x, int y) override;
   void* GetDrawContext() override { return (void*)mCanvas; }
+  int GetFontCacheCount() const override;
 
   bool BitmapExtSupported(const char* ext) override;
   int AlphaChannel() const override { return 3; }

--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -36,6 +36,7 @@ using VST3_API_BASE = iplug::IPlugVST3Controller;
 #include "IPopupMenuControl.h"
 #include "ITextEntryControl.h"
 #include "IBubbleControl.h"
+#include "IPlugTimer.h"
 
 using namespace iplug;
 using namespace igraphics;
@@ -1536,6 +1537,35 @@ void IGraphics::OnGUIIdle()
 {
   TRACE
   ForAllControls(&IControl::OnGUIIdle);
+#ifdef TRACER_BUILD
+  static int idleCount = 0;
+  if (++idleCount >= 60)
+  {
+    idleCount = 0;
+    int bitmapCount = 0;
+    int svgCount = 0;
+#ifdef OS_WIN
+    {
+      StaticStorage<APIBitmap>::Accessor storage(mBitmapCache);
+      bitmapCount = storage.Size();
+    }
+    {
+      StaticStorage<SVGHolder>::Accessor storage(mSVGCache);
+      svgCount = storage.Size();
+    }
+#else
+    {
+      StaticStorage<APIBitmap>::Accessor storage(sBitmapCache);
+      bitmapCount = storage.Size();
+    }
+    {
+      StaticStorage<SVGHolder>::Accessor storage(sSVGCache);
+      svgCount = storage.Size();
+    }
+#endif
+    Trace(TRACELOC, "bitmaps:%d svg:%d fonts:%d timers:%d", bitmapCount, svgCount, GetFontCacheCount(), Timer::GetActiveTimerCount());
+  }
+#endif
 }
 
 void IGraphics::OnDragResize(float x, float y)

--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -964,6 +964,9 @@ public:
    * @param font A const PlatformFontPtr reference to the relevant font */
   virtual void CachePlatformFont(const char* fontID, const PlatformFontPtr& font) = 0;
 
+  /** Retrieve the number of fonts currently cached by the drawing backend */
+  virtual int GetFontCacheCount() const { return 0; }
+
   /** Get the bundle ID on macOS and iOS, returns emtpy string on other OSs */
   virtual const char* GetBundleID() const { return ""; }
 

--- a/IGraphics/IGraphicsPrivate.h
+++ b/IGraphics/IGraphicsPrivate.h
@@ -522,6 +522,7 @@ public:
     void Clear() { return mStorage.Clear(); }
     void Retain() { return mStorage.Retain(); }
     void Release() { return mStorage.Release(); }
+    int Size() const { return mStorage.Size(); }
 
   private:
     StaticStorage& mStorage;
@@ -592,6 +593,8 @@ private:
     if (--mCount == 0)
       Clear();
   }
+
+  int Size() const { return static_cast<int>(mDatas.size()); }
 
   int mCount = 0;
   WDL_Mutex mMutex;

--- a/IPlug/IPlugTimer.cpp
+++ b/IPlug/IPlugTimer.cpp
@@ -14,8 +14,27 @@
  */
 
 #include "IPlugTimer.h"
+#include <atomic>
 
 using namespace iplug;
+
+static std::atomic<int> sTimerCount{0};
+
+Timer::Timer(void* owner)
+  : mOwner(owner)
+{
+  ++sTimerCount;
+}
+
+Timer::~Timer()
+{
+  --sTimerCount;
+}
+
+int Timer::GetActiveTimerCount()
+{
+  return sTimerCount.load();
+}
 
 #if defined OS_MAC || defined OS_IOS
 

--- a/IPlug/IPlugTimer.h
+++ b/IPlug/IPlugTimer.h
@@ -37,17 +37,15 @@ BEGIN_IPLUG_NAMESPACE
 /** Base class for timer */
 struct Timer
 {
-  Timer(void* owner)
-    : mOwner(owner)
-  {
-  }
+  Timer(void* owner);
+  virtual ~Timer();
   Timer(const Timer&) = delete;
   Timer& operator=(const Timer&) = delete;
 
   using ITimerFunction = std::function<void(Timer& t)>;
 
   static Timer* Create(void* owner, ITimerFunction func, uint32_t intervalMs);
-  virtual ~Timer() {};
+  static int GetActiveTimerCount();
   virtual void Stop() = 0;
 
   void* GetOwner() const { return mOwner; }


### PR DESCRIPTION
## Summary
- log bitmap, font and timer counts each idle cycle
- expose cache size helpers for StaticStorage and timers
- allow drawing backends to report cached font totals

## Testing
- `g++ -std=c++17 -DOS_WEB -I. -IWDL -c IPlug/IPlugTimer.cpp` *(fails: emscripten/html5.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c4a1164d7883298c6c0be831e7a5e7