### PR TITLE
Add logger include to VST3 view for tracer builds

### DIFF
--- a/IPlug/VST3/IPlugVST3_View.h
+++ b/IPlug/VST3/IPlugVST3_View.h
@@ -14,6 +14,9 @@
 #include "pluginterfaces/base/keycodes.h"
 
 #include "IPlugStructs.h"
+#include "IPlugLogger.h"
+
+using iplug::Trace;
 
 /** IPlug VST3 View  */
 template <class T>


### PR DESCRIPTION
## Summary
- include `IPlugLogger.h` in VST3 view implementation
- use `iplug::Trace` so `TRACE` macro resolves correctly

## Testing
- `g++ -std=c++17 -DTRACER_BUILD -I. -c IPlug/VST3/IPlugVST3.cpp` *(fails: fatal error: pluginterfaces/base/ibstream.h: No such file or directory)*
- `g++ -std=c++17 -DTRACER_BUILD -I. -x c++ -c IPlug/VST3/IPlugVST3_View.h` *(fails: fatal error: base/source/fstring.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c4a6e33e608329b0f8318e101a7976