### PR TITLE
Use instance font cache for NanoVG

### DIFF
--- a/IGraphics/Drawing/IGraphicsNanoVG.cpp
+++ b/IGraphics/Drawing/IGraphicsNanoVG.cpp
@@ -139,9 +139,6 @@ IGraphicsNanoVG::Bitmap::~Bitmap()
   }
 }
 
-// Fonts
-static StaticStorage<IFontData> sFontCache;
-
 extern std::map<std::string, MTLTexturePtr> gTextureMap;
 
 // Retrieving pixels
@@ -231,14 +228,12 @@ IGraphicsNanoVG::IGraphicsNanoVG(IGEditorDelegate& dlg, int w, int h, int fps, f
 : IGraphics(dlg, w, h, fps, scale)
 {
   DBGMSG("IGraphics NanoVG @ %i FPS\n", fps);
-  StaticStorage<IFontData>::Accessor storage(sFontCache);
-  storage.Retain();
 }
 
-IGraphicsNanoVG::~IGraphicsNanoVG() 
+IGraphicsNanoVG::~IGraphicsNanoVG()
 {
-  StaticStorage<IFontData>::Accessor storage(sFontCache);
-  storage.Release();
+  StaticStorage<IFontData>::Accessor storage(mFontCache);
+  storage.Clear();
   ClearFBOStack();
 }
 
@@ -740,7 +735,7 @@ void IGraphicsNanoVG::PathFill(const IPattern& pattern, const IFillOptions& opti
 
 bool IGraphicsNanoVG::LoadAPIFont(const char* fontID, const PlatformFontPtr& font)
 {
-  StaticStorage<IFontData>::Accessor storage(sFontCache);
+  StaticStorage<IFontData>::Accessor storage(mFontCache);
   IFontData* cached = storage.Find(fontID);
     
   if (cached)
@@ -994,6 +989,6 @@ void IGraphicsNanoVG::DrawMultiLineText(const IText& text, const char* str, cons
 
 int IGraphicsNanoVG::GetFontCacheCount() const
 {
-  StaticStorage<IFontData>::Accessor storage(sFontCache);
+  StaticStorage<IFontData>::Accessor storage(mFontCache);
   return storage.Size();
 }

--- a/IGraphics/Drawing/IGraphicsNanoVG.h
+++ b/IGraphics/Drawing/IGraphicsNanoVG.h
@@ -160,6 +160,7 @@ private:
   bool mInDraw = false;
   WDL_Mutex mFBOMutex;
   std::stack<NVGframebuffer*> mFBOStack; // A stack of FBOs that requires freeing at the end of the frame
+  mutable StaticStorage<IFontData> mFontCache;
   StaticStorage<APIBitmap> mBitmapCache; //not actually static (doesn't require retaining or releasing)
   NVGcontext* mVG = nullptr;
   NVGframebuffer* mMainFrameBuffer = nullptr;


### PR DESCRIPTION
## Summary
- add a per-instance `mFontCache` to the NanoVG backend
- remove global font cache and retain/release logic
- clear NanoVG instance font cache on destruction

## Testing
- `g++ -std=c++17 -DIGRAPHICS_NANOVG -DIGRAPHICS_GL2 -D_WIN32 -DOS_WIN -IIGraphics -I. -I./IPlug -I./WDL -IDependencies/IGraphics/NanoVG/src -c IGraphics/Drawing/IGraphicsNanoVG.cpp` *(fails: windows.h: No such file or directory)*
- `./Scripts/run_clang_format.sh` *(fails: style=file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c4b52475c88329a847747f5217d9ed