### PR TITLE
Add resource load profiling diagnostics

### DIFF
--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -1206,7 +1206,15 @@ public:
 
   /**@return \c true if live edit mode is enabled */
   bool LiveEditEnabled() const { return mLiveEdit != nullptr; }
-  
+
+#if !defined(NDEBUG) || defined(IGRAPHICS_DEBUG_RESOURCE_LOAD)
+  /** Enable or disable diagnostic timing for resource loading */
+  static void EnableResourceLoadProfiling(bool enable);
+
+  /** @return \c true if diagnostic timing for resource loading is enabled */
+  static bool IsResourceLoadProfilingEnabled();
+#endif
+
   /** Returns an IRECT that represents the entire UI bounds
    * This is useful for programatically arranging UI elements by slicing up the IRECT using the various IRECT methods
    * @return An IRECT that corresponds to the entire UI area, with, L = 0, T = 0, R = Width() and B  = Height() */


### PR DESCRIPTION
## Summary
- add high-resolution scoped timers for resource loading
- expose `EnableResourceLoadProfiling` to toggle diagnostic logging
- profile Windows font loading helpers to detect bottlenecks

## Testing
- `cmake -S . -B build` *(fails: The source directory does not appear to contain CMakeLists.txt.)*

------
https://chatgpt.com/codex/tasks/task_e_68c4c6d23224832982d188db98d0d941