### PR TITLE
Use temp folder for Windows logging

### DIFF
--- a/IPlug/IPlugLogger.h
+++ b/IPlug/IPlugLogger.h
@@ -97,7 +97,7 @@ struct LogFile
   {
 #ifdef OS_WIN
     char logFilePath[MAX_WIN32_PATH_LEN];
-    snprintf(logFilePath, MAX_WIN32_PATH_LEN, "%s/%s", "C:\\", LOGFILE);
+    snprintf(logFilePath, MAX_WIN32_PATH_LEN, "C:\\temp\\%s", LOGFILE);
 #else
     char logFilePath[MAX_MACOS_PATH_LEN];
     snprintf(logFilePath, MAX_MACOS_PATH_LEN, "%s/%s", getenv("HOME"), LOGFILE);


### PR DESCRIPTION
## Summary
- write log files to C:\temp on Windows

## Testing
- `g++ -std=c++17 -DOS_WIN -I. -IWDL /tmp/logtest.cpp` *(fails: windows.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c4c9372eb88329b166914c04ccd21d