### PR TITLE
Expose process trace limit and raise default

### DIFF
--- a/IPlug/IPlugConstants.h
+++ b/IPlug/IPlugConstants.h
@@ -38,7 +38,10 @@ using PLUG_SAMPLE_SRC = double;
 using sample = PLUG_SAMPLE_DST;
 
 #define LOGFILE "IPlugLog.txt"
-#define MAX_PROCESS_TRACE_COUNT 100
+// Allow overriding the process trace count limit at compile time for easy tuning
+#ifndef MAX_PROCESS_TRACE_COUNT
+#define MAX_PROCESS_TRACE_COUNT 100000
+#endif
 #define MAX_IDLE_TRACE_COUNT 15
 
 enum EIPlugPluginType


### PR DESCRIPTION
## Summary
- make process trace suppression threshold configurable
- raise default `MAX_PROCESS_TRACE_COUNT` to 100000 to avoid premature trace suppression

## Testing
- `clang-format -n IPlug/IPlugConstants.h` *(fails: code should be clang-formatted)*
- `g++ -fsyntax-only -std=c++17 -I. IPlug/IPlugConstants.h`


------
https://chatgpt.com/codex/tasks/task_e_68c4c93fed0c83299ccb04ff68392e3c