### PR TITLE
Log GL context and window handle on Windows initialization/destruction

### DIFF
--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -55,6 +55,14 @@
 #include <memory>
 #include <vector>
 #include <unordered_map>
+#include <cassert>
+
+#if defined(OS_WIN) && defined(IGRAPHICS_GL)
+  #ifndef NOMINMAX
+    #define NOMINMAX
+  #endif
+  #include <windows.h>
+#endif
 
 #ifdef FillRect
 #undef FillRect
@@ -978,8 +986,28 @@ public:
   {
   public:
     ScopedGLContext(IGraphics* pGraphics)
-    : mIGraphics(*pGraphics) { mIGraphics.ActivateGLContext(); }
-    ~ScopedGLContext() { mIGraphics.DeactivateGLContext(); }
+    : mIGraphics(*pGraphics)
+    {
+#if defined IGRAPHICS_GL && defined OS_WIN
+      DBGMSG("ScopedGLContext pre-activate: %p\n", wglGetCurrentContext());
+#endif
+      mIGraphics.ActivateGLContext();
+#if defined IGRAPHICS_GL && defined OS_WIN
+      HGLRC ctx = wglGetCurrentContext();
+      DBGMSG("ScopedGLContext post-activate: %p\n", ctx);
+      assert(ctx);
+#endif
+    }
+    ~ScopedGLContext()
+    {
+#if defined IGRAPHICS_GL && defined OS_WIN
+      DBGMSG("ScopedGLContext pre-deactivate: %p\n", wglGetCurrentContext());
+#endif
+      mIGraphics.DeactivateGLContext();
+#if defined IGRAPHICS_GL && defined OS_WIN
+      DBGMSG("ScopedGLContext post-deactivate: %p\n", wglGetCurrentContext());
+#endif
+    }
   private:
     IGraphics& mIGraphics;
   };

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1115,6 +1115,11 @@ void* IGraphicsWin::OpenWindow(void* pParent)
 #endif
 
   OnViewInitialized((void*)dc);
+#ifdef IGRAPHICS_SKIA
+  DBGMSG("OnViewInitialized HWND: %p GL Context: %p\n", mPlugWnd, mGrContext.get());
+#else
+  DBGMSG("OnViewInitialized HWND: %p GL Context: %p\n", mPlugWnd, nullptr);
+#endif
 
   SetScreenScale(screenScale); // resizes draw context
 
@@ -1265,6 +1270,11 @@ void IGraphicsWin::CloseWindow()
     }
 #endif
 
+    #ifdef IGRAPHICS_SKIA
+    DBGMSG("OnViewDestroyed HWND: %p GL Context: %p\n", mPlugWnd, mGrContext.get());
+    #else
+    DBGMSG("OnViewDestroyed HWND: %p GL Context: %p\n", mPlugWnd, nullptr);
+    #endif
     OnViewDestroyed();
 
 #ifdef IGRAPHICS_GL


### PR DESCRIPTION
## Summary
- Log HWND and GL context after Windows view initialization and before destruction
- Trace active GL context in `ScopedGLContext` by logging and asserting around activation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c4c8eb5a1c8329a9d86381244e1c18