### PR TITLE
Add LogFileManager using directive for VST3 view

### DIFF
--- a/IPlug/VST3/IPlugVST3_View.h
+++ b/IPlug/VST3/IPlugVST3_View.h
@@ -17,6 +17,7 @@
 #include "IPlugLogger.h"
 
 using iplug::Trace;
+using iplug::LogFileManager;
 
 /** IPlug VST3 View  */
 template <class T>


### PR DESCRIPTION
## Summary
- expose `LogFileManager` in the VST3 view so TRACE macro can resolve the logging class

## Testing
- ❌ `msbuild Examples/IPlugDrumSynth/projects/IPlugDrumSynth-vst3.vcxproj /t:Build /p:Configuration=Release` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_68c4d350cb808329968d354c31eb8c17