### PR TITLE
Add GL context lifecycle tracing

### DIFF
--- a/IGraphics/Platforms/IGraphicsMac.mm
+++ b/IGraphics/Platforms/IGraphicsMac.mm
@@ -92,8 +92,15 @@ void* IGraphicsMac::OpenWindow(void* pParent)
   CloseWindow();
   IGRAPHICS_VIEW* pView = [[IGRAPHICS_VIEW alloc] initWithIGraphics: this];
   mView = (void*) pView;
-    
+
+#ifdef IGRAPHICS_GL
+  {
+    TRACE_SCOPE_F(GetDelegate()->GetPlug()->GetLogFile(), "CreateGLContext");
+    ActivateGLContext();
+  }
+#else
   ActivateGLContext();
+#endif
   OnViewInitialized([pView layer]);
   SetScreenScale([[NSScreen mainScreen] backingScaleFactor]);
   GetDelegate()->LayoutUI(this);
@@ -133,8 +140,11 @@ void IGraphicsMac::CloseWindow()
     IGRAPHICS_VIEW* pView = (IGRAPHICS_VIEW*) mView;
       
 #ifdef IGRAPHICS_GL
-    [[pView pixelFormat] release];
-    [[pView openGLContext] release];
+    {
+      TRACE_SCOPE_F(GetDelegate()->GetPlug()->GetLogFile(), "DestroyGLContext");
+      [[pView pixelFormat] release];
+      [[pView openGLContext] release];
+    }
 #endif
       
     [pView removeAllToolTips];
@@ -724,12 +734,14 @@ EUIAppearance IGraphicsMac::GetUIAppearance() const
 
 void IGraphicsMac::ActivateGLContext()
 {
+  TRACE_SCOPE_F(GetDelegate()->GetPlug()->GetLogFile(), "ActivateGLContext");
   IGRAPHICS_VIEW* pView = (IGRAPHICS_VIEW*) mView;
   [pView activateGLContext];
 }
 
 void IGraphicsMac::DeactivateGLContext()
 {
+  TRACE_SCOPE_F(GetDelegate()->GetPlug()->GetLogFile(), "DeactivateGLContext");
   IGRAPHICS_VIEW* pView = (IGRAPHICS_VIEW*) mView;
   [pView deactivateGLContext];
 }

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -990,6 +990,7 @@ void IGraphicsWin::GetMouseLocation(float& x, float& y) const
 #ifdef IGRAPHICS_GL
 void IGraphicsWin::CreateGLContext()
 {
+  TRACE_SCOPE_F(GetDelegate()->GetPlug()->GetLogFile(), "CreateGLContext");
   PIXELFORMATDESCRIPTOR pfd = {sizeof(PIXELFORMATDESCRIPTOR),
                                1,
                                PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER, // Flags
@@ -1051,6 +1052,7 @@ void IGraphicsWin::CreateGLContext()
 
 void IGraphicsWin::DestroyGLContext()
 {
+  TRACE_SCOPE_F(GetDelegate()->GetPlug()->GetLogFile(), "DestroyGLContext");
   wglMakeCurrent(NULL, NULL);
   wglDeleteContext(mHGLRC);
 }
@@ -1059,6 +1061,7 @@ void IGraphicsWin::DestroyGLContext()
 void IGraphicsWin::ActivateGLContext()
 {
 #ifdef IGRAPHICS_GL
+  TRACE_SCOPE_F(GetDelegate()->GetPlug()->GetLogFile(), "ActivateGLContext");
   mStartHDC = wglGetCurrentDC();
   mStartHGLRC = wglGetCurrentContext();
   HDC dc = GetDC(mPlugWnd);
@@ -1069,6 +1072,7 @@ void IGraphicsWin::ActivateGLContext()
 void IGraphicsWin::DeactivateGLContext()
 {
 #ifdef IGRAPHICS_GL
+  TRACE_SCOPE_F(GetDelegate()->GetPlug()->GetLogFile(), "DeactivateGLContext");
   ReleaseDC(mPlugWnd, (HDC)GetPlatformContext());
   wglMakeCurrent(mStartHDC, mStartHGLRC); // return current ctxt to start
 #endif


### PR DESCRIPTION
## Summary
- trace GL context creation/destruction on Windows and macOS
- instrument GL context activation/deactivation on Windows and macOS

## Testing
- `g++ -std=c++17 -DTRACER_BUILD /tmp/trace_test.cpp -I. -IWDL -o /tmp/trace_test`
- `/tmp/trace_test`
- `cat /tmp/trace_test.log`


------
https://chatgpt.com/codex/tasks/task_e_68c4d7945fdc8329bb10eaabaa18c172