### PR TITLE
Add trace hooks around resource cache lookups

### DIFF
--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -2106,7 +2106,9 @@ EResourceLocation IGraphics::SearchImageResource(const char* name, const char* t
       fullName.SetFormatted((int) (strlen(name) + strlen("@2x")), "%s@%dx%s", baseName.Get(), sourceScale, ext.Get());
     }
 
+    TRACE_CACHE_QUERY_START_F(GetDelegate()->GetPlug()->GetLogFile());
     EResourceLocation found = LocateResource(fullName.Get(), type, result, GetBundleID(), GetWinModuleHandle(), GetSharedResourcesSubPath());
+    TRACE_CACHE_QUERY_END_F(GetDelegate()->GetPlug()->GetLogFile());
 
     if (found > EResourceLocation::kNotFound)
     {
@@ -2134,7 +2136,9 @@ APIBitmap* IGraphics::SearchBitmapInCache(const char* name, int targetScale, int
 
   for (sourceScale = targetScale; sourceScale > 0; SearchNextScale(sourceScale, targetScale))
   {
+    TRACE_CACHE_QUERY_START_F(GetDelegate()->GetPlug()->GetLogFile());
     APIBitmap* pBitmap = storage.Find(name, sourceScale);
+    TRACE_CACHE_QUERY_END_F(GetDelegate()->GetPlug()->GetLogFile());
 
     if (pBitmap)
     {

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -2108,12 +2108,14 @@ PlatformFontPtr IGraphicsWin::LoadPlatformFont(const char* fontID, const char* f
 {
   PROFILE_RESOURCE_LOAD(fontID);
   StaticStorage<InstalledFont>::Accessor fontStorage(sPlatformFontCache);
-
   const auto lookupStart = std::chrono::high_resolution_clock::now();
-  if (auto* pFont = fontStorage.Find(fontID))
+  TRACE_CACHE_QUERY_START_F(GetDelegate()->GetPlug()->GetLogFile());
+  auto* pFont = fontStorage.Find(fontID);
+  TRACE_CACHE_QUERY_END_F(GetDelegate()->GetPlug()->GetLogFile());
+  const auto lookupEnd = std::chrono::high_resolution_clock::now();
+  const auto lookupTime = std::chrono::duration_cast<std::chrono::microseconds>(lookupEnd - lookupStart).count();
+  if (pFont)
   {
-    const auto lookupEnd = std::chrono::high_resolution_clock::now();
-    const auto lookupTime = std::chrono::duration_cast<std::chrono::microseconds>(lookupEnd - lookupStart).count();
     Trace(GetDelegate()->GetPlug()->GetLogFile(), TRACELOC, "LoadPlatformFont: id=%s cache_hit lookup=%lldus", fontID, static_cast<long long>(lookupTime));
     pFont->Retain();
     HFONT font = GetHFont(pFont->GetFamily(), pFont->GetWeight(), pFont->GetItalic(), pFont->GetUnderline());
@@ -2128,8 +2130,6 @@ PlatformFontPtr IGraphicsWin::LoadPlatformFont(const char* fontID, const char* f
   }
   else
   {
-    const auto lookupEnd = std::chrono::high_resolution_clock::now();
-    const auto lookupTime = std::chrono::duration_cast<std::chrono::microseconds>(lookupEnd - lookupStart).count();
     Trace(GetDelegate()->GetPlug()->GetLogFile(), TRACELOC, "LoadPlatformFont: id=%s cache_miss lookup=%lldus", fontID, static_cast<long long>(lookupTime));
   }
 
@@ -2192,12 +2192,14 @@ PlatformFontPtr IGraphicsWin::LoadPlatformFont(const char* fontID, void* pData, 
 {
   PROFILE_RESOURCE_LOAD(fontID);
   StaticStorage<InstalledFont>::Accessor fontStorage(sPlatformFontCache);
-
   const auto lookupStart = std::chrono::high_resolution_clock::now();
-  if (auto* cached = fontStorage.Find(fontID))
+  TRACE_CACHE_QUERY_START_F(GetDelegate()->GetPlug()->GetLogFile());
+  auto* cached = fontStorage.Find(fontID);
+  TRACE_CACHE_QUERY_END_F(GetDelegate()->GetPlug()->GetLogFile());
+  const auto lookupEnd = std::chrono::high_resolution_clock::now();
+  const auto lookupTime = std::chrono::duration_cast<std::chrono::microseconds>(lookupEnd - lookupStart).count();
+  if (cached)
   {
-    const auto lookupEnd = std::chrono::high_resolution_clock::now();
-    const auto lookupTime = std::chrono::duration_cast<std::chrono::microseconds>(lookupEnd - lookupStart).count();
     Trace(GetDelegate()->GetPlug()->GetLogFile(), TRACELOC, "LoadPlatformFont: id=%s cache_hit lookup=%lldus", fontID, static_cast<long long>(lookupTime));
     cached->Retain();
     HFONT font = GetHFont(cached->GetFamily(), cached->GetWeight(), cached->GetItalic(), cached->GetUnderline());
@@ -2212,8 +2214,6 @@ PlatformFontPtr IGraphicsWin::LoadPlatformFont(const char* fontID, void* pData, 
   }
   else
   {
-    const auto lookupEnd = std::chrono::high_resolution_clock::now();
-    const auto lookupTime = std::chrono::duration_cast<std::chrono::microseconds>(lookupEnd - lookupStart).count();
     Trace(GetDelegate()->GetPlug()->GetLogFile(), TRACELOC, "LoadPlatformFont: id=%s cache_miss lookup=%lldus", fontID, static_cast<long long>(lookupTime));
   }
 


### PR DESCRIPTION
## Summary
- add cache query trace markers to Windows font loader
- instrument image and bitmap search functions with cache query traces

## Testing
- `g++ -std=c++17 -DIGRAPHICS_NANOVG -I . -I IPlug -I IPlug/Extras -I WDL -I IGraphics -I IGraphics/Controls -I Dependencies/IGraphics/NanoSVG/src -I Dependencies/IGraphics/NanoVG/src -I Dependencies/IGraphics/STB -c IGraphics/IGraphics.cpp` *(fails: NOT IMPLEMENTED)*
- `g++ -std=c++17 -I . -I IPlug -I WDL -c IGraphics/Platforms/IGraphicsWin.cpp` *(fails: Shlobj.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c4dc8bf4c88329be0766dcf9a6d443