### PR TITLE
Log control attachment scope

### DIFF
--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -372,6 +372,8 @@ void IGraphics::AttachPanelBackground(const IPattern& color)
 
 IControl* IGraphics::AttachControl(IControl* pControl, int ctrlTag, const char* group, int zIndex)
 {
+  TRACE_SCOPE_F(GetDelegate()->GetPlug()->GetLogFile(), "AttachControl");
+  Trace(GetDelegate()->GetPlug()->GetLogFile(), TRACELOC, "ctrlTag=%d group=%s", ctrlTag, group ? group : "");
   if (ctrlTag > kNoTag)
   {
     auto result = mCtrlTags.insert(std::make_pair(ctrlTag, pControl));


### PR DESCRIPTION
## Summary
- profile control attachments with `TRACE_SCOPE_F`
- add control tag and group to trace logs for comparisons

## Testing
- `CC=emcc make -f IGraphicsTest-wam-processor.mk` *(fails: ../../../Dependencies/IPlug/WAM_SDK/wamsdk/processor.cpp: No such file or directory)*
- `g++ -std=c++17 -DTRACER_BUILD -DWEB_API -DIGRAPHICS_NANOVG ... IGraphics/IGraphics.cpp -o /tmp/IGraphics.o` *(fails: IPlug/IPlugTimer.h:107:4: error: #error NOT IMPLEMENTED)*

------
https://chatgpt.com/codex/tasks/task_e_68c4de3e2bcc83299d80e528cd4b2023