### PR TITLE
Add window creation tracing

### DIFF
--- a/IGraphics/Platforms/IGraphicsMac.mm
+++ b/IGraphics/Platforms/IGraphicsMac.mm
@@ -88,6 +88,7 @@ float IGraphicsMac::MeasureText(const IText& text, const char* str, IRECT& bound
 
 void* IGraphicsMac::OpenWindow(void* pParent)
 {
+  TRACE_WINDOW_CREATION_START_F(GetDelegate()->GetPlug()->GetLogFile());
   TRACEF(GetDelegate()->GetPlug()->GetLogFile());
   CloseWindow();
   IGRAPHICS_VIEW* pView = [[IGRAPHICS_VIEW alloc] initWithIGraphics: this];
@@ -106,11 +107,13 @@ void* IGraphicsMac::OpenWindow(void* pParent)
   GetDelegate()->LayoutUI(this);
   UpdateTooltips();
   GetDelegate()->OnUIOpen();
-  
+
   if (pParent)
   {
     [(NSView*) pParent addSubview: pView];
   }
+
+  TRACE_WINDOW_CREATION_END_F(GetDelegate()->GetPlug()->GetLogFile());
 
   return mView;
 }

--- a/IGraphics/Platforms/IGraphicsWeb.cpp
+++ b/IGraphics/Platforms/IGraphicsWeb.cpp
@@ -440,6 +440,7 @@ IGraphicsWeb::~IGraphicsWeb()
 
 void* IGraphicsWeb::OpenWindow(void* pHandle)
 {
+  TRACE_WINDOW_CREATION_START_F(GetDelegate()->GetPlug()->GetLogFile());
 #ifdef IGRAPHICS_GL
   EmscriptenWebGLContextAttributes attr;
   emscripten_webgl_init_context_attributes(&attr);
@@ -457,7 +458,8 @@ void* IGraphicsWeb::OpenWindow(void* pHandle)
 
   GetDelegate()->LayoutUI(this);
   GetDelegate()->OnUIOpen();
-  
+  TRACE_WINDOW_CREATION_END_F(GetDelegate()->GetPlug()->GetLogFile());
+
   return nullptr;
 }
 

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1092,6 +1092,7 @@ EMsgBoxResult IGraphicsWin::ShowMessageBox(const char* str, const char* title, E
 
 void* IGraphicsWin::OpenWindow(void* pParent)
 {
+  TRACE_WINDOW_CREATION_START_F(GetDelegate()->GetPlug()->GetLogFile());
   mParentWnd = (HWND)pParent;
   int screenScale = GetScaleForHWND(mParentWnd);
   int x = 0, y = 0, w = WindowWidth() * screenScale, h = WindowHeight() * screenScale;
@@ -1200,6 +1201,7 @@ void* IGraphicsWin::OpenWindow(void* pParent)
   }
 
   GetDelegate()->OnUIOpen();
+  TRACE_WINDOW_CREATION_END_F(GetDelegate()->GetPlug()->GetLogFile());
 
   return mPlugWnd;
 }


### PR DESCRIPTION
## Summary
- trace window creation start/end in Windows platform
- trace window creation start/end in macOS platform
- trace window creation start/end in Web platform

## Testing
- `x86_64-w64-mingw32-g++ -std=c++17 -I. -I./WDL -I./IGraphics -I./IGraphics/Drawing -I./IPlug -I./Dependencies/IGraphics/NanoSVG/src -I./Dependencies/IGraphics/NanoVG -I./Dependencies/IGraphics/NanoVG/src -DIGRAPHICS_NANOVG -DIMGUI_DISABLE_OBSOLETE_FUNCTIONS -DUNICODE -DWIN32 -D_WINDOWS -D_UNICODE -c IGraphics/Platforms/IGraphicsWin.cpp -o /tmp/IGraphicsWin.o` (fails: you must define either IGRAPHICS_GL2, IGRAPHICS_GLES2 etc or IGRAPHICS_METAL when using IGRAPHICS_NANOVG)
- `clang++ -ObjC++ -std=c++17 -I. -I./WDL -I./IGraphics -I./IGraphics/Drawing -I./IPlug -c IGraphics/Platforms/IGraphicsMac.mm -o /tmp/IGraphicsMac.o` (fails: 'CoreGraphics/CoreGraphics.h' file not found)
- `em++ -std=c++17 -I. -I./WDL -I./IGraphics -I./IGraphics/Drawing -I./IPlug -c IGraphics/Platforms/IGraphicsWeb.cpp -o /tmp/IGraphicsWeb.o` (fails: NO IGRAPHICS_MODE defined)


------
https://chatgpt.com/codex/tasks/task_e_68c4df882ecc83299407af8afda104bb