### PR TITLE
Include logger in graphics sources using tracing macros

### DIFF
--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -10,6 +10,8 @@
 
 #include "IGraphics.h"
 
+#include "IPlugLogger.h"
+
 #include <chrono>
 #if !defined(NDEBUG) || defined(IGRAPHICS_DEBUG_RESOURCE_LOAD)
 #include <atomic>

--- a/IGraphics/Platforms/IGraphicsMac.mm
+++ b/IGraphics/Platforms/IGraphicsMac.mm
@@ -9,6 +9,7 @@
 */
 
 #include "IGraphicsMac.h"
+#include "IPlugLogger.h"
 #import "IGraphicsMac_view.h"
 
 #include "IControl.h"

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -24,6 +24,8 @@
 #include "IPlugPaths.h"
 #include "IPopupMenuControl.h"
 
+#include "IPlugLogger.h"
+
 #include <VersionHelpers.h>
 #include <wininet.h>
 


### PR DESCRIPTION
## Summary
- include `IPlugLogger.h` in graphics sources that emit tracing events

## Testing
- `g++ -std=c++17 -DIGRAPHICS_NANOVG -DIGRAPHICS_GL2 -DOS_LINUX -c IGraphics/IGraphics.cpp -I. -IIGraphics -IIGraphics/Controls -IIGraphics/Platforms -I IPlug -I IPlug/Extras -I WDL -I Dependencies/IGraphics/NanoSVG/src -I Dependencies/IGraphics/NanoVG/src -I Dependencies/IGraphics/STB` *(fails: `IPlug/IPlugTimer.h:107:4: error: #error NOT IMPLEMENTED`)*
- `g++ -std=c++17 -c /tmp/test_trace.cpp -I. -I IPlug -I WDL`

------
https://chatgpt.com/codex/tasks/task_e_68c4e2aebd048329ad01891cd43fbe29