### PR TITLE
Refactor tracing macros to TRACEF and add logger includes

### DIFF
--- a/Examples/IPlugDrumSynth/IPlugDrumSynth.cpp
+++ b/Examples/IPlugDrumSynth/IPlugDrumSynth.cpp
@@ -1,5 +1,6 @@
 #include "IPlugDrumSynth.h"
 #include "IPlug_include_in_plug_src.h"
+#include "IPlugLogger.h"
 
 #if IPLUG_EDITOR
 #include "IControls.h"
@@ -149,7 +150,7 @@ void IPlugDrumSynth::OnReset()
 
 void IPlugDrumSynth::ProcessMidiMsg(const IMidiMsg& msg)
 {
-  TRACE_F(GetLogFile());
+  TRACEF(GetLogFile());
   
   int status = msg.StatusMsg();
   

--- a/Examples/IPlugInstrument/IPlugInstrument.cpp
+++ b/Examples/IPlugInstrument/IPlugInstrument.cpp
@@ -1,6 +1,7 @@
 #include "IPlugInstrument.h"
 #include "IPlug_include_in_plug_src.h"
 #include "LFO.h"
+#include "IPlugLogger.h"
 
 IPlugInstrument::IPlugInstrument(const InstanceInfo& info)
 : iplug::Plugin(info, MakeConfig(kNumParams, kNumPresets))
@@ -107,7 +108,7 @@ void IPlugInstrument::OnReset()
 
 void IPlugInstrument::ProcessMidiMsg(const IMidiMsg& msg)
 {
-  TRACE_F(GetLogFile());
+  TRACEF(GetLogFile());
   
   int status = msg.StatusMsg();
   

--- a/Examples/IPlugMidiEffect/IPlugMidiEffect.cpp
+++ b/Examples/IPlugMidiEffect/IPlugMidiEffect.cpp
@@ -1,6 +1,7 @@
 #include "IPlugMidiEffect.h"
 #include "IPlug_include_in_plug_src.h"
 #include "IControls.h"
+#include "IPlugLogger.h"
 
 IPlugMidiEffect::IPlugMidiEffect(const InstanceInfo& info)
 : Plugin(info, MakeConfig(kNumParams, kNumPresets))
@@ -59,7 +60,7 @@ void IPlugMidiEffect::ProcessBlock(sample** inputs, sample** outputs, int nFrame
 
 void IPlugMidiEffect::ProcessMidiMsg(const IMidiMsg& msg)
 {
-  TRACE_F(GetLogFile());
+  TRACEF(GetLogFile());
   
   int status = msg.StatusMsg();
   

--- a/Examples/IPlugResponsiveUI/IPlugResponsiveUI.cpp
+++ b/Examples/IPlugResponsiveUI/IPlugResponsiveUI.cpp
@@ -2,6 +2,7 @@
 #include "IPlug_include_in_plug_src.h"
 #include "IControls.h"
 #include "Test/TestSizeControl.h"
+#include "IPlugLogger.h"
 
 IPlugResponsiveUI::IPlugResponsiveUI(const InstanceInfo& info)
 : Plugin(info, MakeConfig(kNumParams, kNumPresets))
@@ -87,7 +88,7 @@ void IPlugResponsiveUI::ProcessBlock(sample** inputs, sample** outputs, int nFra
 
 void IPlugResponsiveUI::ProcessMidiMsg(const IMidiMsg& msg)
 {
-  TRACE_F(GetLogFile());
+  TRACEF(GetLogFile());
   
   int status = msg.StatusMsg();
   

--- a/Examples/IPlugWebUI/IPlugWebUI.cpp
+++ b/Examples/IPlugWebUI/IPlugWebUI.cpp
@@ -1,6 +1,7 @@
 #include "IPlugWebUI.h"
 #include "IPlug_include_in_plug_src.h"
 #include "IPlugPaths.h"
+#include "IPlugLogger.h"
 
 IPlugWebUI::IPlugWebUI(const InstanceInfo& info)
 : Plugin(info, MakeConfig(kNumParams, kNumPresets))
@@ -67,7 +68,7 @@ void IPlugWebUI::OnParamChange(int paramIdx)
 
 void IPlugWebUI::ProcessMidiMsg(const IMidiMsg& msg)
 {
-  TRACE_F(GetLogFile());
+  TRACEF(GetLogFile());
   
   msg.PrintMsg();
   SendMidiMsg(msg);

--- a/IGraphics/Platforms/IGraphicsIOS.mm
+++ b/IGraphics/Platforms/IGraphicsIOS.mm
@@ -15,6 +15,7 @@
 #include "IGraphicsCoreText.h"
 #include "IGraphicsIOS.h"
 #include "IPlugPluginBase.h"
+#include "IPlugLogger.h"
 
 #import "IGraphicsIOS_view.h"
 

--- a/IGraphics/Platforms/IGraphicsIOS_view.mm
+++ b/IGraphics/Platforms/IGraphicsIOS_view.mm
@@ -22,6 +22,7 @@
 #include "IGraphicsCoreText.h"
 #include "IPlugParameter.h"
 #include "IPlugPluginBase.h"
+#include "IPlugLogger.h"
 
 extern StaticStorage<CoreTextFontDescriptor> sFontDescriptorCache;
 

--- a/IPlug/AAX/IPlugAAX.cpp
+++ b/IPlug/AAX/IPlugAAX.cpp
@@ -19,6 +19,7 @@
 #include "AAX_CNumberDisplayDelegate.h"
 #include "AAX_CUnitDisplayDelegateDecorator.h"
 #include "IPlugAAX_TaperDelegate.h"
+#include "IPlugLogger.h"
 
 using namespace iplug;
 
@@ -26,13 +27,13 @@ AAX_CEffectParameters* AAX_CALLBACK IPlugAAX::Create() { return MakePlug(Instanc
 
 void AAX_CEffectGUI_IPLUG::CreateViewContents()
 {
-  TRACE_F(GetLogFile());
+  TRACEF(GetLogFile());
   mPlug = dynamic_cast<IPlugAAX*>(GetEffectParameters());
 }
 
 void AAX_CEffectGUI_IPLUG::CreateViewContainer()
 {
-  TRACE_F(GetLogFile());
+  TRACEF(GetLogFile());
 
   void* pWindow = GetViewContainerPtr();
 
@@ -106,7 +107,7 @@ IPlugAAX::~IPlugAAX() { mParamIDs.Empty(true); }
 
 AAX_Result IPlugAAX::EffectInit()
 {
-  TRACE_F(GetLogFile());
+  TRACEF(GetLogFile());
 
   if (GetHost() == kHostUninit)
     SetHost("ProTools", 0); // TODO:vendor version correct?
@@ -186,7 +187,7 @@ AAX_Result IPlugAAX::EffectInit()
 
 AAX_Result IPlugAAX::UpdateParameterNormalizedValue(AAX_CParamID paramID, double iValue, AAX_EUpdateSource iSource)
 {
-  TRACE_F(GetLogFile());
+  TRACEF(GetLogFile());
 
   AAX_Result result = AAX_SUCCESS;
 
@@ -219,7 +220,7 @@ AAX_Result IPlugAAX::UpdateParameterNormalizedValue(AAX_CParamID paramID, double
 
 void IPlugAAX::RenderAudio(AAX_SIPlugRenderInfo* pRenderInfo, const TParamValPair* inSynchronizedParamValues[], int32_t inNumSynchronizedParamValues)
 {
-  TRACE_F(GetLogFile());
+  TRACEF(GetLogFile());
 
   // Get bypass parameter value
   bool bypass;
@@ -411,7 +412,7 @@ AAX_Result IPlugAAX::GetChunkIDFromIndex(int32_t index, AAX_CTypeID* pChunkID) c
 
 AAX_Result IPlugAAX::GetChunkSize(AAX_CTypeID chunkID, uint32_t* pSize) const
 {
-  TRACE_F(GetLogFile());
+  TRACEF(GetLogFile());
 
   if (chunkID == GetUniqueID())
   {
@@ -435,7 +436,7 @@ AAX_Result IPlugAAX::GetChunkSize(AAX_CTypeID chunkID, uint32_t* pSize) const
 
 AAX_Result IPlugAAX::GetChunk(AAX_CTypeID chunkID, AAX_SPlugInChunk* pChunk) const
 {
-  TRACE_F(GetLogFile());
+  TRACEF(GetLogFile());
 
   if (chunkID == GetUniqueID())
   {
@@ -456,7 +457,7 @@ AAX_Result IPlugAAX::GetChunk(AAX_CTypeID chunkID, AAX_SPlugInChunk* pChunk) con
 
 AAX_Result IPlugAAX::SetChunk(AAX_CTypeID chunkID, const AAX_SPlugInChunk* pChunk)
 {
-  TRACE_F(GetLogFile());
+  TRACEF(GetLogFile());
   // TODO: UI thread only?
 
   if (chunkID == GetUniqueID())
@@ -481,7 +482,7 @@ AAX_Result IPlugAAX::SetChunk(AAX_CTypeID chunkID, const AAX_SPlugInChunk* pChun
 
 AAX_Result IPlugAAX::CompareActiveChunk(const AAX_SPlugInChunk* pChunk, AAX_CBoolean* pIsEqual) const
 {
-  TRACE_F(GetLogFile());
+  TRACEF(GetLogFile());
 
   if (pChunk->fChunkID != GetUniqueID())
   {
@@ -526,19 +527,19 @@ AAX_Result IPlugAAX::NotificationReceived(AAX_CTypeID type, const void* pData, u
 
 void IPlugAAX::BeginInformHostOfParamChange(int idx)
 {
-  TRACE_F(GetLogFile());
+  TRACEF(GetLogFile());
   TouchParameter(mParamIDs.Get(idx)->Get());
 }
 
 void IPlugAAX::InformHostOfParamChange(int idx, double normalizedValue)
 {
-  TRACE_F(GetLogFile());
+  TRACEF(GetLogFile());
   SetParameterNormalizedValue(mParamIDs.Get(idx)->Get(), normalizedValue);
 }
 
 void IPlugAAX::EndInformHostOfParamChange(int idx)
 {
-  TRACE_F(GetLogFile());
+  TRACEF(GetLogFile());
   ReleaseParameter(mParamIDs.Get(idx)->Get());
 }
 

--- a/IPlug/AUv2/IPlugAU.cpp
+++ b/IPlug/AUv2/IPlugAU.cpp
@@ -16,6 +16,7 @@
 #include "IPlugAU.h"
 #include "IPlugAU_ioconfig.h"
 #include "dfx-au-utilities.h"
+#include "IPlugLogger.h"
 
 using namespace iplug;
 
@@ -1396,7 +1397,7 @@ bool IPlugAU::CheckLegalIO()
 
 void IPlugAU::AssessInputConnections()
 {
-  TRACE_F(GetLogFile());
+  TRACEF(GetLogFile());
   SetChannelConnections(ERoute::kInput, 0, MaxNChannels(ERoute::kInput), false);
 
   int nIn = mInBuses.GetSize();
@@ -1472,7 +1473,7 @@ OSStatus IPlugAU::GetState(CFPropertyListRef* ppPropList)
   }
 
   *ppPropList = pDict;
-  TRACE_F(GetLogFile());
+  TRACEF(GetLogFile());
   return noErr;
 }
 
@@ -1585,7 +1586,7 @@ OSStatus IPlugAU::SetParamProc(void* pPlug, AudioUnitParameterID paramID, AudioU
 static inline OSStatus RenderCallback(
   AURenderCallbackStruct* pCB, AudioUnitRenderActionFlags* pFlags, const AudioTimeStamp* pTimestamp, UInt32 inputBusIdx, UInt32 nFrames, AudioBufferList* pOutBufList)
 {
-  TRACE_F(((IPlugAU*)pCB->inputProcRefCon)->GetLogFile());
+  TRACEF(((IPlugAU*)pCB->inputProcRefCon)->GetLogFile());
   return pCB->inputProc(pCB->inputProcRefCon, pFlags, pTimestamp, inputBusIdx, nFrames, pOutBufList);
 }
 
@@ -1978,7 +1979,7 @@ void IPlugAU::PreProcess()
 
 void IPlugAU::ResizeScratchBuffers()
 {
-  TRACE_F(GetLogFile());
+  TRACEF(GetLogFile());
   int NInputs = MaxNChannels(ERoute::kInput) * GetBlockSize();
   int NOutputs = MaxNChannels(ERoute::kOutput) * GetBlockSize();
   mInScratchBuf.Resize(NInputs);
@@ -1989,7 +1990,7 @@ void IPlugAU::ResizeScratchBuffers()
 
 void IPlugAU::InformListeners(AudioUnitPropertyID propID, AudioUnitScope scope)
 {
-  TRACE_F(GetLogFile());
+  TRACEF(GetLogFile());
   int i, n = mPropertyListeners.GetSize();
 
   for (i = 0; i < n; ++i)
@@ -2005,7 +2006,7 @@ void IPlugAU::InformListeners(AudioUnitPropertyID propID, AudioUnitScope scope)
 
 void IPlugAU::SetLatency(int samples)
 {
-  TRACE_F(GetLogFile());
+  TRACEF(GetLogFile());
   InformListeners(kAudioUnitProperty_Latency, kAudioUnitScope_Global);
   IPlugProcessor::SetLatency(samples);
 }

--- a/IPlug/AUv3/IPlugAUAudioUnit.mm
+++ b/IPlug/AUv3/IPlugAUAudioUnit.mm
@@ -15,6 +15,7 @@
 #import "IPlugAUAudioUnit.h"
 #include "IPlugAUv3.h"
 #include "AUv2/IPlugAU_ioconfig.h"
+#include "IPlugLogger.h"
 
 #if !__has_feature(objc_arc)
 #error This file must be compiled with Arc. Use -fobjc-arc flag
@@ -774,7 +775,7 @@ static AUAudioUnitPreset* NewAUPreset(NSInteger number, NSString* pName)
 
 - (NSIndexSet*) supportedViewConfigurations:(NSArray<AUAudioUnitViewConfiguration*>*) availableViewConfigurations API_AVAILABLE(macos(10.13), ios(11))
 {
-  TRACE_F(mPlug->GetLogFile());
+  TRACEF(mPlug->GetLogFile());
 
   NSMutableIndexSet* pSet = [[NSMutableIndexSet alloc] init];
   
@@ -791,7 +792,7 @@ static AUAudioUnitPreset* NewAUPreset(NSInteger number, NSString* pName)
 
 - (void) selectViewConfiguration:(AUAudioUnitViewConfiguration*) viewConfiguration API_AVAILABLE(macos(10.13), ios(11))
 {
-  TRACE_F(mPlug->GetLogFile());
+  TRACEF(mPlug->GetLogFile());
   dispatch_async(dispatch_get_main_queue(), ^{
     self->mPlug->OnHostSelectedViewConfiguration((int) [viewConfiguration width], (int) [viewConfiguration height]);
   });

--- a/IPlug/CLAP/IPlugCLAP.cpp
+++ b/IPlug/CLAP/IPlugCLAP.cpp
@@ -13,6 +13,7 @@
 
 #include "IPlugCLAP.h"
 #include "IPlugPluginBase.h"
+#include "IPlugLogger.h"
 #include "host-proxy.hxx"
 #include "plugin.hxx"
 
@@ -907,7 +908,7 @@ bool IPlugCLAP::guiSetScale(double scale) noexcept
 
 bool IPlugCLAP::guiGetSize(uint32_t* pWidth, uint32_t* pHeight) noexcept
 {
-  TRACE_F(GetLogFile());
+  TRACEF(GetLogFile());
 
   if (HasUI())
   {

--- a/IPlug/IPlugAPIBase.cpp
+++ b/IPlug/IPlugAPIBase.cpp
@@ -19,6 +19,7 @@
 #include <ctime>
 
 #include "IPlugAPIBase.h"
+#include "IPlugLogger.h"
 
 using namespace iplug;
 

--- a/IPlug/IPlugPluginBase.cpp
+++ b/IPlug/IPlugPluginBase.cpp
@@ -16,6 +16,7 @@
 #include "IPlugPluginBase.h"
 #include "wdl_base64.h"
 #include "wdlendian.h"
+#include "IPlugLogger.h"
 
 using namespace iplug;
 

--- a/IPlug/VST2/IPlugVST2.cpp
+++ b/IPlug/VST2/IPlugVST2.cpp
@@ -10,6 +10,7 @@
 
 #include "IPlugVST2.h"
 #include "IPlugPluginBase.h"
+#include "IPlugLogger.h"
 #include <cstdio>
 
 using namespace iplug;
@@ -995,7 +996,7 @@ void IPlugVST2::VSTPreProcess(SAMPLETYPE** inputs, SAMPLETYPE** outputs, VstInt3
 // Deprecated.
 void VSTCALLBACK IPlugVST2::VSTProcess(AEffect* pEffect, float** inputs, float** outputs, VstInt32 nFrames)
 {
-  TRACE_F(_this->GetLogFile());
+  TRACEF(_this->GetLogFile());
   IPlugVST2* _this = (IPlugVST2*)pEffect->object;
   _this->VSTPreProcess(inputs, outputs, nFrames);
   ENTER_PARAMS_MUTEX_STATIC
@@ -1006,7 +1007,7 @@ void VSTCALLBACK IPlugVST2::VSTProcess(AEffect* pEffect, float** inputs, float**
 
 void VSTCALLBACK IPlugVST2::VSTProcessReplacing(AEffect* pEffect, float** inputs, float** outputs, VstInt32 nFrames)
 {
-  TRACE_F(_this->GetLogFile());
+  TRACEF(_this->GetLogFile());
   IPlugVST2* _this = (IPlugVST2*)pEffect->object;
   _this->VSTPreProcess(inputs, outputs, nFrames);
   ENTER_PARAMS_MUTEX_STATIC
@@ -1017,7 +1018,7 @@ void VSTCALLBACK IPlugVST2::VSTProcessReplacing(AEffect* pEffect, float** inputs
 
 void VSTCALLBACK IPlugVST2::VSTProcessDoubleReplacing(AEffect* pEffect, double** inputs, double** outputs, VstInt32 nFrames)
 {
-  TRACE_F(_this->GetLogFile());
+  TRACEF(_this->GetLogFile());
   IPlugVST2* _this = (IPlugVST2*)pEffect->object;
   _this->VSTPreProcess(inputs, outputs, nFrames);
   ENTER_PARAMS_MUTEX_STATIC

--- a/IPlug/VST3/IPlugVST3.cpp
+++ b/IPlug/VST3/IPlugVST3.cpp
@@ -17,6 +17,7 @@
 #include "pluginterfaces/vst/ivstparameterchanges.h"
 
 #include "IPlugVST3.h"
+#include "IPlugLogger.h"
 
 using namespace iplug;
 using namespace Steinberg;
@@ -43,7 +44,7 @@ Steinberg::uint32 PLUGIN_API IPlugVST3::getTailSamples() { return GetTailIsInfin
 
 tresult PLUGIN_API IPlugVST3::initialize(FUnknown* context)
 {
-  TRACE_F(GetLogFile());
+  TRACEF(GetLogFile());
 
   if (SingleComponentEffect::initialize(context) == kResultOk)
   {
@@ -62,21 +63,21 @@ tresult PLUGIN_API IPlugVST3::initialize(FUnknown* context)
 
 tresult PLUGIN_API IPlugVST3::terminate()
 {
-  TRACE_F(GetLogFile());
+  TRACEF(GetLogFile());
 
   return SingleComponentEffect::terminate();
 }
 
 tresult PLUGIN_API IPlugVST3::setBusArrangements(SpeakerArrangement* pInputBusArrangements, int32 numInBuses, SpeakerArrangement* pOutputBusArrangements, int32 numOutBuses)
 {
-  TRACE_F(GetLogFile());
+  TRACEF(GetLogFile());
 
   return IPlugVST3ProcessorBase::SetBusArrangements(this, pInputBusArrangements, numInBuses, pOutputBusArrangements, numOutBuses) ? kResultTrue : kResultFalse;
 }
 
 tresult PLUGIN_API IPlugVST3::setActive(TBool state)
 {
-  TRACE_F(GetLogFile());
+  TRACEF(GetLogFile());
 
   OnActivate((bool)state);
   return SingleComponentEffect::setActive(state);
@@ -84,7 +85,7 @@ tresult PLUGIN_API IPlugVST3::setActive(TBool state)
 
 tresult PLUGIN_API IPlugVST3::setupProcessing(ProcessSetup& newSetup)
 {
-  TRACE_F(GetLogFile());
+  TRACEF(GetLogFile());
 
   return SetupProcessing(newSetup, processSetup) ? kResultOk : kResultFalse;
 }
@@ -98,7 +99,7 @@ tresult PLUGIN_API IPlugVST3::setProcessing(TBool state)
 
 tresult PLUGIN_API IPlugVST3::process(ProcessData& data)
 {
-  TRACE_F(GetLogFile());
+  TRACEF(GetLogFile());
 
   Process(data, processSetup, audioInputs, audioOutputs, mMidiMsgsFromEditor, mMidiMsgsFromProcessor, mSysExDataFromEditor, mSysexBuf);
   return kResultOk;
@@ -108,14 +109,14 @@ tresult PLUGIN_API IPlugVST3::canProcessSampleSize(int32 symbolicSampleSize) { r
 
 tresult PLUGIN_API IPlugVST3::setState(IBStream* pState)
 {
-  TRACE_F(GetLogFile());
+  TRACEF(GetLogFile());
 
   return IPlugVST3State::SetState(this, pState) ? kResultOk : kResultFalse;
 }
 
 tresult PLUGIN_API IPlugVST3::getState(IBStream* pState)
 {
-  TRACE_F(GetLogFile());
+  TRACEF(GetLogFile());
 
   return IPlugVST3State::GetState(this, pState) ? kResultOk : kResultFalse;
 }

--- a/IPlug/VST3/IPlugVST3_Common.h
+++ b/IPlug/VST3/IPlugVST3_Common.h
@@ -15,6 +15,7 @@
 #include "IPlugAPIBase.h"
 #include "IPlugVST3_Parameter.h"
 #include "IPlugVST3_ControllerBase.h"
+#include "IPlugLogger.h"
 
 BEGIN_IPLUG_NAMESPACE
 
@@ -49,7 +50,7 @@ struct IPlugVST3State
   template <class T>
   static bool SetState(T* pPlug, Steinberg::IBStream* pState)
   {
-    TRACE_F(pPlug->GetLogFile());
+    TRACEF(pPlug->GetLogFile());
     
     IByteChunk chunk;
     

--- a/IPlug/VST3/IPlugVST3_Processor.cpp
+++ b/IPlug/VST3/IPlugVST3_Processor.cpp
@@ -9,6 +9,7 @@
 */
 
 #include "IPlugVST3_Processor.h"
+#include "IPlugLogger.h"
 
 #pragma mark - IPlugVST3Processor Constructor/Destructor
 
@@ -32,7 +33,7 @@ uint32 PLUGIN_API IPlugVST3Processor::getTailSamples() { return GetTailIsInfinit
 
 tresult PLUGIN_API IPlugVST3Processor::initialize(FUnknown* context)
 {
-  TRACE_F(GetLogFile());
+  TRACEF(GetLogFile());
 
   if (AudioEffect::initialize(context) == kResultOk)
   {
@@ -51,14 +52,14 @@ tresult PLUGIN_API IPlugVST3Processor::terminate() { return AudioEffect::termina
 
 tresult PLUGIN_API IPlugVST3Processor::setBusArrangements(SpeakerArrangement* pInputBusArrangements, int32 numInBuses, SpeakerArrangement* pOutputBusArrangements, int32 numOutBuses)
 {
-  TRACE_F(GetLogFile());
+  TRACEF(GetLogFile());
 
   return SetBusArrangements(this, pInputBusArrangements, numInBuses, pOutputBusArrangements, numOutBuses) ? kResultTrue : kResultFalse;
 }
 
 tresult PLUGIN_API IPlugVST3Processor::setActive(TBool state)
 {
-  TRACE_F(GetLogFile());
+  TRACEF(GetLogFile());
 
   OnActivate((bool)state);
   return AudioEffect::setActive(state);
@@ -66,7 +67,7 @@ tresult PLUGIN_API IPlugVST3Processor::setActive(TBool state)
 
 tresult PLUGIN_API IPlugVST3Processor::setupProcessing(ProcessSetup& newSetup)
 {
-  TRACE_F(GetLogFile());
+  TRACEF(GetLogFile());
 
   return SetupProcessing(newSetup, processSetup) ? kResultOk : kResultFalse;
 }
@@ -80,7 +81,7 @@ tresult PLUGIN_API IPlugVST3Processor::setProcessing(TBool state)
 
 tresult PLUGIN_API IPlugVST3Processor::process(ProcessData& data)
 {
-  TRACE_F(GetLogFile());
+  TRACEF(GetLogFile());
 
   Process(data, processSetup, audioInputs, audioOutputs, mMidiMsgsFromEditor, mMidiMsgsFromProcessor, mSysExDataFromEditor, mSysexBuf);
   return kResultOk;
@@ -90,14 +91,14 @@ tresult PLUGIN_API IPlugVST3Processor::canProcessSampleSize(int32 symbolicSample
 
 tresult PLUGIN_API IPlugVST3Processor::setState(IBStream* pState)
 {
-  TRACE_F(GetLogFile());
+  TRACEF(GetLogFile());
 
   return IPlugVST3State::SetState(this, pState) ? kResultOk : kResultFalse;
 }
 
 tresult PLUGIN_API IPlugVST3Processor::getState(IBStream* pState)
 {
-  TRACE_F(GetLogFile());
+  TRACEF(GetLogFile());
 
   return IPlugVST3State::GetState(this, pState) ? kResultOk : kResultFalse;
 }

--- a/IPlug/VST3/IPlugVST3_View.h
+++ b/IPlug/VST3/IPlugVST3_View.h
@@ -58,7 +58,7 @@ public:
     
   Steinberg::tresult PLUGIN_API onSize(Steinberg::ViewRect* pSize) override
   {
-    TRACE_F(mOwner.GetLogFile());
+    TRACEF(mOwner.GetLogFile());
     
     if (pSize && mOwner.GetHostResizeEnabled())
     {
@@ -72,7 +72,7 @@ public:
   
   Steinberg::tresult PLUGIN_API getSize(Steinberg::ViewRect* pSize) override
   {
-    TRACE_F(mOwner.GetLogFile());
+    TRACEF(mOwner.GetLogFile());
     
     if (mOwner.HasUI())
     {
@@ -338,7 +338,7 @@ public:
 
   void Resize(int w, int h)
   {
-    TRACE_F(mOwner.GetLogFile());
+    TRACEF(mOwner.GetLogFile());
     
     Steinberg::ViewRect newSize = Steinberg::ViewRect(0, 0, w, h);
     plugFrame->resizeView(this, &newSize);


### PR DESCRIPTION
## Summary
- replace deprecated `TRACE_F` with `TRACEF`
- include `IPlugLogger.h` wherever TRACEF is used

## Testing
- `g++ -std=c++17 -DVST3_API -DIPLUG_DSP=1 -DIPLUG_EDITOR=0 -DOS_LINUX -IExamples/IPlugMidiEffect -I. -I./IPlug -I./IGraphics -I./WDL -I./IPlug/VST3 -IDependencies/IPlug/VST3_SDK -c Examples/IPlugMidiEffect/IPlugMidiEffect.cpp -o /tmp/test.o` *(fails: public.sdk/source/vst/vstsinglecomponenteffect.h: No such file or directory)*
- `g++ -std=c++17 -DOS_LINUX -I. -I./IPlug -I./WDL -c /tmp/test_trace.cpp -o /tmp/test_trace.o`

------
https://chatgpt.com/codex/tasks/task_e_68c4ee9980088329aa0c166f566a22ee