### PR TITLE
Add OnIdle tracing

### DIFF
--- a/Examples/IPlugChunks/IPlugChunks.cpp
+++ b/Examples/IPlugChunks/IPlugChunks.cpp
@@ -1,6 +1,7 @@
 #include "IPlugChunks.h"
 #include "IPlug_include_in_plug_src.h"
 #include "IControls.h"
+#include "IPlugLogger.h"
 
 IPlugChunks::IPlugChunks(const InstanceInfo& info)
 : Plugin(info, MakeConfig(kNumParams, kNumPresets))
@@ -118,6 +119,9 @@ bool IPlugChunks::OnMessage(int msgTag, int ctrlTag, int dataSize, const void* p
 
 void IPlugChunks::OnIdle()
 {
+  if (auto* base = dynamic_cast<IPluginBase*>(this))
+    TRACE_SCOPE_F(base->GetLogFile(), "OnIdle");
+
   if(mStepPos != mPrevPos)
   {
     mPrevPos = mStepPos;

--- a/Examples/IPlugCocoaUI/IPlugCocoaUI.mm
+++ b/Examples/IPlugCocoaUI/IPlugCocoaUI.mm
@@ -1,5 +1,6 @@
 #include "IPlugCocoaUI.h"
 #include "IPlug_include_in_plug_src.h"
+#include "IPlugLogger.h"
 
 #ifdef FRAMEWORK_BUILD
 #import <AUv3Framework/IPlugCocoaUI-Swift.h>
@@ -77,6 +78,9 @@ bool IPlugCocoaUI::OnHostRequestingSupportedViewConfiguration(int width, int hei
 
 void IPlugCocoaUI::OnIdle()
 {
+  if (auto* base = dynamic_cast<IPluginBase*>(this))
+    TRACE_SCOPE_F(base->GetLogFile(), "OnIdle");
+
   mSender.TransmitData(*this);
 }
 

--- a/Examples/IPlugControls/IPlugControls.cpp
+++ b/Examples/IPlugControls/IPlugControls.cpp
@@ -1,6 +1,7 @@
 #include "IPlugControls.h"
 #include "IPlug_include_in_plug_src.h"
 #include "IPlugPaths.h"
+#include "IPlugLogger.h"
 #include "IconsForkAwesome.h"
 #include "IconsFontaudio.h"
 
@@ -570,6 +571,9 @@ void IPlugControls::OnUIClose()
 #if IPLUG_DSP
 void IPlugControls::OnIdle()
 {
+  if (auto* base = dynamic_cast<IPluginBase*>(this))
+    TRACE_SCOPE_F(base->GetLogFile(), "OnIdle");
+
   mScopeSender.TransmitData(*this);
   mMeterSender.TransmitData(*this);
   mRTTextSender.TransmitData(*this);

--- a/Examples/IPlugDrumSynth/IPlugDrumSynth.cpp
+++ b/Examples/IPlugDrumSynth/IPlugDrumSynth.cpp
@@ -140,6 +140,9 @@ void IPlugDrumSynth::ProcessBlock(sample** inputs, sample** outputs, int nFrames
 
 void IPlugDrumSynth::OnIdle()
 {
+  if (auto* base = dynamic_cast<IPluginBase*>(this))
+    TRACE_SCOPE_F(base->GetLogFile(), "OnIdle");
+
   mSender.TransmitData(*this);
 }
 

--- a/Examples/IPlugInstrument/IPlugInstrument.cpp
+++ b/Examples/IPlugInstrument/IPlugInstrument.cpp
@@ -96,6 +96,9 @@ void IPlugInstrument::ProcessBlock(sample** inputs, sample** outputs, int nFrame
 
 void IPlugInstrument::OnIdle()
 {
+  if (auto* base = dynamic_cast<IPluginBase*>(this))
+    TRACE_SCOPE_F(base->GetLogFile(), "OnIdle");
+
   mMeterSender.TransmitData(*this);
   mLFOVisSender.TransmitData(*this);
 }

--- a/Examples/IPlugReaperExtension/IPlugReaperExtension.cpp
+++ b/Examples/IPlugReaperExtension/IPlugReaperExtension.cpp
@@ -1,6 +1,7 @@
 #include "IPlugReaperExtension.h"
 #include "ReaperExt_include_in_plug_src.h"
 
+#include "IPlugLogger.h"
 #include "IControls.h"
 #include "roboto.hpp"
 
@@ -70,6 +71,9 @@ IPlugReaperExtension::IPlugReaperExtension(reaper_plugin_info_t* pRec)
 
 void IPlugReaperExtension::OnIdle()
 {
+  if (auto* base = dynamic_cast<IPluginBase*>(this))
+    TRACE_SCOPE_F(base->GetLogFile(), "OnIdle");
+
   int tracks = CountTracks(0);
   
   if(tracks != mPrevTrackCount) {

--- a/Examples/IPlugResponsiveUI/IPlugResponsiveUI.cpp
+++ b/Examples/IPlugResponsiveUI/IPlugResponsiveUI.cpp
@@ -115,6 +115,9 @@ handle:
 
 void IPlugResponsiveUI::OnIdle()
 {
+  if (auto* base = dynamic_cast<IPluginBase*>(this))
+    TRACE_SCOPE_F(base->GetLogFile(), "OnIdle");
+
   mScopeSender.TransmitData(*this);
 }
 

--- a/Examples/IPlugSideChain/IPlugSideChain.cpp
+++ b/Examples/IPlugSideChain/IPlugSideChain.cpp
@@ -1,5 +1,6 @@
 #include "IPlugSideChain.h"
 #include "IPlug_include_in_plug_src.h"
+#include "IPlugLogger.h"
 
 IPlugSideChain::IPlugSideChain(const InstanceInfo& info)
 : Plugin(info, MakeConfig(kNumParams, kNumPresets))
@@ -32,6 +33,9 @@ IPlugSideChain::IPlugSideChain(const InstanceInfo& info)
 
 void IPlugSideChain::OnIdle()
 {
+  if (auto* base = dynamic_cast<IPluginBase*>(this))
+    TRACE_SCOPE_F(base->GetLogFile(), "OnIdle");
+
   mInputPeakSender.TransmitData(*this);
   mOutputPeakSender.TransmitData(*this);
   

--- a/Examples/IPlugSurroundEffect/IPlugSurroundEffect.cpp
+++ b/Examples/IPlugSurroundEffect/IPlugSurroundEffect.cpp
@@ -1,6 +1,7 @@
 #include "IPlugSurroundEffect.h"
 #include "IPlug_include_in_plug_src.h"
 #include "IControls.h"
+#include "IPlugLogger.h"
 
 uint64_t GetAPIBusTypeForChannelIOConfig(int configIdx, ERoute dir, int busIdx, const IOConfig* pConfig, WDL_TypedBuf<uint64_t>* APIBusTypes)
 {
@@ -79,6 +80,9 @@ IPlugSurroundEffect::IPlugSurroundEffect(const InstanceInfo& info)
 #if IPLUG_DSP
 void IPlugSurroundEffect::OnIdle()
 {
+  if (auto* base = dynamic_cast<IPluginBase*>(this))
+    TRACE_SCOPE_F(base->GetLogFile(), "OnIdle");
+
   mInputPeakSender.TransmitData(*this);
   mOutputPeakSender.TransmitData(*this);
 }

--- a/Examples/IPlugSvelteUI/IPlugSvelteUI.cpp
+++ b/Examples/IPlugSvelteUI/IPlugSvelteUI.cpp
@@ -1,6 +1,7 @@
 #include "IPlugSvelteUI.h"
 #include "IPlug_include_in_plug_src.h"
 #include "IPlugPaths.h"
+#include "IPlugLogger.h"
 
 IPlugSvelteUI::IPlugSvelteUI(const InstanceInfo& info)
 : Plugin(info, MakeConfig(kNumParams, kNumPresets))
@@ -47,5 +48,8 @@ void IPlugSvelteUI::OnReset()
 
 void IPlugSvelteUI::OnIdle()
 {
+  if (auto* base = dynamic_cast<IPluginBase*>(this))
+    TRACE_SCOPE_F(base->GetLogFile(), "OnIdle");
+
   mSender.TransmitData(*this);
 }

--- a/Examples/IPlugSwiftUI/IPlugSwiftUI.mm
+++ b/Examples/IPlugSwiftUI/IPlugSwiftUI.mm
@@ -1,5 +1,6 @@
 #include "IPlugSwiftUI.h"
 #include "IPlug_include_in_plug_src.h"
+#include "IPlugLogger.h"
 
 #ifdef FRAMEWORK_BUILD
 #import <AUv3Framework/IPlugSwiftUI-Swift.h>
@@ -20,6 +21,9 @@ IPlugSwiftUI::IPlugSwiftUI(const InstanceInfo& info)
 
 void IPlugSwiftUI::OnIdle()
 {
+  if (auto* base = dynamic_cast<IPluginBase*>(this))
+    TRACE_SCOPE_F(base->GetLogFile(), "OnIdle");
+
   mScopeSender.TransmitData(*this);
 }
 

--- a/Examples/IPlugVisualizer/IPlugVisualizer.cpp
+++ b/Examples/IPlugVisualizer/IPlugVisualizer.cpp
@@ -1,6 +1,7 @@
 #include "IPlugVisualizer.h"
 #include "IPlug_include_in_plug_src.h"
 #include "IControls.h"
+#include "IPlugLogger.h"
 
 constexpr int kCtrlTagSpectrumAnalyzer = 0;
 
@@ -55,6 +56,9 @@ bool IPlugVisualizer::OnMessage(int msgTag, int ctrlTag, int dataSize, const voi
 
 void IPlugVisualizer::OnIdle()
 {
+  if (auto* base = dynamic_cast<IPluginBase*>(this))
+    TRACE_SCOPE_F(base->GetLogFile(), "OnIdle");
+
   mSender.TransmitData(*this);
 }
 

--- a/IPlug/IPlugAPIBase.cpp
+++ b/IPlug/IPlugAPIBase.cpp
@@ -193,6 +193,12 @@ void IPlugAPIBase::OnTimer(Timer& t)
   OnIdle();
 }
 
+void IPlugAPIBase::OnIdle()
+{
+  if (auto* base = dynamic_cast<IPluginBase*>(this))
+    TRACE_SCOPE_F(base->GetLogFile(), "OnIdle");
+}
+
 void IPlugAPIBase::SendMidiMsgFromUI(const IMidiMsg& msg)
 {
   DeferMidiMsg(msg);                             // queue the message so that it will be handled by the processor


### PR DESCRIPTION
## Summary
- trace each idle tick by logging in IPlugAPIBase::OnIdle
- log idle ticks from example plug-ins

## Testing
- `make -f Examples/IPlugControls/projects/IPlugControls-wam-processor.mk` *(fails: ../config/IPlugControls-web.mk: No such file or directory)*
- `g++ -std=c++17 -I . -I ./WDL IPlug/IPlugAPIBase.cpp -c -o /tmp/IPlugAPIBase.o` *(fails: fatal error: IGraphicsEditorDelegate.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f4e5e3508329af7276ecc17fabd2