### PR TITLE
Add draw control tracing

### DIFF
--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -962,6 +962,15 @@ void IGraphics::DrawControl(IControl* pControl, const IRECT& bounds, float scale
     }
 
     PrepareRegion(clipBounds);
+    auto* plug = dynamic_cast<IPluginBase*>(GetDelegate());
+    if (plug)
+    {
+      WDL_String label{pControl->GetName()};
+      label.AppendFormatted(64, ":%d", pControl->GetTag());
+      if (CStringHasContents(pControl->GetGroup()))
+        label.AppendFormatted(64, ":%s", pControl->GetGroup());
+      TRACE_SCOPE_F(plug->GetLogFile(), label.Get());
+    }
     pControl->Draw(*this);
 #ifdef AAX_API
     pControl->DrawPTHighlight(*this);


### PR DESCRIPTION
## Summary
- trace control draw durations in `IGraphics::DrawControl`

## Testing
- `make -f Tests/IGraphicsTest/config/IGraphicsTest-web.mk TRACER=1` *(fails: No rule to make target '../../../common-web.mk')*
- `g++ -std=c++17 -DTRACER_BUILD -DIGRAPHICS_NANOVG -DNDEBUG -I. -IIGraphics -IIGraphics/Controls -IIGraphics/Platforms -IIGraphics/Extras -IIPlug -IWDL -IDependencies/IGraphics/NanoSVG/src -IDependencies/IGraphics/NanoVG/src -c IGraphics/IGraphics.cpp` *(fails: fatal error: Easing.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f4e846f88329859e7e67ed608c00