### PR TITLE
Add logging instrumentation to base mouse handlers

### DIFF
--- a/IGraphics/IControl.cpp
+++ b/IGraphics/IControl.cpp
@@ -14,6 +14,8 @@
 
 #include "IControl.h"
 #include "IPlugParameter.h"
+#include "IPlugLogger.h"
+#include "IPlugPluginBase.h"
 
 
 BEGIN_IPLUG_NAMESPACE
@@ -251,8 +253,23 @@ void IControl::SetDisabled(bool disable)
 
 void IControl::OnMouseDown(float x, float y, const IMouseMod& mod)
 {
+  if (auto* plug = dynamic_cast<IPluginBase*>(GetUI()->GetDelegate()))
+    TRACE_SCOPE_F(plug->GetLogFile(), "IControl::OnMouseDown");
+
   if (mod.R)
     PromptUserInput(GetValIdxForPos(x, y));
+}
+
+void IControl::OnMouseUp(float x, float y, const IMouseMod& mod)
+{
+  if (auto* plug = dynamic_cast<IPluginBase*>(GetUI()->GetDelegate()))
+    TRACE_SCOPE_F(plug->GetLogFile(), "IControl::OnMouseUp");
+}
+
+void IControl::OnMouseDrag(float x, float y, float dX, float dY, const IMouseMod& mod)
+{
+  if (auto* plug = dynamic_cast<IPluginBase*>(GetUI()->GetDelegate()))
+    TRACE_SCOPE_F(plug->GetLogFile(), "IControl::OnMouseDrag");
 }
 
 void IControl::OnMouseDblClick(float x, float y, const IMouseMod& mod)
@@ -266,10 +283,19 @@ void IControl::OnMouseDblClick(float x, float y, const IMouseMod& mod)
 
 void IControl::OnMouseOver(float x, float y, const IMouseMod& mod)
 {
+  if (auto* plug = dynamic_cast<IPluginBase*>(GetUI()->GetDelegate()))
+    TRACE_SCOPE_F(plug->GetLogFile(), "IControl::OnMouseOver");
+
   bool prev = mMouseIsOver;
   mMouseIsOver = true;
   if (prev == false)
     SetDirty(false);
+}
+
+void IControl::OnMouseMove(float x, float y, const IMouseMod& mod)
+{
+  if (auto* plug = dynamic_cast<IPluginBase*>(GetUI()->GetDelegate()))
+    TRACE_SCOPE_F(plug->GetLogFile(), "IControl::OnMouseMove");
 }
 
 void IControl::OnMouseOut()

--- a/IGraphics/IControl.h
+++ b/IGraphics/IControl.h
@@ -90,15 +90,21 @@ public:
    * @param x The X coordinate of the mouse event
    * @param y The Y coordinate of the mouse event
    * @param mod A struct indicating which modifier keys are held for the event */
-  virtual void OnMouseUp(float x, float y, const IMouseMod& mod) {}
+  virtual void OnMouseUp(float x, float y, const IMouseMod& mod);
 
-  /** Implement this method to respond to a mouse drag event on this control. 
+  /** Implement this method to respond to a mouse drag event on this control.
    * @param x The X coordinate of the mouse event
    * @param y The Y coordinate of the mouse event
    * @param dX The X delta (difference) since the last event
    * @param dY The Y delta (difference) since the last event
    * @param mod A struct indicating which modifier keys are held for the event */
-  virtual void OnMouseDrag(float x, float y, float dX, float dY, const IMouseMod& mod) {}
+  virtual void OnMouseDrag(float x, float y, float dX, float dY, const IMouseMod& mod);
+
+  /** Implement this method to respond to a mouse move event on this control.
+   * @param x The X coordinate of the mouse event
+   * @param y The Y coordinate of the mouse event
+   * @param mod A struct indicating which modifier keys are held for the event */
+  virtual void OnMouseMove(float x, float y, const IMouseMod& mod);
    
   /** Implement this method to respond to a mouse double click event on this control. 
    * @param x The X coordinate of the mouse event


### PR DESCRIPTION
## Summary
- log plugin-scoped timing for IControl mouse events
- expose new virtual OnMouseMove and move default mouse handler bodies into source file

## Testing
- `g++ -std=c++17 -DIGRAPHICS_NANOVG -I. -I./IGraphics -I./IPlug -I./WDL -IDependencies/IGraphics/NanoSVG/src -c IGraphics/IControl.cpp` *(fails: `FontDescriptor` not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f4e7cef48329bc8ffe6dd6fb02d7