### PR TITLE
Add tracing for initialization and UI setup

### DIFF
--- a/Examples/IPlugControls/IPlugControls.cpp
+++ b/Examples/IPlugControls/IPlugControls.cpp
@@ -8,6 +8,7 @@
 IPlugControls::IPlugControls(const InstanceInfo& info)
 : Plugin(info, MakeConfig(kNumParams, kNumPresets))
 {
+  TRACE_SCOPE_F(GetLogFile(), "IPlugControls::IPlugControls");
   GetParam(kParamGain)->InitDouble("Gain", 100., 0., 100.0, 0.01, "%");
   GetParam(kParamMode)->InitEnum("Mode", 0, 4, "", IParam::kFlagsNone, "", "one", "two", "three", "four");
   GetParam(kParamFreq1)->InitDouble("Freq 1 - X", 0.5, 0.001, 10., 0.01, "Hz", IParam::kFlagsNone, "", IParam::ShapePowCurve(1.));
@@ -19,6 +20,10 @@ IPlugControls::IPlugControls(const InstanceInfo& info)
   };
   
   mLayoutFunc = [&](IGraphics* pGraphics) {
+    if(auto* plug = dynamic_cast<IPluginBase*>(pGraphics->GetDelegate()))
+    {
+      TRACE_SCOPE_F(plug->GetLogFile(), "IPlugControls::LayoutUI");
+    }
     if(pGraphics->NControls())
     {
       //Could handle new layout here
@@ -587,6 +592,7 @@ void IPlugControls::OnIdle()
 
 void IPlugControls::OnReset()
 {
+  TRACE_SCOPE_F(GetLogFile(), "IPlugControls::OnReset");
   mPeakAvgMeterSender.Reset(GetSampleRate());
 }
 

--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -92,6 +92,10 @@ IGraphics::IGraphics(IGEditorDelegate& dlg, int w, int h, int fps, float scale)
   , mMaxScale(DEFAULT_MAX_DRAW_SCALE)
   , mDelegate(&dlg)
 {
+  if (auto* plug = dynamic_cast<IPluginBase*>(GetDelegate()))
+  {
+    TRACE_SCOPE_F(plug->GetLogFile(), "IGraphics::IGraphics");
+  }
 #ifdef OS_WIN
   StaticStorage<APIBitmap>::Accessor bitmapStorage(mBitmapCache);
 #else

--- a/IGraphics/IGraphicsEditorDelegate.cpp
+++ b/IGraphics/IGraphicsEditorDelegate.cpp
@@ -11,6 +11,8 @@
 #include "IGraphicsEditorDelegate.h"
 #include "IGraphics.h"
 #include "IControl.h"
+#include "IPlugPluginBase.h"
+#include "IPlugLogger.h"
 
 using namespace iplug;
 using namespace igraphics;
@@ -26,13 +28,21 @@ IGEditorDelegate::~IGEditorDelegate()
 
 void* IGEditorDelegate::OpenWindow(void* pParent)
 {
+  if(auto* plug = dynamic_cast<IPluginBase*>(this))
+  {
+    TRACE_SCOPE_F(plug->GetLogFile(), "IGraphics::OpenWindow");
+  }
+
   if(!mGraphics)
   {
+    if(auto* plug = dynamic_cast<IPluginBase*>(this))
+      TRACE_SCOPE_F(plug->GetLogFile(), "IGraphics::Init");
+
     mGraphics = std::unique_ptr<IGraphics>(CreateGraphics());
     if (mLastWidth && mLastHeight && mLastScale)
       GetUI()->Resize(mLastWidth, mLastHeight, mLastScale);
   }
-  
+
   if(mGraphics)
     return mGraphics->OpenWindow(pParent);
   else

--- a/IPlug/IPlugAPIBase.cpp
+++ b/IPlug/IPlugAPIBase.cpp
@@ -26,6 +26,7 @@ using namespace iplug;
 IPlugAPIBase::IPlugAPIBase(Config c, EAPI plugAPI)
   : IPluginBase(c.nParams, c.nPresets, c.pluginName)
 {
+  TRACE_SCOPE_F(GetLogFile(), "IPlugAPIBase::IPlugAPIBase");
   mInstanceID = this;
   mUniqueID = c.uniqueID;
   mMfrID = c.mfrID;

--- a/IPlug/VST3/IPlugVST3.cpp
+++ b/IPlug/VST3/IPlugVST3.cpp
@@ -44,7 +44,7 @@ Steinberg::uint32 PLUGIN_API IPlugVST3::getTailSamples() { return GetTailIsInfin
 
 tresult PLUGIN_API IPlugVST3::initialize(FUnknown* context)
 {
-  TRACEF(GetLogFile());
+  TRACE_SCOPE_F(GetLogFile(), "IPlugVST3::initialize");
 
   if (SingleComponentEffect::initialize(context) == kResultOk)
   {
@@ -63,7 +63,7 @@ tresult PLUGIN_API IPlugVST3::initialize(FUnknown* context)
 
 tresult PLUGIN_API IPlugVST3::terminate()
 {
-  TRACEF(GetLogFile());
+  TRACE_SCOPE_F(GetLogFile(), "IPlugVST3::terminate");
 
   return SingleComponentEffect::terminate();
 }


### PR DESCRIPTION
## Summary
- log VST3 init/terminate via `TRACE_SCOPE_F`
- instrument API base, graphics, and example plug-in with `TRACE_SCOPE_F`

## Testing
- `bash Examples/IPlugControls/scripts/makedist-web.sh off` *(fails: can't open file '/upstream/emscripten/tools/file_packager.py')*

------
https://chatgpt.com/codex/tasks/task_e_68c4f7fc8a108329816d26c63f3157fa