### PR TITLE
Use control tag in trace

### DIFF
--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -969,11 +969,10 @@ void IGraphics::DrawControl(IControl* pControl, const IRECT& bounds, float scale
     auto* plug = dynamic_cast<IPluginBase*>(GetDelegate());
     if (plug)
     {
-      WDL_String label{pControl->GetName()};
-      label.AppendFormatted(64, ":%d", pControl->GetTag());
       if (CStringHasContents(pControl->GetGroup()))
-        label.AppendFormatted(64, ":%s", pControl->GetGroup());
-      TRACE_SCOPE_F(plug->GetLogFile(), label.Get());
+        Trace(plug->GetLogFile(), TRACELOC, "tag=%d:%s", pControl->GetTag(), pControl->GetGroup());
+      else
+        Trace(plug->GetLogFile(), TRACELOC, "tag=%d", pControl->GetTag());
     }
     pControl->Draw(*this);
 #ifdef AAX_API


### PR DESCRIPTION
## Summary
- log control tag instead of control name in DrawControl

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68c4fcaf1e348329b2c61b5d05c76887