### PR TITLE
Include IPlugLogger in source files using trace macros

### DIFF
--- a/IGraphics/Platforms/IGraphicsWeb.cpp
+++ b/IGraphics/Platforms/IGraphicsWeb.cpp
@@ -15,6 +15,8 @@
 #include "IGraphicsWeb.h"
 #include "IPlugPluginBase.h"
 
+#include "IPlugLogger.h"
+
 BEGIN_IPLUG_NAMESPACE
 BEGIN_IGRAPHICS_NAMESPACE
 

--- a/IPlug/APP/IPlugAPP.cpp
+++ b/IPlug/APP/IPlugAPP.cpp
@@ -10,6 +10,7 @@
 
 #include "IPlugAPP.h"
 #include "IPlugAPP_host.h"
+#include "IPlugLogger.h"
 
 #if defined OS_MAC || defined OS_LINUX
   #include <IPlugSWELL.h>

--- a/IPlug/IPlugProcessor.cpp
+++ b/IPlug/IPlugProcessor.cpp
@@ -14,6 +14,7 @@
  */
 
 #include "IPlugProcessor.h"
+#include "IPlugLogger.h"
 
 #ifdef OS_WIN
   #define strtok_r strtok_s
@@ -250,10 +251,10 @@ bool IPlugProcessor::LegalIO(int NInputChans, int NOutputChans) const
     legal = ((NInputChans < 0 || NInputChans == pIO->GetTotalNChannels(ERoute::kInput)) && (NOutputChans < 0 || NOutputChans == pIO->GetTotalNChannels(ERoute::kOutput)));
   }
 
-  #ifdef TRACER_BUILD
+#ifdef TRACER_BUILD
   if (auto* base = dynamic_cast<const IPluginBase*>(this))
     Trace(base->GetLogFile(), TRACELOC, "inst=%p %d:%d:%s", this, NInputChans, NOutputChans, (legal ? "legal" : "illegal"));
-  #endif
+#endif
   return legal;
 }
 


### PR DESCRIPTION
## Summary
- include `IPlugLogger.h` in modules that use tracing macros
- ensure logger header follows precompiled headers

## Testing
- `cmake -S . -B build` *(fails: The source directory does not appear to contain CMakeLists.txt)*

------
https://chatgpt.com/codex/tasks/task_e_68c4fcaeaf008329bde22c6e5bfc64c4