### PR TITLE
Guard VST3 view tracing with IPluginBase checks

### DIFF
--- a/IPlug/VST3/IPlugVST3_View.h
+++ b/IPlug/VST3/IPlugVST3_View.h
@@ -14,6 +14,7 @@
 #include "pluginterfaces/gui/iplugviewcontentscalesupport.h"
 
 #include "IPlugLogger.h"
+#include "IPlugPluginBase.h"
 #include "IPlugStructs.h"
 
 using iplug::LogFileManager;
@@ -54,7 +55,8 @@ public:
 
   Steinberg::tresult PLUGIN_API onSize(Steinberg::ViewRect* pSize) override
   {
-    TRACEF(mOwner.GetLogFile());
+    if (auto* plug = dynamic_cast<IPluginBase*>(GetPlug()))
+      TRACEF(plug->GetLogFile());
 
     if (pSize && mOwner.GetHostResizeEnabled())
     {
@@ -68,7 +70,8 @@ public:
 
   Steinberg::tresult PLUGIN_API getSize(Steinberg::ViewRect* pSize) override
   {
-    TRACEF(mOwner.GetLogFile());
+    if (auto* plug = dynamic_cast<IPluginBase*>(GetPlug()))
+      TRACEF(plug->GetLogFile());
 
     if (mOwner.HasUI())
     {
@@ -108,7 +111,8 @@ public:
 
   Steinberg::tresult PLUGIN_API attached(void* pParent, Steinberg::FIDString type) override
   {
-    TRACE_SCOPE_F(mOwner.GetLogFile(), "VST3View::attached");
+    if (auto* plug = dynamic_cast<IPluginBase*>(GetPlug()))
+      TRACE_SCOPE_F(plug->GetLogFile(), "VST3View::attached");
 
     if (mOwner.HasUI())
     {
@@ -122,7 +126,8 @@ public:
       else // Carbon
         return Steinberg::kResultFalse;
 #endif
-      Trace(mOwner.GetLogFile(), TRACELOC, "attached parent:%p view:%p size:%d:%d", pParent, pView, mOwner.GetEditorWidth(), mOwner.GetEditorHeight());
+      if (auto* plug = dynamic_cast<IPluginBase*>(GetPlug()))
+        Trace(plug->GetLogFile(), TRACELOC, "attached parent:%p view:%p size:%d:%d", pParent, pView, mOwner.GetEditorWidth(), mOwner.GetEditorHeight());
       return Steinberg::kResultTrue;
     }
 
@@ -131,11 +136,13 @@ public:
 
   Steinberg::tresult PLUGIN_API removed() override
   {
-    TRACE_SCOPE_F(mOwner.GetLogFile(), "VST3View::removed");
+    if (auto* plug = dynamic_cast<IPluginBase*>(GetPlug()))
+      TRACE_SCOPE_F(plug->GetLogFile(), "VST3View::removed");
 
     if (mOwner.HasUI())
     {
-      Trace(mOwner.GetLogFile(), TRACELOC, "removed view:%p", mOwner.GetView());
+      if (auto* plug = dynamic_cast<IPluginBase*>(GetPlug()))
+        Trace(plug->GetLogFile(), TRACELOC, "removed view:%p", mOwner.GetView());
       mOwner.CloseWindow();
     }
 


### PR DESCRIPTION
## Summary
- include IPlugPluginBase and logger in VST3 view
- guard TRACEF/TRACE_SCOPE_F and Trace calls via dynamic_cast to IPluginBase

## Testing
- `cmake -S . -B build` *(fails: The source directory does not appear to contain CMakeLists.txt)*
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68c4fcac6b788329876a98da90034321