### PR TITLE
Fix VST3 view tracing compile errors

### DIFF
--- a/IPlug/VST3/IPlugVST3_View.h
+++ b/IPlug/VST3/IPlugVST3_View.h
@@ -19,6 +19,7 @@
 
 using iplug::LogFileManager;
 using iplug::Trace;
+using iplug::ScopedTimer;
 
 /** IPlug VST3 View  */
 template <class T>
@@ -56,7 +57,9 @@ public:
   Steinberg::tresult PLUGIN_API onSize(Steinberg::ViewRect* pSize) override
   {
     if (auto* plug = dynamic_cast<IPluginBase*>(GetPlug()))
+    {
       TRACEF(plug->GetLogFile());
+    }
 
     if (pSize && mOwner.GetHostResizeEnabled())
     {
@@ -71,7 +74,9 @@ public:
   Steinberg::tresult PLUGIN_API getSize(Steinberg::ViewRect* pSize) override
   {
     if (auto* plug = dynamic_cast<IPluginBase*>(GetPlug()))
+    {
       TRACEF(plug->GetLogFile());
+    }
 
     if (mOwner.HasUI())
     {
@@ -112,7 +117,9 @@ public:
   Steinberg::tresult PLUGIN_API attached(void* pParent, Steinberg::FIDString type) override
   {
     if (auto* plug = dynamic_cast<IPluginBase*>(GetPlug()))
+    {
       TRACE_SCOPE_F(plug->GetLogFile(), "VST3View::attached");
+    }
 
     if (mOwner.HasUI())
     {
@@ -127,7 +134,9 @@ public:
         return Steinberg::kResultFalse;
 #endif
       if (auto* plug = dynamic_cast<IPluginBase*>(GetPlug()))
+      {
         Trace(plug->GetLogFile(), TRACELOC, "attached parent:%p view:%p size:%d:%d", pParent, pView, mOwner.GetEditorWidth(), mOwner.GetEditorHeight());
+      }
       return Steinberg::kResultTrue;
     }
 
@@ -137,12 +146,16 @@ public:
   Steinberg::tresult PLUGIN_API removed() override
   {
     if (auto* plug = dynamic_cast<IPluginBase*>(GetPlug()))
+    {
       TRACE_SCOPE_F(plug->GetLogFile(), "VST3View::removed");
+    }
 
     if (mOwner.HasUI())
     {
-      if (auto* plug = dynamic_cast<IPluginBase*>(GetPlug()))
-        Trace(plug->GetLogFile(), TRACELOC, "removed view:%p", mOwner.GetView());
+        if (auto* plug = dynamic_cast<IPluginBase*>(GetPlug()))
+        {
+          Trace(plug->GetLogFile(), TRACELOC, "removed view:%p", mOwner.GetView());
+        }
       mOwner.CloseWindow();
     }
 


### PR DESCRIPTION
## Summary
- ensure ScopedTimer is visible for TRACE_SCOPE_F usage
- guard trace macros with braces to keep conditional variables in scope

## Testing
- `g++ -std=c++17 -I. -I./IPlug -I./Dependencies -c /tmp/test.cpp` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ff5635d08329b83e266942b84ab1