### PR TITLE
Fix VST3 view compilation without auto

### DIFF
--- a/IPlug/VST3/IPlugVST3_View.h
+++ b/IPlug/VST3/IPlugVST3_View.h
@@ -18,8 +18,8 @@
 #include "IPlugStructs.h"
 
 using iplug::LogFileManager;
-using iplug::Trace;
 using iplug::ScopedTimer;
+using iplug::Trace;
 
 /** IPlug VST3 View  */
 template <class T>
@@ -56,7 +56,7 @@ public:
 
   Steinberg::tresult PLUGIN_API onSize(Steinberg::ViewRect* pSize) override
   {
-    if (auto* plug = dynamic_cast<IPluginBase*>(GetPlug()))
+    if (IPluginBase* plug = dynamic_cast<IPluginBase*>(GetPlug()))
     {
       TRACEF(plug->GetLogFile());
     }
@@ -73,7 +73,7 @@ public:
 
   Steinberg::tresult PLUGIN_API getSize(Steinberg::ViewRect* pSize) override
   {
-    if (auto* plug = dynamic_cast<IPluginBase*>(GetPlug()))
+    if (IPluginBase* plug = dynamic_cast<IPluginBase*>(GetPlug()))
     {
       TRACEF(plug->GetLogFile());
     }
@@ -116,7 +116,7 @@ public:
 
   Steinberg::tresult PLUGIN_API attached(void* pParent, Steinberg::FIDString type) override
   {
-    if (auto* plug = dynamic_cast<IPluginBase*>(GetPlug()))
+    if (IPluginBase* plug = dynamic_cast<IPluginBase*>(GetPlug()))
     {
       TRACE_SCOPE_F(plug->GetLogFile(), "VST3View::attached");
     }
@@ -133,7 +133,7 @@ public:
       else // Carbon
         return Steinberg::kResultFalse;
 #endif
-      if (auto* plug = dynamic_cast<IPluginBase*>(GetPlug()))
+      if (IPluginBase* plug = dynamic_cast<IPluginBase*>(GetPlug()))
       {
         Trace(plug->GetLogFile(), TRACELOC, "attached parent:%p view:%p size:%d:%d", pParent, pView, mOwner.GetEditorWidth(), mOwner.GetEditorHeight());
       }
@@ -145,17 +145,17 @@ public:
 
   Steinberg::tresult PLUGIN_API removed() override
   {
-    if (auto* plug = dynamic_cast<IPluginBase*>(GetPlug()))
+    if (IPluginBase* plug = dynamic_cast<IPluginBase*>(GetPlug()))
     {
       TRACE_SCOPE_F(plug->GetLogFile(), "VST3View::removed");
     }
 
     if (mOwner.HasUI())
     {
-        if (auto* plug = dynamic_cast<IPluginBase*>(GetPlug()))
-        {
-          Trace(plug->GetLogFile(), TRACELOC, "removed view:%p", mOwner.GetView());
-        }
+      if (IPluginBase* plug = dynamic_cast<IPluginBase*>(GetPlug()))
+      {
+        Trace(plug->GetLogFile(), TRACELOC, "removed view:%p", mOwner.GetView());
+      }
       mOwner.CloseWindow();
     }
 


### PR DESCRIPTION
## Summary
- remove use of `auto` for plugin pointer in VST3 view
- keep logging and tracing working on compilers without `auto`

## Testing
- `clang-format -i IPlug/VST3/IPlugVST3_View.h`
- `g++ -std=c++17 -I. -I./IPlug -I./Dependencies/IPlug/VST3_SDK -I./Dependencies/IPlug/VST3_SDK/base/source -I./Dependencies/IPlug/VST3_SDK/pluginterfaces -fsyntax-only /tmp/test.cpp` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c500d908008329a75e52a62fd031aa