### PR TITLE
Fix missing IPluginBase using directive in VST3 view

### DIFF
--- a/IPlug/VST3/IPlugVST3_View.h
+++ b/IPlug/VST3/IPlugVST3_View.h
@@ -20,6 +20,7 @@
 using iplug::LogFileManager;
 using iplug::ScopedTimer;
 using iplug::Trace;
+using iplug::IPluginBase;
 
 /** IPlug VST3 View  */
 template <class T>


### PR DESCRIPTION
## Summary
- ensure `IPluginBase` is brought into scope for the VST3 view

## Testing
- `g++ -std=c++17 -DNDEBUG -DTRACER_BUILD -I. -IIPlug -IIGraphics -IWDL -IDependencies/IPlug/VST3_SDK -c /tmp/test.cpp`

------
https://chatgpt.com/codex/tasks/task_e_68c5028fedb0832995f76e305eab3937