### PR TITLE
Add GetPlug helper for VST3 view

### DIFF
--- a/IPlug/VST3/IPlugVST3_View.h
+++ b/IPlug/VST3/IPlugVST3_View.h
@@ -418,6 +418,9 @@ public:
     Steinberg::ViewRect newSize = Steinberg::ViewRect(0, 0, w, h);
     plugFrame->resizeView(this, &newSize);
   }
+ 
+private:
+  T* GetPlug() const { return &mOwner; }
 
   T& mOwner;
 };


### PR DESCRIPTION
## Summary
- add private GetPlug helper to IPlugVST3View to access owner pointer

## Testing
- `msbuild Examples/IPlugEffect/projects/IPlugEffect-vst3.vcxproj` *(fails: command not found)*
- `dotnet build Examples/IPlugEffect/projects/IPlugEffect-vst3.vcxproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c50551972c8329a999094ab5328ce7