### PR TITLE
Make font caches instance-specific for Windows backend

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -179,8 +179,8 @@ private:
 
   WDL_String mMainWndClassName;
 
-  static StaticStorage<InstalledFont> sPlatformFontCache;
-  static StaticStorage<HFontHolder> sHFontCache;
+  StaticStorage<InstalledFont> mPlatformFontCache;
+  StaticStorage<HFontHolder> mHFontCache;
   std::vector<InstalledFont*> mInstalledFonts;
   std::wstring mWndClassName;
   bool mWndClassRegistered = false;


### PR DESCRIPTION
## Summary
- make Windows font caches instance-specific to avoid cross-instance blocking
- reference new caches in LoadPlatformFont, CachePlatformFont and edit window setup

## Testing
- `clang-format -i IGraphics/Platforms/IGraphicsWin.h IGraphics/Platforms/IGraphicsWin.cpp`
- `x86_64-w64-mingw32-g++ -fsyntax-only IGraphics/Platforms/IGraphicsWin.cpp` *(fails: Shlobj.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c59c64d6a48329a7a02f7736987206