### PR TITLE
Refactor timer management to avoid global lock

### DIFF
--- a/IPlug/IPlugTimer.h
+++ b/IPlug/IPlugTimer.h
@@ -17,8 +17,6 @@
  * base/source/timer.cpp, so thanks to them
  * */
 
-#include "mutex.h"
-#include "ptrlist.h"
 #include <cmath>
 #include <cstring>
 #include <functional>
@@ -80,12 +78,6 @@ public:
   static void CALLBACK TimerProc(HWND hwnd, UINT uMsg, UINT_PTR idEvent, DWORD dwTime);
 
 private:
-  static WDL_Mutex sMutex;
-  /**
-   * Global list of timers required for mapping from OS timer IDs. Consider
-   * replacing with a per-instance manager to avoid cross-plugin interactions.
-   */
-  static WDL_PtrList<Timer_impl> sTimers;
   UINT_PTR ID = 0;
   ITimerFunction mTimerFunc;
   uint32_t mIntervalMs;


### PR DESCRIPTION
## Summary
- Track active timers per owner using a mutex-protected map
- Simplify Windows timer implementation by using the timer object pointer as the OS timer ID and dropping global lock/list

## Testing
- `g++ -I./WDL -DOS_WEB -fsyntax-only -std=c++17 IPlug/IPlugTimer.cpp` *(fails: emscripten/html5.h: No such file or directory)*
- `g++ -I./WDL -DOS_WIN -fsyntax-only -std=c++17 IPlug/IPlugTimer.cpp` *(fails: windows headers missing)*


------
https://chatgpt.com/codex/tasks/task_e_68c5a702900c83299c4834071aa37555