### PR TITLE
Use per-instance bitmap/SVG caches in IGraphics

### DIFF
--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -1901,10 +1901,8 @@ private:
   IDisplayTickFunc mDisplayTickFunc = nullptr;
   IUIAppearanceChangedFunc mAppearanceChangedFunc = nullptr;
 
-#ifdef OS_WIN
   StaticStorage<APIBitmap> mBitmapCache;
   StaticStorage<SVGHolder> mSVGCache;
-#endif
 
 protected:
   IGEditorDelegate* mDelegate;


### PR DESCRIPTION
## Summary
- Drop global `sBitmapCache` and `sSVGCache` in favor of `IGraphics` members
- Update all `StaticStorage` accessors to reference the per-instance caches
- Caches remain protected by `StaticStorage`'s internal mutexes for thread-safe access

## Testing
- `cmake -S . -B build` *(fails: The source directory does not appear to contain CMakeLists.txt)*
- `Scripts/run_clang_format.sh` *(fails: style=file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a9fcb3408329a9b49a4f710b9b04