### PR TITLE
Retain cacheable layers and release on cleanup

### DIFF
--- a/IGraphics/Drawing/IGraphicsNanoVG.cpp
+++ b/IGraphics/Drawing/IGraphicsNanoVG.cpp
@@ -475,7 +475,7 @@ void IGraphicsNanoVG::ApplyShadowMask(ILayerPtr& layer, RawBitmapData& mask, con
     APIBitmap* shadowBitmap = CreateAPIBitmap(width, height, pBitmap->GetScale(), pBitmap->GetDrawScale());
     IBitmap tempLayerBitmap(shadowBitmap, 1, false);
     IBitmap maskBitmap(&maskRawBitmap, 1, false);
-    ILayer shadowLayer(shadowBitmap, layer->Bounds(), nullptr, IRECT(), 0);
+    ILayer shadowLayer(*this, shadowBitmap, layer->Bounds(), nullptr, IRECT(), 0, false, nullptr);
 
     PathTransformSave();
     PushLayer(layer.get());


### PR DESCRIPTION
## Summary
- retain layer bitmaps when cacheable and generate unique cache keys
- release retained layer bitmaps on layer destruction and reload via key when needed
- update NanoVG shadow layer construction for new layer API

## Testing
- `g++ -std=c++17 -DIGRAPHICS_NANOVG -c IGraphics/IGraphics.cpp -I. -IIGraphics -IWDL -IIGraphics/Drawing -I./Examples -I./IPlug -I./Dependencies/IPlug -I./Dependencies/IPlug/RTAudio -I./Dependencies/IPlug/RTMidi -IDependencies/IGraphics/NanoSVG/src` *(fails: IBubbleControl.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b353c6248329843b5851ea4de2cd