### PR TITLE
Retain cacheable layers and release on cleanup

### DIFF
--- a/IGraphics/Drawing/IGraphicsNanoVG.cpp
+++ b/IGraphics/Drawing/IGraphicsNanoVG.cpp
@@ -475,7 +475,7 @@ void IGraphicsNanoVG::ApplyShadowMask(ILayerPtr& layer, RawBitmapData& mask, con
     APIBitmap* shadowBitmap = CreateAPIBitmap(width, height, pBitmap->GetScale(), pBitmap->GetDrawScale());
     IBitmap tempLayerBitmap(shadowBitmap, 1, false);
     IBitmap maskBitmap(&maskRawBitmap, 1, false);
-    ILayer shadowLayer(shadowBitmap, layer->Bounds(), nullptr, IRECT(), 0);
+    ILayer shadowLayer(*this, shadowBitmap, layer->Bounds(), nullptr, IRECT(), 0, false, nullptr);
 
     PathTransformSave();
     PushLayer(layer.get());

--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -48,6 +48,21 @@ using VST3_API_BASE = iplug::IPlugVST3Controller;
 using namespace iplug;
 using namespace igraphics;
 
+ILayer::~ILayer()
+{
+  if (mBitmap)
+  {
+    if (mCacheable)
+    {
+      mGraphics.ReleaseBitmap(IBitmap(mBitmap, 1, false, mCacheKey.Get()));
+    }
+    else
+    {
+      delete mBitmap;
+    }
+  }
+}
+
 #if !defined(NDEBUG) || defined(IGRAPHICS_DEBUG_RESOURCE_LOAD)
 static std::atomic<bool> sResourceLoadProfiling{false};
 
@@ -2137,10 +2152,12 @@ IBitmap IGraphics::ScaleBitmap(const IBitmap& inBitmap, const char* name, int sc
   mDrawScale = inBitmap.GetDrawScale();
 
   IRECT bounds = IRECT(0, 0, inBitmap.W() / inBitmap.GetDrawScale(), inBitmap.H() / inBitmap.GetDrawScale());
-  StartLayer(nullptr, bounds, true);
+  StartLayer(nullptr, bounds, false);
   DrawBitmap(inBitmap, bounds, 0, 0, nullptr);
   ILayerPtr layer = EndLayer();
-  IBitmap outBitmap = IBitmap(layer->mBitmap.release(), inBitmap.N(), inBitmap.GetFramesAreHorizontal(), name);
+  APIBitmap* pAPIBitmap = layer->mBitmap;
+  layer->mBitmap = nullptr;
+  IBitmap outBitmap = IBitmap(pAPIBitmap, inBitmap.N(), inBitmap.GetFramesAreHorizontal(), name);
   RetainBitmap(outBitmap, name);
 
   mScreenScale = screenScale;
@@ -2306,7 +2323,14 @@ void IGraphics::StartLayer(IControl* pControl, const IRECT& r, bool cacheable, i
 
   static int sLayerId = 0;
   int id = ++sLayerId;
-  auto* pLayer = new ILayer(CreateAPIBitmap(w, h, GetScreenScale(), GetDrawScale(), cacheable, MSAASampleCount), alignedBounds, pControl, pControl ? pControl->GetRECT() : IRECT(), id);
+  APIBitmap* pBitmap = CreateAPIBitmap(w, h, GetScreenScale(), GetDrawScale(), cacheable, MSAASampleCount);
+  WDL_String key;
+  if (cacheable)
+  {
+    key.SetFormatted(32, "layer-%i", id);
+    RetainBitmap(IBitmap(pBitmap, 1, false, key.Get()), key.Get());
+  }
+  auto* pLayer = new ILayer(*this, pBitmap, alignedBounds, pControl, pControl ? pControl->GetRECT() : IRECT(), id, cacheable, key.GetLength() ? key.Get() : nullptr);
   PushLayer(pLayer);
 
   if (plug)
@@ -2396,7 +2420,15 @@ bool IGraphics::CheckLayer(const ILayerPtr& layer)
   if (plug)
     TRACE_SCOPE_F(plug->GetLogFile(), "CheckLayer");
 
-  const APIBitmap* pBitmap = layer ? layer->GetAPIBitmap() : nullptr;
+  APIBitmap* pBitmap = layer ? layer->mBitmap : nullptr;
+
+  if (!pBitmap && layer && layer->mCacheable && layer->mCacheKey.GetLength())
+  {
+    StaticStorage<APIBitmap>::Accessor storage(mBitmapCache);
+    pBitmap = storage.Find(layer->mCacheKey.Get(), GetScreenScale());
+    if (pBitmap)
+      layer->mBitmap = pBitmap;
+  }
 
   if (pBitmap && layer->mControl && layer->mControlRECT != layer->mControl->GetRECT())
   {

--- a/IGraphics/IGraphicsStructs.h
+++ b/IGraphics/IGraphicsStructs.h
@@ -2374,54 +2374,67 @@ struct IPattern
 
 /** An abstraction that is used to store a temporary raster image/framebuffer.
  * The layer is drawn with a specific offset to the graphics context.
- * ILayers take ownership of the underlying bitmaps
- * In GPU-based backends (NanoVG), this is a texture. */
+ * ILayers take ownership of the underlying bitmaps unless cacheable,
+ * where the bitmap is retained in the global cache. In GPU-based backends
+ * (NanoVG), this is a texture. */
 class ILayer
 {
   friend IGraphics;
 
 public:
   /** Create a layer/offscreen context (used internally)
+   * @param pGraphics The owning IGraphics instance
    * @param pBitmap The APIBitmap to use for the layer
-   * @param layerRect The bounds of the layer withing the graphics context
+   * @param layerRect The bounds of the layer within the graphics context
    * @param pControl The control that the layer belongs to
    * @param controlRect The bounds of the control
-   * @param id A unique identifier for the layer */
-  ILayer(APIBitmap* pBitmap, const IRECT& layerRect, IControl* pControl, const IRECT& controlRect, int id)
-    : mBitmap(pBitmap)
+   * @param id A unique identifier for the layer
+   * @param cacheable Set \c true if the bitmap is retained in the cache
+   * @param cacheKey The key used when retaining the bitmap */
+  ILayer(IGraphics& pGraphics, APIBitmap* pBitmap, const IRECT& layerRect, IControl* pControl, const IRECT& controlRect, int id, bool cacheable, const char* cacheKey)
+    : mGraphics(pGraphics)
+    , mBitmap(pBitmap)
     , mControl(pControl)
     , mControlRECT(controlRect)
     , mRECT(layerRect)
     , mInvalid(false)
     , mID(id)
+    , mCacheable(cacheable)
   {
+    if (cacheKey)
+      mCacheKey.Set(cacheKey);
   }
 
+  ~ILayer();
+
   ILayer(const ILayer&) = delete;
-  ILayer operator=(const ILayer&) = delete;
+  ILayer& operator=(const ILayer&) = delete;
 
   /** Mark the layer as needing its contents redrawn  */
   void Invalidate() { mInvalid = true; }
 
   /**  @return const APIBitmap* The API bitmap for the layer */
-  const APIBitmap* GetAPIBitmap() const { return mBitmap.get(); }
+  const APIBitmap* GetAPIBitmap() const { return mBitmap; }
 
   /** @return IBitmap An IBitmap to use the layer directly */
-  IBitmap GetBitmap() const { return IBitmap(mBitmap.get(), 1, false); }
+  IBitmap GetBitmap() const { return IBitmap(mBitmap, 1, false); }
 
   /** @return The unique identifier for this layer */
   int GetID() const { return mID; }
 
-  /** @return const IRECT& The bounds of the layer withing the graphics context */
+  /** @return const IRECT& The bounds of the layer within the graphics context */
   const IRECT& Bounds() const { return mRECT; }
 
 private:
-  std::unique_ptr<APIBitmap> mBitmap;
+  IGraphics& mGraphics;
+  APIBitmap* mBitmap;
   IControl* mControl;
   IRECT mControlRECT;
   IRECT mRECT;
   bool mInvalid;
   int mID;
+  bool mCacheable;
+  WDL_String mCacheKey;
 };
 
 /** ILayerPtr is a managed pointer for transferring the ownership of layers */


### PR DESCRIPTION
## Summary
- retain layer bitmaps when cacheable and generate unique cache keys
- release retained layer bitmaps on layer destruction and reload via key when needed
- update NanoVG shadow layer construction for new layer API

## Testing
- `g++ -std=c++17 -DIGRAPHICS_NANOVG -DOS_MAC -c IGraphics/IGraphics.cpp -I. -IIGraphics -IIGraphics/Controls -IWDL -IIGraphics/Drawing -I./Examples -I./IPlug -I./IPlug/Extras -I./Dependencies/IPlug -I./Dependencies/IPlug/RTAudio -I./Dependencies/IPlug/RTMidi -IDependencies/IGraphics/NanoSVG/src -IDependencies/IGraphics/NanoVG/src -IDependencies/IGraphics/STB` *(fails: fatal error: CoreText/CoreText.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b353c6248329843b5851ea4de2cd