### PR TITLE
Refactor graphics globals and cleanup unused variables

### DIFF
--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -1595,10 +1595,9 @@ void IGraphics::OnGUIIdle()
     TRACEF(plug->GetLogFile());
   ForAllControls(&IControl::OnGUIIdle);
 #ifdef TRACER_BUILD
-  static int idleCount = 0;
-  if (++idleCount >= 60)
+  if (++mIdleCount >= 60)
   {
-    idleCount = 0;
+    mIdleCount = 0;
     int bitmapCount = 0;
     int svgCount = 0;
     {
@@ -2321,8 +2320,7 @@ void IGraphics::StartLayer(IControl* pControl, const IRECT& r, bool cacheable, i
   const int w = static_cast<int>(std::ceil(pixelBackingScale * std::ceil(alignedBounds.W())));
   const int h = static_cast<int>(std::ceil(pixelBackingScale * std::ceil(alignedBounds.H())));
 
-  static int sLayerId = 0;
-  int id = ++sLayerId;
+  int id = ++mLayerId;
   APIBitmap* pBitmap = CreateAPIBitmap(w, h, GetScreenScale(), GetDrawScale(), cacheable, MSAASampleCount);
   WDL_String key;
   if (cacheable)

--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -1919,6 +1919,10 @@ protected:
   friend class ITextEntryControl;
   
   std::stack<ILayer*> mLayers;
+  int mLayerId = 0;
+#ifdef TRACER_BUILD
+  int mIdleCount = 0;
+#endif
 
   IRECT mClipRECT;
   IMatrix mTransform;

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -11,7 +11,6 @@
 // #define IGRAPHICS_DISABLE_VSYNC
 
 #include <Shlobj.h>
-#include <atomic>
 #include <commctrl.h>
 
 #include <chrono>
@@ -42,7 +41,6 @@ using namespace igraphics;
 #pragma warning(disable : 4312) // Pointer size cast mismatch.
 #pragma warning(disable : 4311) // Pointer size cast mismatch.
 
-static double sFPS = 0.0;
 
 #if !defined(NDEBUG) || defined(IGRAPHICS_DEBUG_RESOURCE_LOAD)
 class ResourceLoadTimer
@@ -764,8 +762,8 @@ LRESULT CALLBACK IGraphicsWin::ParamEditProc(HWND hWnd, UINT msg, WPARAM wParam,
 IGraphicsWin::IGraphicsWin(IGEditorDelegate& dlg, int w, int h, int fps, float scale)
   : IGRAPHICS_DRAW_CLASS(dlg, w, h, fps, scale)
 {
-  static std::atomic<int> sClassID{0};
-  mWndClassName = L"IPlugWndClass_" + std::to_wstring(sClassID++);
+  static thread_local int sClassID = 0;
+  mWndClassName = L"IPlugWndClass_" + std::to_wstring(++sClassID);
 
   const COLORREF wcol = RGB(255, 255, 255);
   for (int i = 0; i < 16; ++i)


### PR DESCRIPTION
## Summary
- make idle and layer counters per-instance
- use thread-local class IDs on Windows
- remove unused sFPS variable

## Testing
- `clang++ -std=c++17 -fsyntax-only IGraphics/IGraphics.cpp` *(fails: Either NO_IGRAPHICS or one and only one choice of graphics library must be defined!)*
- `clang++ -std=c++17 -fsyntax-only IGraphics/Platforms/IGraphicsWin.cpp` *(fails: 'Shlobj.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5bd0c3a9c8329b997d0fa8a14a7f8