### PR TITLE
Support instance-local CoreText font descriptor caches

### DIFF
--- a/IGraphics/Platforms/IGraphicsIOS.h
+++ b/IGraphics/Platforms/IGraphicsIOS.h
@@ -11,6 +11,9 @@
 #pragma once
 
 #include "IGraphics_select.h"
+#ifdef IPLUG_SEPARATE_FONTDESC_CACHE
+#include "IGraphicsCoreText.h"
+#endif
 
 BEGIN_IPLUG_NAMESPACE
 BEGIN_IGRAPHICS_NAMESPACE
@@ -71,8 +74,11 @@ public:
   void AttachGestureRecognizer(EGestureType type) override;
   
   bool PlatformSupportsMultiTouch() const override { return true; }
-  
+
   EUIAppearance GetUIAppearance() const override;
+#ifdef IPLUG_SEPARATE_FONTDESC_CACHE
+  StaticStorage<CoreTextFontDescriptor>& GetFontDescriptorCache() { return mFontDescriptorCache; }
+#endif
 
 protected:
   PlatformFontPtr LoadPlatformFont(const char* fontID, const char* fileNameOrResID) override;
@@ -84,6 +90,9 @@ protected:
   void CreatePlatformTextEntry(int paramIdx, const IText& text, const IRECT& bounds, int length, const char* str) override;
 
 private:
+#ifdef IPLUG_SEPARATE_FONTDESC_CACHE
+  StaticStorage<CoreTextFontDescriptor> mFontDescriptorCache;
+#endif
   void* mView = nullptr;
   WDL_String mBundleID;
   WDL_String mAppGroupID;

--- a/IGraphics/Platforms/IGraphicsIOS.mm
+++ b/IGraphics/Platforms/IGraphicsIOS.mm
@@ -46,7 +46,9 @@ END_IPLUG_NAMESPACE
 using namespace iplug;
 using namespace igraphics;
 
+#ifndef IPLUG_SEPARATE_FONTDESC_CACHE
 StaticStorage<CoreTextFontDescriptor> sFontDescriptorCache;
+#endif
 
 #pragma mark -
 
@@ -340,7 +342,11 @@ PlatformFontPtr IGraphicsIOS::LoadPlatformFont(const char* fontID, void* pData, 
 
 void IGraphicsIOS::CachePlatformFont(const char* fontID, const PlatformFontPtr& font)
 {
+#ifdef IPLUG_SEPARATE_FONTDESC_CACHE
+  CoreTextHelpers::CachePlatformFont(fontID, font, mFontDescriptorCache);
+#else
   CoreTextHelpers::CachePlatformFont(fontID, font, sFontDescriptorCache);
+#endif
 }
 
 void IGraphicsIOS::LaunchBluetoothMidiDialog(float x, float y)

--- a/IGraphics/Platforms/IGraphicsIOS_view.mm
+++ b/IGraphics/Platforms/IGraphicsIOS_view.mm
@@ -22,7 +22,9 @@
 #include "IControl.h"
 #include "IPlugParameter.h"
 
+#ifndef IPLUG_SEPARATE_FONTDESC_CACHE
 extern StaticStorage<CoreTextFontDescriptor> sFontDescriptorCache;
+#endif
 
 @implementation IGRAPHICS_UITABLEVC
 

--- a/IGraphics/Platforms/IGraphicsMac.h
+++ b/IGraphics/Platforms/IGraphicsMac.h
@@ -74,6 +74,9 @@ public:
   float MeasureText(const IText& text, const char* str, IRECT& bounds) const override;
 
   EUIAppearance GetUIAppearance() const override;
+#ifdef IPLUG_SEPARATE_FONTDESC_CACHE
+  StaticStorage<CoreTextFontDescriptor>& GetFontDescriptorCache() { return mFontDescriptorCache; }
+#endif
 protected:
 
   IPopupMenu* CreatePlatformPopupMenu(IPopupMenu& menu, const IRECT bounds, bool& isAsync) override;
@@ -93,7 +96,10 @@ private:
 
   void RepositionCursor(CGPoint point);
   void StoreCursorPosition();
-  
+
+#ifdef IPLUG_SEPARATE_FONTDESC_CACHE
+  StaticStorage<CoreTextFontDescriptor> mFontDescriptorCache;
+#endif
   void* mView = nullptr;
   CGPoint mCursorLockPosition;
   WDL_String mBundleID, mAppGroupID;

--- a/IGraphics/Platforms/IGraphicsMac.mm
+++ b/IGraphics/Platforms/IGraphicsMac.mm
@@ -41,7 +41,9 @@ static int GetSystemVersion()
   return v;
 }
 
+#ifndef IPLUG_SEPARATE_FONTDESC_CACHE
 StaticStorage<CoreTextFontDescriptor> sFontDescriptorCache;
+#endif
 
 #pragma mark -
 
@@ -49,15 +51,19 @@ IGraphicsMac::IGraphicsMac(IGEditorDelegate& dlg, int w, int h, int fps, float s
 : IGRAPHICS_DRAW_CLASS(dlg, w, h, fps, scale)
 {
   NSApplicationLoad();
+#ifndef IPLUG_SEPARATE_FONTDESC_CACHE
   StaticStorage<CoreTextFontDescriptor>::Accessor storage(sFontDescriptorCache);
   storage.Retain();
+#endif
 }
 
 IGraphicsMac::~IGraphicsMac()
 {
+#ifndef IPLUG_SEPARATE_FONTDESC_CACHE
   StaticStorage<CoreTextFontDescriptor>::Accessor storage(sFontDescriptorCache);
   storage.Release();
-  
+#endif
+
   CloseWindow();
 }
 
@@ -78,7 +84,11 @@ PlatformFontPtr IGraphicsMac::LoadPlatformFont(const char* fontID, void* pData, 
 
 void IGraphicsMac::CachePlatformFont(const char* fontID, const PlatformFontPtr& font)
 {
+#ifdef IPLUG_SEPARATE_FONTDESC_CACHE
+  CoreTextHelpers::CachePlatformFont(fontID, font, mFontDescriptorCache);
+#else
   CoreTextHelpers::CachePlatformFont(fontID, font, sFontDescriptorCache);
+#endif
 }
 
 float IGraphicsMac::MeasureText(const IText& text, const char* str, IRECT& bounds) const

--- a/IGraphics/Platforms/IGraphicsMac_view.mm
+++ b/IGraphics/Platforms/IGraphicsMac_view.mm
@@ -377,7 +377,9 @@ static int MacKeyEventToVK(NSEvent* pEvent, int& flag)
 
 #pragma mark -
 
+#ifndef IPLUG_SEPARATE_FONTDESC_CACHE
 extern StaticStorage<CoreTextFontDescriptor> sFontDescriptorCache;
+#endif
 
 @implementation IGRAPHICS_VIEW
 
@@ -1132,7 +1134,11 @@ static void MakeCursorFromName(NSCursor*& cursor, const char *name)
     [mTextFieldView setDrawsBackground: TRUE];
   }
 
+#ifdef IPLUG_SEPARATE_FONTDESC_CACHE
+  CoreTextFontDescriptor* CTFontDescriptor = CoreTextHelpers::GetCTFontDescriptor(text, mGraphics->GetFontDescriptorCache());
+#else
   CoreTextFontDescriptor* CTFontDescriptor = CoreTextHelpers::GetCTFontDescriptor(text, sFontDescriptorCache);
+#endif
   double ratio = CTFontDescriptor->GetEMRatio() * mGraphics->GetDrawScale();
   NSFontDescriptor* fontDescriptor = (NSFontDescriptor*) CTFontDescriptor->GetDescriptor();
   NSFont* font = [NSFont fontWithDescriptor: fontDescriptor size: text.mSize * ratio];


### PR DESCRIPTION
## Summary
- add `IPLUG_SEPARATE_FONTDESC_CACHE` macro and instance-level font descriptor caches
- use per-instance caches in CoreText helper calls for macOS and iOS

## Testing
- `clang++ -fsyntax-only -DIPLUG_SEPARATE_FONTDESC_CACHE IGraphics/Platforms/IGraphicsMac.mm` *(fails: 'CoreGraphics/CoreGraphics.h' file not found)*
- `clang++ -fsyntax-only -DIPLUG_SEPARATE_FONTDESC_CACHE IGraphics/Platforms/IGraphicsIOS.mm` *(fails: 'QuartzCore/QuartzCore.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d69e980c83299b91973794541b24