### PR TITLE
Add per-plugin timer manager support

### DIFF
--- a/IPlug/IPlugAPIBase.cpp
+++ b/IPlug/IPlugAPIBase.cpp
@@ -66,7 +66,11 @@ void IPlugAPIBase::OnHostRequestingImportantParameters(int count, WDL_TypedBuf<i
 
 void IPlugAPIBase::CreateTimer()
 {
+#if defined OS_WIN && IPLUG_SEPARATE_TIMER_MANAGER
+  mTimer = std::unique_ptr<Timer>(Timer::Create(std::bind(&IPlugAPIBase::OnTimer, this, std::placeholders::_1), IDLE_TIMER_RATE, &GetTimerManager()));
+#else
   mTimer = std::unique_ptr<Timer>(Timer::Create(std::bind(&IPlugAPIBase::OnTimer, this, std::placeholders::_1), IDLE_TIMER_RATE));
+#endif
 }
 
 bool IPlugAPIBase::CompareState(const uint8_t* pIncomingState, int startPos) const

--- a/IPlug/IPlugPluginBase.h
+++ b/IPlug/IPlugPluginBase.h
@@ -19,6 +19,9 @@
 #include "IPlugParameter.h"
 #include "IPlugStructs.h"
 #include "IPlugLogger.h"
+#if defined OS_WIN && IPLUG_SEPARATE_TIMER_MANAGER
+#include "IPlugTimer.h"
+#endif
 
 BEGIN_IPLUG_NAMESPACE
 
@@ -28,9 +31,13 @@ class IPluginBase : public EDITOR_DELEGATE_CLASS
 public:
   IPluginBase(int nParams, int nPresets);
   virtual ~IPluginBase();
-  
+
   IPluginBase(const IPluginBase&) = delete;
   IPluginBase& operator=(const IPluginBase&) = delete;
+
+#if defined OS_WIN && IPLUG_SEPARATE_TIMER_MANAGER
+  TimerManager& GetTimerManager() { return mTimerManager; }
+#endif
 
 #pragma mark - Plug-in properties
   /** @return the name of the plug-in as a CString */
@@ -397,6 +404,9 @@ public:
   friend class IPlugAPIBase;
   
 private:
+#if defined OS_WIN && IPLUG_SEPARATE_TIMER_MANAGER
+  TimerManager mTimerManager;
+#endif
   int mCurrentPresetIdx = 0;
   /** \c true if the plug-in does opaque state chunks. If false the host will provide a default interface */
   bool mStateChunks = false;

--- a/IPlug/IPlugTimer.cpp
+++ b/IPlug/IPlugTimer.cpp
@@ -63,25 +63,88 @@ void Timer_impl::TimerProc(CFRunLoopTimerRef timer, void *info)
 
 #elif defined OS_WIN
 
-Timer* Timer::Create(ITimerFunction func, uint32_t intervalMs)
+Timer* Timer::Create(ITimerFunction func, uint32_t intervalMs
+#if IPLUG_SEPARATE_TIMER_MANAGER
+                     , TimerManager* pTimerManager
+#endif
+                     )
 {
-  return new Timer_impl(func, intervalMs);
+  return new Timer_impl(func, intervalMs
+#if IPLUG_SEPARATE_TIMER_MANAGER
+                        , pTimerManager
+#endif
+                        );
 }
 
+#if IPLUG_SEPARATE_TIMER_MANAGER
+WDL_Mutex TimerManager::sMgrMutex;
+WDL_PtrList<TimerManager> TimerManager::sManagers;
+
+TimerManager::TimerManager()
+{
+  WDL_MutexLock lock(&sMgrMutex);
+  sManagers.Add(this);
+}
+
+TimerManager::~TimerManager()
+{
+  WDL_MutexLock lock(&sMgrMutex);
+  sManagers.DeletePtr(this);
+}
+
+TimerManager& TimerManager::Global()
+{
+  static TimerManager gGlobal;
+  return gGlobal;
+}
+
+Timer_impl* TimerManager::FindTimer(UINT_PTR id)
+{
+  WDL_MutexLock mgrLock(&sMgrMutex);
+
+  for (auto m = 0; m < sManagers.GetSize(); m++)
+  {
+    TimerManager* pMgr = sManagers.Get(m);
+    WDL_MutexLock lock(&pMgr->mMutex);
+
+    for (auto i = 0; i < pMgr->mTimers.GetSize(); i++)
+    {
+      Timer_impl* pTimer = pMgr->mTimers.Get(i);
+
+      if (pTimer->ID == id)
+        return pTimer;
+    }
+  }
+
+  return nullptr;
+}
+#else
 WDL_Mutex Timer_impl::sMutex;
 WDL_PtrList<Timer_impl> Timer_impl::sTimers;
+#endif
 
-Timer_impl::Timer_impl(ITimerFunction func, uint32_t intervalMs)
+Timer_impl::Timer_impl(ITimerFunction func, uint32_t intervalMs
+#if IPLUG_SEPARATE_TIMER_MANAGER
+                       , TimerManager* pTimerManager
+#endif
+                       )
 : mTimerFunc(func)
 , mIntervalMs(intervalMs)
-
+#if IPLUG_SEPARATE_TIMER_MANAGER
+, mManager(pTimerManager ? pTimerManager : &TimerManager::Global())
+#endif
 {
   ID = SetTimer(0, 0, intervalMs, TimerProc); //TODO: timer ID correct?
-  
+
   if (ID)
   {
+#if IPLUG_SEPARATE_TIMER_MANAGER
+    WDL_MutexLock lock(&mManager->mMutex);
+    mManager->mTimers.Add(this);
+#else
     WDL_MutexLock lock(&sMutex);
     sTimers.Add(this);
+#endif
   }
 }
 
@@ -95,26 +158,36 @@ void Timer_impl::Stop()
   if (ID)
   {
     KillTimer(0, ID);
+#if IPLUG_SEPARATE_TIMER_MANAGER
+    WDL_MutexLock lock(&mManager->mMutex);
+    mManager->mTimers.DeletePtr(this);
+#else
     WDL_MutexLock lock(&sMutex);
     sTimers.DeletePtr(this);
+#endif
     ID = 0;
   }
 }
 
 void CALLBACK Timer_impl::TimerProc(HWND hwnd, UINT uMsg, UINT_PTR idEvent, DWORD dwTime)
 {
+#if IPLUG_SEPARATE_TIMER_MANAGER
+  if (Timer_impl* pTimer = TimerManager::FindTimer(idEvent))
+    pTimer->mTimerFunc(*pTimer);
+#else
   WDL_MutexLock lock(&sMutex);
 
   for (auto i = 0; i < sTimers.GetSize(); i++)
   {
     Timer_impl* pTimer = sTimers.Get(i);
-    
+
     if (pTimer->ID == idEvent)
     {
       pTimer->mTimerFunc(*pTimer);
       return;
     }
   }
+#endif
 }
 #elif defined OS_WEB
 Timer* Timer::Create(ITimerFunction func, uint32_t intervalMs)


### PR DESCRIPTION
## Summary
- introduce IPLUG_SEPARATE_TIMER_MANAGER macro to allow per-plugin timer management on Windows
- implement TimerManager with mutex and timer list for each plugin instance
- wire plugins to use their own TimerManager via new accessor

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5e06a5c9c8329a7e114d9c71ce192