### PR TITLE
Add per-plugin OSC state manager

### DIFF
--- a/Examples/IPlugOSCEditor/IPlugOSCEditor.cpp
+++ b/Examples/IPlugOSCEditor/IPlugOSCEditor.cpp
@@ -1,84 +1,97 @@
 #include "IPlugOSCEditor.h"
-#include "IPlug_include_in_plug_src.h"
 #include "IControls.h"
+#include "IPlug_include_in_plug_src.h"
 #include "IWebViewControl.h"
 
 IPlugOSCEditor::IPlugOSCEditor(const InstanceInfo& info)
-: Plugin(info, MakeConfig(kNumParams, kNumPresets))
-, OSCReceiver(8000)
-, OSCSender("127.0.0.1", 8000)
+  : Plugin(info, MakeConfig(kNumParams, kNumPresets))
+#if IPLUG_SEPARATE_OSC_STATE
+  , OSCManager()
+  , OSCReceiver(*this, 8000)
+  , OSCSender(*this, "127.0.0.1", 8000)
+#else
+  , OSCReceiver(8000)
+  , OSCSender("127.0.0.1", 8000)
+#endif
 {
   GetParam(kGain)->InitDouble("Gain", 0., 0., 100.0, 0.01, "%");
 
   auto logFunc = [&](WDL_String& log) {
     IGraphics* pGraphics = GetUI();
-    
+
     if (pGraphics)
       pGraphics->GetControlWithTag(kCtrlTagWebView)->As<IWebViewControl>()->LoadHTML(log.Get());
-    
+
     DBGMSG("%s\n", log.Get());
   };
-  
+
   OSCReceiver::SetLogFunc(logFunc);
   OSCSender::SetLogFunc(logFunc);
 
 #if IPLUG_EDITOR // http://bit.ly/2S64BDd
-  mMakeGraphicsFunc = [&]() {
-    return MakeGraphics(*this, PLUG_WIDTH, PLUG_HEIGHT, PLUG_FPS, GetScaleForScreen(PLUG_WIDTH, PLUG_HEIGHT));
-  };
-  
+  mMakeGraphicsFunc = [&]() { return MakeGraphics(*this, PLUG_WIDTH, PLUG_HEIGHT, PLUG_FPS, GetScaleForScreen(PLUG_WIDTH, PLUG_HEIGHT)); };
+
   mLayoutFunc = [&](IGraphics* pGraphics) {
     pGraphics->AttachCornerResizer(EUIResizerMode::Scale, false);
     pGraphics->AttachPanelBackground(COLOR_GRAY);
     pGraphics->EnableMouseOver(true);
     pGraphics->LoadFont("Roboto-Regular", ROBOTO_FN);
     const IRECT b = pGraphics->GetBounds().GetPadded(-10.f);
-    
+
     auto setSendIPAndPort = [&, pGraphics](IControl* pCaller) {
       WDL_String log;
       const char* ip = pGraphics->GetControlWithTag(kCtrlTagSendIP)->As<IEditableTextControl>()->GetStr();
       int port = static_cast<int>(pGraphics->GetControlWithTag(kCtrlTagSendPort)->As<IVNumberBoxControl>()->GetRealValue());
       SetDestination(ip, port);
     };
-    
+
     IRECT topRow = b.SubRectVertical(3, 0).GetMidVPadded(40.f);
     IRECT bottomRow = b.SubRectVertical(3, 2);
     pGraphics->AttachControl(new IVLabelControl(topRow.SubRectHorizontal(3, 0).GetPadded(-10.f), "Send IP", DEFAULT_STYLE.WithValueText(DEFAULT_LABEL_TEXT).WithDrawShadows(false)));
-    pGraphics->AttachControl(new IEditableTextControl(topRow.SubRectHorizontal(3, 0).GetPadded(-10.f).GetFromBottom(44.f), "127.0.0.1"), kCtrlTagSendIP)->SetActionFunction(setSendIPAndPort)->SetTextEntryLength(32);
-    
-    pGraphics->AttachControl(new IVNumberBoxControl(topRow.SubRectHorizontal(3, 1).GetPadded(-10.f), kNoParameter, setSendIPAndPort, "Send Port", DEFAULT_STYLE, true, 8000, 4000, 10000, "%0.0f", false), kCtrlTagSendPort);
-    
-    pGraphics->AttachControl(new IVNumberBoxControl(topRow.SubRectHorizontal(3, 2).GetPadded(-10.f), kNoParameter, [&](IControl* pCaller){
-      SetReceivePort(static_cast<int>(pCaller->As<IVNumberBoxControl>()->GetRealValue()));
-    }, "Receive Port", DEFAULT_STYLE, true, 8000, 4000, 10000, "%0.0f", false));
-    
-    pGraphics->AttachControl(new IVKnobControl(b.GetCentredInside(100), [&](IControl* pCaller) {
-                                                OscMessageWrite msg;
-                                                msg.PushWord("gain");
-                                                msg.PushFloatArg((float) pCaller->GetValue());
-                                                SendOSCMessage(msg);}
-                                               , "Gain"), kCtrlTagGain);
-    
-    bool showDevTools = false;
-    
-#if DEBUG
-    showDevTools = true;
-#endif
+    pGraphics->AttachControl(new IEditableTextControl(topRow.SubRectHorizontal(3, 0).GetPadded(-10.f).GetFromBottom(44.f), "127.0.0.1"), kCtrlTagSendIP)
+      ->SetActionFunction(setSendIPAndPort)
+      ->SetTextEntryLength(32);
 
-    pGraphics->AttachControl(new IWebViewControl(bottomRow, true, [](IWebViewControl* pControl){
-      pControl->LoadHTML("...");
-    }, [](IWebViewControl* pControl, const char* jsonMsg){
-      // You can handle key up/down events on the WebView here (or any other messages that you send from the UI)
-      DBGMSG("Received message %s\n", jsonMsg);
-    }, showDevTools), kCtrlTagWebView)->Hide(true);
-        
-    pGraphics->AttachControl(new IVButtonControl(bottomRow.GetFromTop(20).GetFromLeft(200).GetVShifted(-20),
-    [](IControl* pControl){
-      SplashClickActionFunc(pControl);
-    }, "Show OSC Console", DEFAULT_STYLE.WithDrawShadows(false).WithDrawFrame(false)))->SetAnimationEndActionFunction([](IControl* pControl){
-      pControl->GetUI()->GetControlWithTag(kCtrlTagWebView)->Hide(!pControl->GetUI()->GetControlWithTag(kCtrlTagWebView)->IsHidden());
-    });
-    
+    pGraphics->AttachControl(
+      new IVNumberBoxControl(topRow.SubRectHorizontal(3, 1).GetPadded(-10.f), kNoParameter, setSendIPAndPort, "Send Port", DEFAULT_STYLE, true, 8000, 4000, 10000, "%0.0f", false), kCtrlTagSendPort);
+
+    pGraphics->AttachControl(new IVNumberBoxControl(
+      topRow.SubRectHorizontal(3, 2).GetPadded(-10.f), kNoParameter, [&](IControl* pCaller) { SetReceivePort(static_cast<int>(pCaller->As<IVNumberBoxControl>()->GetRealValue())); }, "Receive Port",
+      DEFAULT_STYLE, true, 8000, 4000, 10000, "%0.0f", false));
+
+    pGraphics->AttachControl(new IVKnobControl(
+                               b.GetCentredInside(100),
+                               [&](IControl* pCaller) {
+                                 OscMessageWrite msg;
+                                 msg.PushWord("gain");
+                                 msg.PushFloatArg((float)pCaller->GetValue());
+                                 SendOSCMessage(msg);
+                               },
+                               "Gain"),
+                             kCtrlTagGain);
+
+    bool showDevTools = false;
+
+  #if DEBUG
+    showDevTools = true;
+  #endif
+
+    pGraphics
+      ->AttachControl(new IWebViewControl(
+                        bottomRow, true, [](IWebViewControl* pControl) { pControl->LoadHTML("..."); },
+                        [](IWebViewControl* pControl, const char* jsonMsg) {
+                          // You can handle key up/down events on the WebView here (or any other messages that you send from the UI)
+                          DBGMSG("Received message %s\n", jsonMsg);
+                        },
+                        showDevTools),
+                      kCtrlTagWebView)
+      ->Hide(true);
+
+    pGraphics
+      ->AttachControl(new IVButtonControl(
+        bottomRow.GetFromTop(20).GetFromLeft(200).GetVShifted(-20), [](IControl* pControl) { SplashClickActionFunc(pControl); }, "Show OSC Console",
+        DEFAULT_STYLE.WithDrawShadows(false).WithDrawFrame(false)))
+      ->SetAnimationEndActionFunction([](IControl* pControl) { pControl->GetUI()->GetControlWithTag(kCtrlTagWebView)->Hide(!pControl->GetUI()->GetControlWithTag(kCtrlTagWebView)->IsHidden()); });
   };
 #endif
 }
@@ -88,9 +101,11 @@ void IPlugOSCEditor::ProcessBlock(sample** inputs, sample** outputs, int nFrames
 {
   const double gain = GetParam(kGain)->Value() / 100.;
   const int nChans = NOutChansConnected();
-  
-  for (int s = 0; s < nFrames; s++) {
-    for (int c = 0; c < nChans; c++) {
+
+  for (int s = 0; s < nFrames; s++)
+  {
+    for (int c = 0; c < nChans; c++)
+    {
       outputs[c][s] = inputs[c][s] * gain;
     }
   }
@@ -105,11 +120,12 @@ void IPlugOSCEditor::OnOSCMessage(OscMessageRead& msg)
 
   IGraphics* pGraphics = GetUI();
 
-  if(strcmp(msg.GetMessage(), "/gain") == 0)
+  if (strcmp(msg.GetMessage(), "/gain") == 0)
   {
     auto* pValue = msg.PopFloatArg(true);
-    if (pValue) {
-      if(pGraphics)
+    if (pValue)
+    {
+      if (pGraphics)
         pGraphics->GetControlWithTag(kCtrlTagGain)->SetValueFromDelegate(*pValue);
     }
   }
@@ -118,44 +134,45 @@ void IPlugOSCEditor::OnOSCMessage(OscMessageRead& msg)
 
   oscStr.Append(msg.GetMessage());
 
-  while (nArgs) {
+  while (nArgs)
+  {
     msg.GetIndexedArg(index, &type);
 
-    switch (type) {
-      case 'i':
-      {
-        auto* pValue = msg.PopIntArg(false);
-        if (pValue)
-          oscStr.AppendFormatted(256, " %i", *pValue);
-        break;
-      }
-      case 'f':
-      {
-        auto* pValue = msg.PopFloatArg(false);
-        if (pValue)
-          oscStr.AppendFormatted(256, " %f", *pValue);
-        break;
-      }
-      case 's':
-      {
-        auto* pValue = msg.PopStringArg(false);
-        if (pValue)
-          oscStr.AppendFormatted(256, " %s", pValue);
-        break;
-      }
-      default :
-        break;
+    switch (type)
+    {
+    case 'i': {
+      auto* pValue = msg.PopIntArg(false);
+      if (pValue)
+        oscStr.AppendFormatted(256, " %i", *pValue);
+      break;
+    }
+    case 'f': {
+      auto* pValue = msg.PopFloatArg(false);
+      if (pValue)
+        oscStr.AppendFormatted(256, " %f", *pValue);
+      break;
+    }
+    case 's': {
+      auto* pValue = msg.PopStringArg(false);
+      if (pValue)
+        oscStr.AppendFormatted(256, " %s", pValue);
+      break;
+    }
+    default:
+      break;
     }
     nArgs--;
   }
 
-  if(oscStr.GetLength()) {
+  if (oscStr.GetLength())
+  {
     WDL_String str;
     str.Set("Received message: ");
     str.Append(&oscStr);
     DBGMSG("%s\n", str.Get());
-    
-    if(pGraphics) {
+
+    if (pGraphics)
+    {
       pGraphics->GetControlWithTag(kCtrlTagWebView)->As<IWebViewControl>()->LoadHTML(str.Get());
     }
   }

--- a/Examples/IPlugOSCEditor/IPlugOSCEditor.h
+++ b/Examples/IPlugOSCEditor/IPlugOSCEditor.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "IPlug_include_in_plug_hdr.h"
 #include "IPlugOSC.h"
+#include "IPlug_include_in_plug_hdr.h"
 
 const int kNumPresets = 1;
 
@@ -23,12 +23,16 @@ enum ECtrlTags
 using namespace iplug;
 using namespace igraphics;
 
+#if IPLUG_SEPARATE_OSC_STATE
+class IPlugOSCEditor final : public Plugin, public OSCManager, public OSCReceiver, public OSCSender
+#else
 class IPlugOSCEditor final : public Plugin, public OSCReceiver, public OSCSender
+#endif
 {
 public:
   IPlugOSCEditor(const InstanceInfo& info);
-  
+
   void ProcessBlock(sample** inputs, sample** outputs, int nFrames) override;
-  
+
   void OnOSCMessage(OscMessageRead& msg) override;
 };

--- a/IPlug/Extras/OSC/IPlugOSC.h
+++ b/IPlug/Extras/OSC/IPlugOSC.h
@@ -1,10 +1,10 @@
 /*
  ==============================================================================
- 
- This file is part of the iPlug 2 library. Copyright (C) the iPlug 2 developers. 
- 
+
+ This file is part of the iPlug 2 library. Copyright (C) the iPlug 2 developers.
+
  See LICENSE.txt for  more info.
- 
+
  ==============================================================================
 */
 
@@ -24,13 +24,17 @@
 
 #include "jnetlib/jnetlib.h"
 
-#include "IPlugPlatform.h"
 #include "IPlugLogger.h"
 #include "IPlugOSC_msg.h"
+#include "IPlugPlatform.h"
 #include "IPlugTimer.h"
 
 
 BEGIN_IPLUG_NAMESPACE
+
+#ifndef IPLUG_SEPARATE_OSC_STATE
+  #define IPLUG_SEPARATE_OSC_STATE 0
+#endif
 
 #ifndef OSC_TIMER_RATE
 static constexpr int OSC_TIMER_RATE = 100;
@@ -43,31 +47,31 @@ class OSCDevice
 {
 public:
   /** Construct a new OSCDevice object
-   * @param dest 
-   * @param maxpacket 
-   * @param sendsleep 
+   * @param dest
+   * @param maxpacket
+   * @param sendsleep
    * @param listen_addr */
   OSCDevice(const char* dest, int maxpacket, int sendsleep, struct sockaddr_in* listen_addr);
-  
+
   virtual ~OSCDevice();
-  
+
   /** \todo */
   void RunInput();
-  
+
   /** \todo */
   void RunOutput();
-  
+
   /** \todo */
   void AddInstance(void (*callback)(void* d1, int dev_idx, int msglen, void* msg), void* d1, int dev_idx);
 
   /** \todo
-   * @param type 
-   * @param msg 
+   * @param type
+   * @param msg
    * @param len */
   void OnMessage(char type, const unsigned char* msg, int len);
-  
+
   /** \todo
-   * @param src 
+   * @param src
    * @param len */
   void SendOSC(const char* src, int len);
 
@@ -80,18 +84,30 @@ private:
   };
 
   WDL_TypedBuf<rec> mInstances;
+
 public:
   double mLastOpenTime = 0;
   bool mHasInput = false;
   bool mHasOutput = false;
-  
+
   SOCKET mSendSocket;
   int mMaxMacketSize, mSendSleep;
   WDL_String mDestination;
-  
+
   struct sockaddr_in mSendAddress, mReceiveAddress;
   WDL_Queue mSendQueue, mReceiveQueue;
 };
+
+#if IPLUG_SEPARATE_OSC_STATE
+/** Manager for OSC state when separated per plug-in */
+class OSCManager
+{
+public:
+  WDL_PtrList<OSCDevice> mDevices;
+  std::unique_ptr<Timer> mTimer;
+  int mInstances = 0;
+};
+#endif
 
 /** \todo */
 class OSCInterface
@@ -102,51 +118,59 @@ class OSCInterface
     int sz; // size of msg
     unsigned char msg[3];
   };
-  
+
 public:
   /** Construct a new OSCInterface object
-  * @param logFunc */
+   * @param logFunc */
+#if IPLUG_SEPARATE_OSC_STATE
+  OSCInterface(OSCManager& manager, OSCLogFunc logFunc = nullptr);
+#else
   OSCInterface(OSCLogFunc logFunc = nullptr);
-  
+#endif
+
   virtual ~OSCInterface();
-  
+
   OSCInterface(const OSCInterface&) = delete;
   OSCInterface& operator=(const OSCInterface&) = delete;
-  
+
   /** Create a Receiver object
-   * @param log 
-   * @param port 
+   * @param log
+   * @param port
    * @return OSCDevice* */
   OSCDevice* CreateReceiver(WDL_String& log, int port = 8000);
-  
+
   /** Create a Sender object
-   * @param log 
-   * @param port 
+   * @param log
+   * @param port
    * @return OSCDevice* */
   OSCDevice* CreateSender(WDL_String& log, const char* ip = "127.0.0.1", int port = 8000);
-  
+
 public:
   /** \todo
    * @param msg */
   virtual void OnOSCMessage(OscMessageRead& msg) {};
-  
+
   /** Set the Log Func object
    * @param logFunc */
   void SetLogFunc(OSCLogFunc logFunc) { mLogFunc = logFunc; }
-  
+
 private:
-  static void MessageCallback(void *d1, int dev_idx, int msglen, void *msg);
+  static void MessageCallback(void* d1, int dev_idx, int msglen, void* msg);
 
   void OnTimer(Timer& timer);
-  
+
   // these are non-owned refs
   WDL_PtrList<OSCDevice> mDevices;
-  
+
 protected:
   OSCLogFunc mLogFunc;
+#if IPLUG_SEPARATE_OSC_STATE
+  OSCManager& mManager;
+#else
   static std::unique_ptr<Timer> mTimer;
   static int sInstances;
-  WDL_HeapBuf mIncomingEvents;  // incomingEvent list, each is 8-byte aligned
+#endif
+  WDL_HeapBuf mIncomingEvents; // incomingEvent list, each is 8-byte aligned
   WDL_Mutex mIncomingEvents_mutex;
 };
 
@@ -155,19 +179,24 @@ class OSCSender : public OSCInterface
 {
 public:
   /** Construct a new OSCSender object
-   * @param destIP 
-   * @param port 
+   * @param destIP
+   * @param port
    * @param logFunc  */
+#if IPLUG_SEPARATE_OSC_STATE
+  OSCSender(OSCManager& manager, const char* destIP = "127.0.0.1", int port = 8000, OSCLogFunc logFunc = nullptr);
+#else
   OSCSender(const char* destIP = "127.0.0.1", int port = 8000, OSCLogFunc logFunc = nullptr);
-  
+#endif
+
   /** Set the Destination object
-   * @param ip 
+   * @param ip
    * @param port */
   void SetDestination(const char* ip, int port);
-  
+
   /**
    * @param msg */
   void SendOSCMessage(OscMessageWrite& msg);
+
 private:
   int mPort = 0;
   WDL_String mDestIP;
@@ -178,17 +207,21 @@ class OSCReceiver : public OSCInterface
 {
 public:
   /** @brief Construct a new OSCReceiver object
-   * @param port 
+   * @param port
    * @param logFunc */
+#if IPLUG_SEPARATE_OSC_STATE
+  OSCReceiver(OSCManager& manager, int port = 8000, OSCLogFunc logFunc = nullptr);
+#else
   OSCReceiver(int port = 8000, OSCLogFunc logFunc = nullptr);
-  
+#endif
+
   /** Set the Receive Port object
    * @param port */
   void SetReceivePort(int port);
-  
+
   /** \todo */
   virtual void OnOSCMessage(OscMessageRead& msg) = 0;
-  
+
 private:
   OSCDevice* mDevice = nullptr;
   int mPort = 0;


### PR DESCRIPTION
## Summary
- introduce `IPLUG_SEPARATE_OSC_STATE` macro and `OSCManager` to encapsulate OSC state per plug‑in
- route timer, instance count, and device list management through the per‑plugin manager
- update OSC example to construct sender/receiver with shared manager when the macro is enabled

## Testing
- `clang-format -i IPlug/Extras/OSC/IPlugOSC.h IPlug/Extras/OSC/IPlugOSC.cpp Examples/IPlugOSCEditor/IPlugOSCEditor.h Examples/IPlugOSCEditor/IPlugOSCEditor.cpp`
- `g++ -std=c++17 -I. -I./IPlug -I./WDL -DIPLUG_SEPARATE_OSC_STATE=1 -DOS_LINUX -c IPlug/Extras/OSC/IPlugOSC.cpp` *(fails: NOT IMPLEMENTED)*

------
https://chatgpt.com/codex/tasks/task_e_68c5e742f51c83298f7027f7a0f6b8ba