### PR TITLE
Fix Win32 preprocessor conditionals

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1095,13 +1095,11 @@ void* IGraphicsWin::OpenWindow(void* pParent)
     h = cR.bottom - cR.top;
   }
 
-  if (
 #if IPLUG_SEPARATE_WIN_WINDOWING
-    mWndClassReg++ == 0
+  if (mWndClassReg++ == 0)
 #else
-    sWndClassReg++ == 0
+  if (sWndClassReg++ == 0)
 #endif
-  )
   {
     WNDCLASSW wndClass = { CS_DBLCLKS | CS_OWNDC, WndProc, 0, 0, mHInstance, 0, 0, 0, 0,
 #if IPLUG_SEPARATE_WIN_WINDOWING
@@ -1113,11 +1111,10 @@ void* IGraphicsWin::OpenWindow(void* pParent)
     RegisterClassW(&wndClass);
   }
 
-  mPlugWnd = CreateWindowW(
 #if IPLUG_SEPARATE_WIN_WINDOWING
-    mWndClassName,
+  mPlugWnd = CreateWindowW(mWndClassName,
 #else
-    sWndClassName,
+  mPlugWnd = CreateWindowW(sWndClassName,
 #endif
     L"IPlug", WS_CHILD | WS_VISIBLE | WS_CLIPCHILDREN | WS_CLIPSIBLINGS, x, y, w, h, mParentWnd, 0, mHInstance, this);
 


### PR DESCRIPTION
## Summary
- fix Win32 window class registration by moving preprocessor conditionals outside `if` and `CreateWindowW` calls

## Testing
- `x86_64-w64-mingw32-g++ -c IGraphics/Platforms/IGraphicsWin.cpp -I. -IIGraphics -IIGraphics/Platforms -IIGraphics/Drawing -IIGraphics/Controls -IWDL -IIPlug -IDependencies/IGraphics/NanoSVG/src -IDependencies/IGraphics/NanoVG/src -IDependencies/IGraphics/glad_GL2/include -IDependencies/IGraphics/glad_GL2/src -IDependencies/IGraphics/STB -DIGRAPHICS_NANOVG -DIGRAPHICS_GL2` *(fails: ‘fmodf’/’floorf’ not in std)*

------
https://chatgpt.com/codex/tasks/task_e_68c5fc43e4708329ba2159b8d9c474c4