### PR TITLE
Include logger header in VST3 view

### DIFF
--- a/IPlug/VST3/IPlugVST3_View.h
+++ b/IPlug/VST3/IPlugVST3_View.h
@@ -14,6 +14,7 @@
 #include "pluginterfaces/base/keycodes.h"
 
 #include "IPlugStructs.h"
+#include "IPlugLogger.h"
 
 /** IPlug VST3 View  */
 template <class T>


### PR DESCRIPTION
## Summary
- include `IPlugLogger.h` in `IPlugVST3_View.h` so TRACE is declared

## Testing
- `g++ -std=c++17 /tmp/build_test.cpp -I. -IIPlug -IWDL -IDependencies/vst3sdk-full -DTRACER_BUILD -DOS_LINUX -DNDEBUG` *(fails: expected class-name before ‘,’ token)*

------
https://chatgpt.com/codex/tasks/task_e_68c5fdb1d0408329a241a7cd2ecf206d