### PR TITLE
Centralize OSC and font descriptor separation macros

### DIFF
--- a/IPlug/Extras/OSC/IPlugOSC.h
+++ b/IPlug/Extras/OSC/IPlugOSC.h
@@ -28,13 +28,10 @@
 #include "IPlugOSC_msg.h"
 #include "IPlugPlatform.h"
 #include "IPlugTimer.h"
+#include "InstanceSeparation.h"
 
 
 BEGIN_IPLUG_NAMESPACE
-
-#ifndef IPLUG_SEPARATE_OSC_STATE
-  #define IPLUG_SEPARATE_OSC_STATE 0
-#endif
 
 #ifndef OSC_TIMER_RATE
 static constexpr int OSC_TIMER_RATE = 100;

--- a/IPlug/InstanceSeparation.h
+++ b/IPlug/InstanceSeparation.h
@@ -33,6 +33,11 @@
   #define IPLUG_SEPARATE_SKIA_FONT_CACHE 0
 #endif
 
+#ifndef IPLUG_SEPARATE_FONTDESC_CACHE
+  // Separate CoreText font descriptor caches per IGraphics instance (macOS/iOS)
+  #define IPLUG_SEPARATE_FONTDESC_CACHE 0
+#endif
+
 #ifndef IPLUG_SEPARATE_IOS_TEXTURE_CACHE
   #define IPLUG_SEPARATE_IOS_TEXTURE_CACHE 0
 #endif
@@ -59,6 +64,11 @@
 
 #ifndef IPLUG_SEPARATE_QWERTY_STATE
   #define IPLUG_SEPARATE_QWERTY_STATE 0
+#endif
+
+#ifndef IPLUG_SEPARATE_OSC_STATE
+  // Separate Open Sound Control (OSC) state per plug-in instance
+  #define IPLUG_SEPARATE_OSC_STATE 0
 #endif
 
 #ifndef IPLUG_SEPARATE_BUBBLE_INDEX


### PR DESCRIPTION
## Summary
- declare `IPLUG_SEPARATE_FONTDESC_CACHE` and `IPLUG_SEPARATE_OSC_STATE` in `InstanceSeparation.h`
- include `InstanceSeparation.h` in the OSC module and drop local macro definition

## Testing
- `g++ -std=c++17 -DOS_LINUX=1 -DIPLUG_DUMMY=1 -I. -I./IPlug -I./IPlug/Extras/OSC -I./IGraphics -I./WDL -I./WDL/jnetlib -c IPlug/Extras/OSC/IPlugOSC.cpp` *(fails: NOT IMPLEMENTED)*

------
https://chatgpt.com/codex/tasks/task_e_68c5fec08fec832992716241929a157d