### PR TITLE
Use central InstanceSeparation macros

### DIFF
--- a/IPlug/IPlugLogger.h
+++ b/IPlug/IPlugLogger.h
@@ -32,12 +32,9 @@
 
 #include "IPlugConstants.h"
 #include "IPlugUtilities.h"
+#include "IPlug/InstanceSeparation.h"
 
 BEGIN_IPLUG_NAMESPACE
-
-#ifndef IPLUG_SEPARATE_LOGGER_STATE
-  #define IPLUG_SEPARATE_LOGGER_STATE 0
-#endif
 
 #ifdef NDEBUG
   #define DBGMSG(...)                                                                                                                                                                                  \

--- a/WDL/eel2/eel_lice.h
+++ b/WDL/eel2/eel_lice.h
@@ -1,9 +1,7 @@
 #ifndef _EEL_LICE_H_
 #define _EEL_LICE_H_
 
-#ifndef IPLUG_SEPARATE_EEL_IMAGE_CACHE
-#define IPLUG_SEPARATE_EEL_IMAGE_CACHE 0
-#endif
+#include "IPlug/InstanceSeparation.h"
 
 // #define EEL_LICE_GET_FILENAME_FOR_STRING(idx, fs, p) (((sInst*)opaque)->GetFilenameForParameter(idx,fs,p))
 // #define EEL_LICE_GET_CONTEXT(opaque) (((opaque) ? (((sInst *)opaque)->m_gfx_state) : NULL)

--- a/WDL/swell/swell-fontnamecache.h
+++ b/WDL/swell/swell-fontnamecache.h
@@ -3,9 +3,7 @@
 #include "../mutex.h"
 #include "../assocarray.h"
 
-#ifndef IPLUG_SEPARATE_SWELL_FONTNAME_CACHE
-#define IPLUG_SEPARATE_SWELL_FONTNAME_CACHE 0
-#endif
+#include "IPlug/InstanceSeparation.h"
 
 struct NSString;
 

--- a/WDL/swell/swell-gdi-internalpool.h
+++ b/WDL/swell/swell-gdi-internalpool.h
@@ -20,9 +20,7 @@
   // used for HDC/HGDIOBJ pooling (to avoid excess heap use), used by swell-gdi.mm and swell-gdi-generic.cpp
 */
 
-#ifndef IPLUG_SEPARATE_SWELL_GDI_POOL
-#define IPLUG_SEPARATE_SWELL_GDI_POOL 0
-#endif
+#include "IPlug/InstanceSeparation.h"
 
 #if defined(_DEBUG)
   #define SWELL_GDI_DEBUG

--- a/WDL/swell/swell-timerqueue.h
+++ b/WDL/swell/swell-timerqueue.h
@@ -2,9 +2,7 @@
 
 #include "../mutex.h"
 
-#ifndef IPLUG_SEPARATE_SWELL_TIMER_QUEUE
-#define IPLUG_SEPARATE_SWELL_TIMER_QUEUE 0
-#endif
+#include "IPlug/InstanceSeparation.h"
 
 struct TimerInfoRec;
 


### PR DESCRIPTION
## Summary
- replace local `IPLUG_SEPARATE_*` defines with `#include "IPlug/InstanceSeparation.h"`
- ensure EEL, SWELL and logger headers use shared macro configuration

## Testing
- `cmake -S . -B build` *(fails: The source directory does not appear to contain CMakeLists.txt)*

------
https://chatgpt.com/codex/tasks/task_e_68c600558784832995c307a9fe8af53f