### PR TITLE
Fix TRACE macro include visibility

### DIFF
--- a/IPlug/IPlugEditorDelegate.h
+++ b/IPlug/IPlugEditorDelegate.h
@@ -24,6 +24,7 @@
 #include "IPlugParameter.h"
 #include "IPlugMidi.h"
 #include "IPlugStructs.h"
+#include "IPlugLogger.h"
 
 BEGIN_IPLUG_NAMESPACE
 

--- a/IPlug/IPlugLogger.h
+++ b/IPlug/IPlugLogger.h
@@ -32,7 +32,7 @@
 
 #include "IPlugConstants.h"
 #include "IPlugUtilities.h"
-#include "IPlug/InstanceSeparation.h"
+#include "InstanceSeparation.h"
 
 BEGIN_IPLUG_NAMESPACE
 

--- a/IPlug/IPlugProcessor.h
+++ b/IPlug/IPlugProcessor.h
@@ -25,6 +25,7 @@
 #include "IPlugPlatform.h"
 #include "IPlugConstants.h"
 #include "IPlugStructs.h"
+#include "IPlugLogger.h"
 #include "IPlugUtilities.h"
 #include "NChanDelay.h"
 

--- a/IPlug/VST3/IPlugVST3_Common.h
+++ b/IPlug/VST3/IPlugVST3_Common.h
@@ -11,8 +11,9 @@
 #pragma once
 
 #include "pluginterfaces/base/ibstream.h"
-#
+
 #include "IPlugAPIBase.h"
+#include "IPlugLogger.h"
 #include "IPlugVST3_Parameter.h"
 #include "IPlugVST3_ControllerBase.h"
 


### PR DESCRIPTION
## Summary
- fix IPlugLogger include path so TRACE macro is accessible
- include IPlugLogger in VST3 state and core headers that use TRACE

## Testing
- `x86_64-w64-mingw32-g++ -std=c++17 -DIGRAPHICS_GL2 -c IGraphics/Platforms/IGraphicsWin.cpp -I. -IIGraphics -IIPlug -IWDL -IDependencies/IGraphics/NanoSVG/src` *(fails: glad/glad.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c60625405083298d2fecad715d6d28