### PR TITLE
Simplify CreateWindowW call

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1112,11 +1112,10 @@ void* IGraphicsWin::OpenWindow(void* pParent)
   }
 
 #if IPLUG_SEPARATE_WIN_WINDOWING
-  mPlugWnd = CreateWindowW(mWndClassName,
+  mPlugWnd = CreateWindowW(mWndClassName, L"IPlug", WS_CHILD | WS_VISIBLE | WS_CLIPCHILDREN | WS_CLIPSIBLINGS, x, y, w, h, mParentWnd, 0, mHInstance, this);
 #else
-  mPlugWnd = CreateWindowW(sWndClassName,
+  mPlugWnd = CreateWindowW(sWndClassName, L"IPlug", WS_CHILD | WS_VISIBLE | WS_CLIPCHILDREN | WS_CLIPSIBLINGS, x, y, w, h, mParentWnd, 0, mHInstance, this);
 #endif
-    L"IPlug", WS_CHILD | WS_VISIBLE | WS_CLIPCHILDREN | WS_CLIPSIBLINGS, x, y, w, h, mParentWnd, 0, mHInstance, this);
 
   HDC dc = GetDC(mPlugWnd);
   SetPlatformContext(dc);


### PR DESCRIPTION
## Summary
- inline the window title and style arguments in each CreateWindowW branch to remove conditional continuation

## Testing
- `clang-format --dry-run -Werror -lines=1114:1118 IGraphics/Platforms/IGraphicsWin.cpp`
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68c610128e348329a6021739a3f22762