### PR TITLE
Add optional GLAD support for LICE GL context

### DIFF
--- a/WDL/lice/lice_gl_ctx.cpp
+++ b/WDL/lice/lice_gl_ctx.cpp
@@ -73,13 +73,23 @@ bool LICE_GL_ctx::Init()
   }
 
   // check now for all the extension functions we will ever need
-  if (glewInit() != GLEW_OK ||
-    !glewIsSupported("GL_EXT_framebuffer_object") ||
-    !glewIsSupported("GL_ARB_texture_rectangle"))
+#if defined(GLAD_GL_H) || defined(IGRAPHICS_GL2) || defined(IGRAPHICS_GL3)
+  if (!gladLoadGLLoader((GLADloadproc) wglGetProcAddress) ||
+      !GLAD_GL_EXT_framebuffer_object ||
+      !GLAD_GL_ARB_texture_rectangle)
   {
     Close();
     return false;
   }
+#else
+  if (glewInit() != GLEW_OK ||
+      !glewIsSupported("GL_EXT_framebuffer_object") ||
+      !glewIsSupported("GL_ARB_texture_rectangle"))
+  {
+    Close();
+    return false;
+  }
+#endif
 
   // any one-time initialization goes here
   glPixelStorei(GL_UNPACK_ALIGNMENT, 1);

--- a/WDL/lice/lice_gl_ctx.h
+++ b/WDL/lice/lice_gl_ctx.h
@@ -4,10 +4,14 @@
 #include "lice.h"
 #include "../../IPlug/InstanceSeparation.h"
 
+#if defined(GLAD_GL_H) || defined(IGRAPHICS_GL2) || defined(IGRAPHICS_GL3)
+#include <glad/glad.h>
+#else
 #define GLEW_STATIC
 #include "glew/include/gl/glew.h"
 #include "glew/include/gl/wglew.h"
 #include "glew/include/gl/wglext.h"
+#endif
 
 #define MAX_CACHED_GLYPHS 4096
 


### PR DESCRIPTION
## Summary
- support GLAD as an alternative to GLEW in LICE OpenGL context
- load extensions with gladLoadGLLoader and check GLAD flags when GLAD is present

## Testing
- `x86_64-w64-mingw32-g++ -c WDL/lice/lice_gl_ctx.cpp` *(fails: ‘LICE_GL_ctx::GlyphCache’ is private within this context)*

------
https://chatgpt.com/codex/tasks/task_e_68c61b866ea08329abac2045214801f8