### PR TITLE
Add optional GLAD support for LICE GL context

### DIFF
--- a/WDL/lice/lice_gl_ctx.h
+++ b/WDL/lice/lice_gl_ctx.h
@@ -4,10 +4,15 @@
 #include "lice.h"
 #include "../../IPlug/InstanceSeparation.h"
 
+#ifdef GLAD_GL_H
+#include <glad/glad.h>
+#include <GL/glu.h>
+#else
 #define GLEW_STATIC
-#include "glew/include/gl/glew.h"
-#include "glew/include/gl/wglew.h"
-#include "glew/include/gl/wglext.h"
+#include "glew/include/GL/glew.h"
+#include "glew/include/GL/wglew.h"
+#include "glew/include/GL/wglext.h"
+#endif
 
 #define MAX_CACHED_GLYPHS 4096
 
@@ -46,6 +51,8 @@ private:
 
   GlyphCache m_glyphCache[MAX_CACHED_GLYPHS];
   int m_nCachedGlyphs;
+
+  static int GlyphCacheCmp(const void* p1, const void* p2);
 };
 
 // GL context functions


### PR DESCRIPTION
## Summary
- support GLAD as an alternative to GLEW in LICE OpenGL context
- load extensions with gladLoadGLLoader and check GLAD flags when GLAD is present
- fix GLU/GLEW includes and make glyph cache comparator an internal static helper
- avoid forcing GLAD when building with GLEW-only projects

## Testing
- `g++ -c WDL/lice/lice_gl_ctx.cpp -I WDL/lice/glew/include` *(fails: GL/glu.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c61b866ea08329abac2045214801f8