### PR TITLE
Add optional GLAD support for LICE GL context

### DIFF
--- a/WDL/lice/lice_gl_ctx.cpp
+++ b/WDL/lice/lice_gl_ctx.cpp
@@ -72,14 +72,24 @@ bool LICE_GL_ctx::Init()
     return false;
   }
 
-  // check now for all the extension functions we will ever need
-  if (glewInit() != GLEW_OK ||
-    !glewIsSupported("GL_EXT_framebuffer_object") ||
-    !glewIsSupported("GL_ARB_texture_rectangle"))
+// check now for all the extension functions we will ever need
+#if defined(GLAD_GL_H) || defined(IGRAPHICS_GL2) || defined(IGRAPHICS_GL3)
+  if (!gladLoadGLLoader((GLADloadproc) wglGetProcAddress) ||
+      !GLAD_GL_EXT_framebuffer_object ||
+      !GLAD_GL_ARB_texture_rectangle)
   {
     Close();
     return false;
   }
+#else
+  if (glewInit() != GLEW_OK ||
+      !glewIsSupported("GL_EXT_framebuffer_object") ||
+      !glewIsSupported("GL_ARB_texture_rectangle"))
+  {
+    Close();
+    return false;
+  }
+#endif
 
   // any one-time initialization goes here
   glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
@@ -142,10 +152,10 @@ void LICE_GL_ctx::ClearTex()
   m_nCachedGlyphs = 0;
 }
 
-static int _glyphcmp(const void* p1, const void* p2)
+int LICE_GL_ctx::GlyphCacheCmp(const void* p1, const void* p2)
 {
-  LICE_GL_ctx::GlyphCache* gc1 = (LICE_GL_ctx::GlyphCache*) p1;
-  LICE_GL_ctx::GlyphCache* gc2 = (LICE_GL_ctx::GlyphCache*) p2;
+  const GlyphCache* gc1 = (const GlyphCache*) p1;
+  const GlyphCache* gc2 = (const GlyphCache*) p2;
 
   if (gc1->glyph_w < gc2->glyph_w) return -1;
   if (gc1->glyph_w > gc2->glyph_w) return 1;
@@ -164,7 +174,7 @@ int LICE_GL_ctx::GetTexFromGlyph(const unsigned char* glyph, int glyph_w, int gl
   gc.glyph_w = glyph_w;
   gc.glyph_h = glyph_h;
 
-  GlyphCache* p = (GlyphCache*) bsearch(&gc, m_glyphCache, m_nCachedGlyphs, sizeof(GlyphCache), _glyphcmp);
+  GlyphCache* p = (GlyphCache*) bsearch(&gc, m_glyphCache, m_nCachedGlyphs, sizeof(GlyphCache), GlyphCacheCmp);
   if (p) return p->tex;
 
   glGenTextures(1, &gc.tex);
@@ -178,7 +188,7 @@ int LICE_GL_ctx::GetTexFromGlyph(const unsigned char* glyph, int glyph_w, int gl
   gc.glyph = (unsigned char*) malloc(glyph_w*glyph_h);
   memcpy(gc.glyph, glyph, glyph_w*glyph_h);
   m_glyphCache[m_nCachedGlyphs++] = gc; // copy
-  qsort(m_glyphCache, m_nCachedGlyphs, sizeof(GlyphCache), _glyphcmp);
+  qsort(m_glyphCache, m_nCachedGlyphs, sizeof(GlyphCache), GlyphCacheCmp);
 
   return gc.tex;
 }

--- a/WDL/lice/lice_gl_ctx.h
+++ b/WDL/lice/lice_gl_ctx.h
@@ -1,13 +1,18 @@
 #ifndef _GL_CTX_
 #define _GL_CTX_
 
+#if defined(GLAD_GL_H) || defined(IGRAPHICS_GL2) || defined(IGRAPHICS_GL3)
+#include <glad/glad.h>
+#include <GL/glu.h>
+#else
+#define GLEW_STATIC
+#include "glew/include/GL/glew.h"
+#include "glew/include/GL/wglew.h"
+#include "glew/include/GL/WGLEXT.H"
+#endif
+
 #include "lice.h"
 #include "../../IPlug/InstanceSeparation.h"
-
-#define GLEW_STATIC
-#include "glew/include/gl/glew.h"
-#include "glew/include/gl/wglew.h"
-#include "glew/include/gl/wglext.h"
 
 #define MAX_CACHED_GLYPHS 4096
 
@@ -46,6 +51,8 @@ private:
 
   GlyphCache m_glyphCache[MAX_CACHED_GLYPHS];
   int m_nCachedGlyphs;
+
+  static int GlyphCacheCmp(const void* p1, const void* p2);
 };
 
 // GL context functions


### PR DESCRIPTION
## Summary
- support GLAD as an alternative to GLEW in LICE OpenGL context
- load extensions with gladLoadGLLoader and check GLAD flags when GLAD is present
- fix GLEW include ordering and casing to avoid gl.h/glew.h conflicts
- avoid forcing GLAD when building with GLEW-only projects

## Testing
- `g++ -c WDL/lice/lice_gl_ctx.cpp -I WDL/lice/glew/include` *(fails: windows.h: No such file or directory)*
- `x86_64-w64-mingw32-g++ -c WDL/lice/lice_gl_ctx.cpp -I WDL/lice/glew/include` *(fails: __int64 does not name a type)*

------
https://chatgpt.com/codex/tasks/task_e_68c61b866ea08329abac2045214801f8