### PR TITLE
Clean up GL context initialization

### DIFF
--- a/WDL/lice/lice_gl_ctx.cpp
+++ b/WDL/lice/lice_gl_ctx.cpp
@@ -74,7 +74,6 @@ bool LICE_GL_ctx::Init()
 
 
 #if defined(GLAD_GL_H) || defined(IGRAPHICS_GL2) || defined(IGRAPHICS_GL3)
- _codex-plugin-instance-seperation
   if (!gladLoadGLLoader((GLADloadproc) wglGetProcAddress) ||
       !GLAD_GL_EXT_framebuffer_object ||
       !GLAD_GL_ARB_texture_rectangle)


### PR DESCRIPTION
## Summary
- remove stray codex separator directive from GL context initialization

## Testing
- `x86_64-w64-mingw32-g++ -std=c++17 -c WDL/lice/lice_gl_ctx.cpp -IDependencies/IGraphics/glad_GL3/include -I. -DIGRAPHICS_GL3 -DGL_TEXTURE_RECTANGLE_ARB=0x84F5 -DGLAD_GL_EXT_framebuffer_object=1 -DGLAD_GL_ARB_texture_rectangle=1 -v`

------
https://chatgpt.com/codex/tasks/task_e_68c6272f49188329a6199abebb6cbeaa