### PR TITLE
Link GLU library for Windows LICE GL builds

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -36,6 +36,8 @@ using namespace igraphics;
 #pragma warning(disable:4312) // Pointer size cast mismatch.
 #pragma warning(disable:4311) // Pointer size cast mismatch.
 
+#pragma comment(lib, "glu32.lib")
+
 #if IPLUG_SEPARATE_WIN_WINDOWING
 // Per-instance windowing variables are stored on the IGraphicsWin instance
 #else


### PR DESCRIPTION
## Summary
- Link `glu32.lib` on Windows so builds using the LICE OpenGL context resolve GLU symbols

## Testing
- `x86_64-w64-mingw32-g++ /tmp/test_glu.cpp -o /tmp/test_glu.exe` *(fails: undefined reference to `gluNewNurbsRenderer`)*
- `x86_64-w64-mingw32-g++ /tmp/test_glu.cpp -lglu32 -lopengl32 -o /tmp/test_glu.exe`
- `ls -l /tmp/test_glu.exe`


------
https://chatgpt.com/codex/tasks/task_e_68c628ae16ac8329806a7913d9736560