### PR TITLE
Centralize OpenGL loader selection

### DIFF
--- a/IGraphics/IGraphics_include_in_plug_hdr.h
+++ b/IGraphics/IGraphics_include_in_plug_hdr.h
@@ -35,7 +35,16 @@
   #endif
 #elif defined IGRAPHICS_GL2 || defined IGRAPHICS_GL3
   #if defined OS_WIN
-    #include <glad/glad.h>
+    #if defined(USE_GLAD)
+      #include <glad/glad.h>
+    #elif defined(USE_GLEW)
+      #define GLEW_STATIC
+      #include "../WDL/lice/glew/include/GL/glew.h"
+      #include "../WDL/lice/glew/include/GL/wglew.h"
+      #include "../WDL/lice/glew/include/GL/WGLEXT.H"
+    #else
+      #error Define USE_GLAD or USE_GLEW to select the OpenGL loader
+    #endif
   #elif defined OS_MAC
     #if defined IGRAPHICS_GL2
       #include <OpenGL/gl.h>

--- a/IGraphics/IGraphics_select.h
+++ b/IGraphics/IGraphics_select.h
@@ -34,7 +34,16 @@
   #elif defined IGRAPHICS_GL2 || defined IGRAPHICS_GL3
     #define IGRAPHICS_GL
     #if defined OS_WIN
-      #include <glad/glad.h>
+      #if defined(USE_GLAD)
+        #include <glad/glad.h>
+      #elif defined(USE_GLEW)
+        #define GLEW_STATIC
+        #include "../WDL/lice/glew/include/GL/glew.h"
+        #include "../WDL/lice/glew/include/GL/wglew.h"
+        #include "../WDL/lice/glew/include/GL/WGLEXT.H"
+      #else
+        #error Define USE_GLAD or USE_GLEW to select the OpenGL loader
+      #endif
     #elif defined OS_MAC
       #if defined IGRAPHICS_GL2
         #include <OpenGL/gl.h>

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1034,8 +1034,15 @@ void IGraphicsWin::CreateGLContext()
 #endif
 
   //TODO: return false if GL init fails?
+#if defined(USE_GLAD)
   if (!gladLoadGL())
     DBGMSG("Error initializing glad");
+#elif defined(USE_GLEW)
+  if (glewInit() != GLEW_OK)
+    DBGMSG("Error initializing glew");
+#else
+  #error Define USE_GLAD or USE_GLEW to select the OpenGL loader
+#endif
 
   glGetError();
 
@@ -2442,7 +2449,14 @@ void IGraphicsWin::VBlankNotify()
 #if defined IGRAPHICS_SKIA
   #include "IGraphicsSkia.cpp"
   #ifdef IGRAPHICS_GL
-    #include "glad.c"
+    #if defined(USE_GLAD)
+      #include "glad.c"
+    #elif defined(USE_GLEW)
+      #define GLEW_STATIC
+      #include "../../WDL/lice/glew/src/glew.c"
+    #else
+      #error Define USE_GLAD or USE_GLEW to select the OpenGL loader
+    #endif
   #endif
 #elif defined IGRAPHICS_NANOVG
   #include "IGraphicsNanoVG.cpp"
@@ -2451,7 +2465,14 @@ void IGraphicsWin::VBlankNotify()
   #pragma comment(lib, "freetype.lib")
 #endif
   #include "nanovg.c"
-  #include "glad.c"
+  #if defined(USE_GLAD)
+    #include "glad.c"
+  #elif defined(USE_GLEW)
+    #define GLEW_STATIC
+    #include "../../WDL/lice/glew/src/glew.c"
+  #else
+    #error Define USE_GLAD or USE_GLEW to select the OpenGL loader
+  #endif
 #else
   #error
 #endif

--- a/WDL/lice/lice_gl_ctx.cpp
+++ b/WDL/lice/lice_gl_ctx.cpp
@@ -73,7 +73,7 @@ bool LICE_GL_ctx::Init()
   }
 
 
-#if defined(GLAD_GL_H) || defined(IGRAPHICS_GL2) || defined(IGRAPHICS_GL3)
+#if defined(USE_GLAD)
   if (!gladLoadGLLoader((GLADloadproc) wglGetProcAddress) ||
       !GLAD_GL_EXT_framebuffer_object ||
       !GLAD_GL_ARB_texture_rectangle)
@@ -81,7 +81,7 @@ bool LICE_GL_ctx::Init()
     Close();
     return false;
   }
-#else
+#elif defined(USE_GLEW)
   if (glewInit() != GLEW_OK ||
       !glewIsSupported("GL_EXT_framebuffer_object") ||
       !glewIsSupported("GL_ARB_texture_rectangle"))
@@ -89,6 +89,8 @@ bool LICE_GL_ctx::Init()
     Close();
     return false;
   }
+#else
+  #error Define USE_GLAD or USE_GLEW to select the OpenGL loader
 #endif
 
   // any one-time initialization goes here

--- a/WDL/lice/lice_gl_ctx.h
+++ b/WDL/lice/lice_gl_ctx.h
@@ -1,14 +1,16 @@
 #ifndef _GL_CTX_
 #define _GL_CTX_
 
-#if defined(GLAD_GL_H) || defined(IGRAPHICS_GL2) || defined(IGRAPHICS_GL3)
+#if defined(USE_GLAD)
 #include <glad/glad.h>
 #include <GL/glu.h>
-#else
+#elif defined(USE_GLEW)
 #define GLEW_STATIC
 #include "glew/include/GL/glew.h"
 #include "glew/include/GL/wglew.h"
 #include "glew/include/GL/WGLEXT.H"
+#else
+#error Define USE_GLAD or USE_GLEW to select the OpenGL loader
 #endif
 
 #include "lice.h"


### PR DESCRIPTION
## Summary
- Allow choosing between GLAD and GLEW via USE_GLAD / USE_GLEW macro
- Initialize the matching loader in LICE and Windows platform code
- Wrap IGraphics headers and platform includes to avoid conflicting loaders

## Testing
- `g++ -DUSE_GLAD -I. -c WDL/lice/lice_gl_ctx.cpp -o /tmp/lice_gl_ctx.o` *(fails: glad/glad.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c629bc8e808329b56cc3bd259b9e73