### PR TITLE
Handle per-instance GL context

### DIFF
--- a/WDL/lice/lice_glbitmap.cpp
+++ b/WDL/lice/lice_glbitmap.cpp
@@ -3,16 +3,24 @@
 
 #include "../plush2/plush.h"
 
+#if IPLUG_SEPARATE_GL_CONTEXT
+LICE_GLBitmap::LICE_GLBitmap(LICE_GL_ctx* ctx)
+{
+  m_bmp = 0;
+  m_fbo = 0;
+  m_tex = 0;
+  m_bufloc = EMPTY;
+  m_ctx = ctx;
+}
+#else
 LICE_GLBitmap::LICE_GLBitmap()
 {
   m_bmp = 0;
   m_fbo = 0;
   m_tex = 0;
   m_bufloc = EMPTY;
-#if IPLUG_SEPARATE_GL_CONTEXT
-  m_ctx = nullptr;
-#endif
 }
+#endif
 
 // This is separate from the constructor for initialization order reasons
 #if IPLUG_SEPARATE_GL_CONTEXT


### PR DESCRIPTION
## Summary
- Allow `LICE_GLBitmap` to receive a `LICE_GL_ctx*` when `IPLUG_SEPARATE_GL_CONTEXT` is enabled so each `IGraphics` can supply its own GL context

## Testing
- `make` (fails: Package gdk-3.0 was not found)

------
https://chatgpt.com/codex/tasks/task_e_68c62b4988e08329a2766a65a2e65013