### PR TITLE
Add conditional GLAD includes for GDK backend

### DIFF
--- a/WDL/swell/swell-generic-gdk.cpp
+++ b/WDL/swell/swell-generic-gdk.cpp
@@ -53,8 +53,13 @@ extern "C" {
 
 #include <X11/Xatom.h>
 
-#include <GL/gl.h>
-#include <GL/glx.h>
+#if defined(USE_GLAD)
+  #include <glad/glad.h>
+  #include <GL/glx.h>   // still required for GLX functions
+#else
+  #include <GL/gl.h>
+  #include <GL/glx.h>
+#endif
 
 static void (*_gdk_drag_drop_done)(GdkDragContext *, gboolean); // may not always be available
 


### PR DESCRIPTION
## Summary
- Conditionally include GLAD headers when USE_GLAD is defined for the GDK backend

## Testing
- `make` *(fails: gdk/gdk.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c62ed4fac08329a1499b4d9ef29e67