### PR TITLE
Add GLAD loader support on non-Windows platforms

### DIFF
--- a/IGraphics/IGraphics_include_in_plug_hdr.h
+++ b/IGraphics/IGraphics_include_in_plug_hdr.h
@@ -46,13 +46,21 @@
       #error Define USE_GLAD or USE_GLEW to select the OpenGL loader
     #endif
   #elif defined OS_MAC
-    #if defined IGRAPHICS_GL2
-      #include <OpenGL/gl.h>
-    #elif defined IGRAPHICS_GL3
-      #include <OpenGL/gl3.h>
+    #if defined(USE_GLAD)
+      #include <glad/glad.h>
+    #else
+      #if defined IGRAPHICS_GL2
+        #include <OpenGL/gl.h>
+      #elif defined IGRAPHICS_GL3
+        #include <OpenGL/gl3.h>
+      #endif
     #endif
   #else
-    #include <OpenGL/gl.h>
+    #if defined(USE_GLAD)
+      #include <glad/glad.h>
+    #else
+      #include <OpenGL/gl.h>
+    #endif
   #endif
 #endif
 

--- a/IGraphics/IGraphics_select.h
+++ b/IGraphics/IGraphics_select.h
@@ -45,13 +45,21 @@
         #error Define USE_GLAD or USE_GLEW to select the OpenGL loader
       #endif
     #elif defined OS_MAC
-      #if defined IGRAPHICS_GL2
-        #include <OpenGL/gl.h>
-      #elif defined IGRAPHICS_GL3
-        #include <OpenGL/gl3.h>
+      #if defined(USE_GLAD)
+        #include <glad/glad.h>
+      #else
+        #if defined IGRAPHICS_GL2
+          #include <OpenGL/gl.h>
+        #elif defined IGRAPHICS_GL3
+          #include <OpenGL/gl3.h>
+        #endif
       #endif
     #else
-      #include <OpenGL/gl.h>
+      #if defined(USE_GLAD)
+        #include <glad/glad.h>
+      #else
+        #include <OpenGL/gl.h>
+      #endif
     #endif
   #endif
 


### PR DESCRIPTION
## Summary
- Allow using GLAD on macOS and other non-Windows builds by conditionally including `glad/glad.h`
- Fallback to platform OpenGL headers when `USE_GLAD` is not defined

## Testing
- `g++ -std=c++17 -fsyntax-only -I. -IIPlug -IIGraphics/Platforms -IDependencies/IGraphics/glad_GL3/include -DIGRAPHICS_GL3 -DOS_MAC -DUSE_GLAD IGraphics/IGraphics_include_in_plug_hdr.h` *(fails: CoreGraphics/CoreGraphics.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c62edcf7108329971751d51cfe26c0