### PR TITLE
Add GLAD fallback for macOS OpenGL includes

### DIFF
--- a/IGraphics/Drawing/IGraphicsNanoVG.cpp
+++ b/IGraphics/Drawing/IGraphicsNanoVG.cpp
@@ -18,7 +18,11 @@
     #if defined IGRAPHICS_GL2
       #define NANOVG_GL2_IMPLEMENTATION
     #elif defined IGRAPHICS_GL3
-      #include <OpenGL/gl3.h>
+      #if defined(USE_GLAD)
+        #include <glad/glad.h>
+      #else
+        #include <OpenGL/gl3.h>
+      #endif
       #define NANOVG_GL3_IMPLEMENTATION
     #else
       #error Define either IGRAPHICS_GL2 or IGRAPHICS_GL3 for IGRAPHICS_NANOVG with OS_MAC

--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -38,7 +38,11 @@
   #if defined IGRAPHICS_GL2
     #error SKIA doesn't work correctly with IGRAPHICS_GL2
   #elif defined IGRAPHICS_GL3
-    #include <OpenGL/gl3.h>
+    #if defined(USE_GLAD)
+      #include <glad/glad.h>
+    #else
+      #include <OpenGL/gl3.h>
+    #endif
   #elif defined IGRAPHICS_METAL
     // even though this is a .cpp we are in an objc(pp) compilation unit
     #include "include/gpu/ganesh/mtl/GrMtlBackendContext.h"


### PR DESCRIPTION
## Summary
- allow using GLAD instead of the system OpenGL headers for macOS GL3 builds in NanoVG and Skia backends
- ensure conditional GL3 includes use GLAD when available

## Testing
- `clang-format -i IGraphics/Drawing/IGraphicsNanoVG.cpp IGraphics/Drawing/IGraphicsSkia.cpp`
- `g++ -std=c++17 -fsyntax-only -DIGRAPHICS_GL -DIGRAPHICS_GL3 -DOS_MAC -DUSE_GLAD -DIGRAPHICS_NANOVG -I. -IIGraphics -IIPlug -IWDL -IDependencies/IGraphics/glad_GL3/include -IDependencies/IGraphics/NanoVG/src -IDependencies/IGraphics/NanoSVG/src IGraphics/Drawing/IGraphicsNanoVG.cpp` (fails: missing CoreText/CoreText.h)
- `g++ -std=c++17 -fsyntax-only -DIGRAPHICS_GL -DIGRAPHICS_GL3 -DOS_MAC -DUSE_GLAD -DIGRAPHICS_SKIA -I. -IIGraphics -IIPlug -IWDL -IDependencies/IGraphics/glad_GL3/include IGraphics/Drawing/IGraphicsSkia.cpp` (fails: missing SkSVGDOM.h)


------
https://chatgpt.com/codex/tasks/task_e_68c62edb41d883298eef78ffdda7f321