### PR TITLE
Add Vulkan build option for Skia on Windows

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.h
+++ b/IGraphics/Drawing/IGraphicsSkia.h
@@ -10,6 +10,8 @@
 
 #if defined IGRAPHICS_GL
   #define SK_GL
+#elif defined IGRAPHICS_VULKAN
+  #define SK_VULKAN
 #endif
 
 #pragma warning(push)

--- a/common-win.props
+++ b/common-win.props
@@ -25,7 +25,11 @@
     <STATIC_LIBS_PATH>$(DEPS_PATH)\Build\win\$(Platform)\$(Configuration)</STATIC_LIBS_PATH>
     <ICUDAT_PATH>$(DEPS_PATH)\Build\win\bin\icudtl.dat</ICUDAT_PATH>
     <YOGA_INC_PATHS>$(IGRAPHICS_DEPS_PATH)\yoga;$(IGRAPHICS_DEPS_PATH)\yoga\yoga</YOGA_INC_PATHS>
-    <IGRAPHICS_INC_PATHS>$(IGRAPHICS_PATH);$(IGRAPHICS_PATH)\Controls;$(IGRAPHICS_PATH)\Drawing;$(IGRAPHICS_PATH)\Platforms;$(IGRAPHICS_PATH)\Extras;$(NANOSVG_PATH);$(NANOVG_PATH);$(PNG_PATH);$(ZLIB_PATH);$(FREETYPE_PATH);$(STB_PATH);$(SKIA_INC_PATHS);$(YOGA_INC_PATHS)</IGRAPHICS_INC_PATHS>
+    <VULKAN_SDK_PATH Condition="'$(VULKAN_SDK)' != ''">$(VULKAN_SDK)</VULKAN_SDK_PATH>
+    <VULKAN_INC_PATHS Condition="'$(VULKAN_SDK_PATH)' != ''">$(VULKAN_SDK_PATH)\Include</VULKAN_INC_PATHS>
+    <VULKAN_LIB_PATHS Condition="'$(VULKAN_SDK_PATH)' != ''">$(VULKAN_SDK_PATH)\Lib</VULKAN_LIB_PATHS>
+    <VULKAN_LIBS Condition="'$(VULKAN_SDK_PATH)' != ''">vulkan-1.lib;</VULKAN_LIBS>
+    <IGRAPHICS_INC_PATHS>$(IGRAPHICS_PATH);$(IGRAPHICS_PATH)\Controls;$(IGRAPHICS_PATH)\Drawing;$(IGRAPHICS_PATH)\Platforms;$(IGRAPHICS_PATH)\Extras;$(NANOSVG_PATH);$(NANOVG_PATH);$(PNG_PATH);$(ZLIB_PATH);$(FREETYPE_PATH);$(STB_PATH);$(SKIA_INC_PATHS);$(YOGA_INC_PATHS);$(VULKAN_INC_PATHS)</IGRAPHICS_INC_PATHS>
     <CLAP_SDK Condition="'$(CLAP_SDK)'==''">$(IPLUG_DEPS_PATH)\CLAP_SDK\include</CLAP_SDK>
     <CLAP_HELPERS Condition="'$(CLAP_HELPERS)'==''">$(IPLUG_DEPS_PATH)\CLAP_HELPERS\include\clap\helpers</CLAP_HELPERS>
     <VST2_SDK Condition="'$(VST2_SDK)'==''">$(IPLUG_DEPS_PATH)\VST2_SDK</VST2_SDK>
@@ -89,8 +93,8 @@
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
     </ItemDefinitionGroup>
     <Link>
-      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(STATIC_LIBS_PATH);$(AAX_SDK)\Libs\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>$(VULKAN_LIBS)%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(STATIC_LIBS_PATH);$(AAX_SDK)\Libs\$(Configuration);$(VULKAN_LIB_PATHS);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ImportLibrary>$(IntDir)$(TargetName).lib</ImportLibrary>
     </Link>
     <Lib>


### PR DESCRIPTION
## Summary
- enable Skia's Vulkan backend when `IGRAPHICS_VULKAN` is defined
- allow Windows builds to locate Vulkan SDK includes and libraries

## Testing
- `xmllint --noout common-win.props`
- `clang++ -fsyntax-only -std=c++17 IGraphics/Drawing/IGraphicsSkia.cpp` *(fails: 'IGraphics.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c69e78755c8329877b88b015f1a8c1