### PR TITLE
Add Vulkan rendering context for Windows

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -19,6 +19,12 @@
 #include <vector>
 #include <string>
 
+#ifdef IGRAPHICS_VULKAN
+#define VK_USE_PLATFORM_WIN32_KHR
+#include <vulkan/vulkan.h>
+#include <vulkan/vulkan_win32.h>
+#endif
+
 
 BEGIN_IPLUG_NAMESPACE
 BEGIN_IGRAPHICS_NAMESPACE
@@ -135,7 +141,21 @@ private:
 
   void ActivateGLContext() override;
   void DeactivateGLContext() override;
-  
+
+#ifdef IGRAPHICS_VULKAN
+  void CreateVulkanContext(); // Vulkan context management
+  void DestroyVulkanContext();
+  void ActivateVulkanContext();
+  void DeactivateVulkanContext();
+  VkInstance mVkInstance = VK_NULL_HANDLE;
+  VkDevice mVkDevice = VK_NULL_HANDLE;
+  VkSurfaceKHR mVkSurface = VK_NULL_HANDLE;
+  VkSwapchainKHR mVkSwapchain = VK_NULL_HANDLE;
+  VkQueue mPresentQueue = VK_NULL_HANDLE;
+  VkSemaphore mImageAvailableSemaphore = VK_NULL_HANDLE;
+  VkSemaphore mRenderFinishedSemaphore = VK_NULL_HANDLE;
+#endif
+
 #ifdef IGRAPHICS_GL
   void CreateGLContext(); // OpenGL context management - TODO: RAII instead ?
   void DestroyGLContext();


### PR DESCRIPTION
## Summary
- add Vulkan context creation and lifecycle handling on Windows
- create Win32 Vulkan surface and swap-chain presentation
- integrate Vulkan activation and cleanup into window management

## Testing
- `clang-format -n IGraphics/Platforms/IGraphicsWin.h IGraphics/Platforms/IGraphicsWin.cpp` *(warnings: code should be clang-formatted)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a0eb26788329a8c745dde1f37b46