### PR TITLE
Enable Vulkan build option and correct Windows Vulkan init

### DIFF
--- a/Dependencies/IGraphics/build-skia-win.sh
+++ b/Dependencies/IGraphics/build-skia-win.sh
@@ -13,7 +13,7 @@ TMP_DIR="$BASE_DIR/tmp/skia"
 WIN_LIB_DIR="$BASE_DIR/win"
 WIN_BIN_DIR="$BASE_DIR/win/bin"
 
-ERROR_MSG="Error: Please provide 'Debug' or 'Release' as the first argument, and 'x64' or 'Win32' as the second argument."
+ERROR_MSG="Error: Please provide 'Debug' or 'Release' as the first argument, and 'x64' or 'Win32' as the second argument. Optionally pass --vulkan to enable Vulkan support."
 
 LIBS=(
   "skia.lib"
@@ -65,6 +65,12 @@ generate_build_files() {
   else
     extra_args="$extra_args
       target_cpu = \"x64\"
+    "
+  fi
+
+  if [ "$USE_VULKAN" = true ]; then
+    extra_args="$extra_args
+      skia_use_vulkan = true
     "
   fi
 
@@ -141,13 +147,19 @@ move_libs() {
 }
 
 main() {
-  if [ "$#" -ne 2 ]; then
+  if [ "$#" -lt 2 ]; then
     echo "$ERROR_MSG"
     exit 1
   fi
 
   local config=$1
   local arch=$2
+  local option=$3
+
+  USE_VULKAN=false
+  if [ "$option" = "--vulkan" ]; then
+    USE_VULKAN=true
+  fi
 
   case "$config" in
     "Debug"|"Release") ;;

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -570,21 +570,6 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
           ScopedGLContext scopedGLCtx {pGraphics};
           pGraphics->Draw(rects);
           SwapBuffers((HDC) pGraphics->GetPlatformContext());
-#elif defined IGRAPHICS_VULKAN
-          ScopedGLContext scopedGLCtx {pGraphics};
-          pGraphics->Draw(rects);
-          IGraphicsWin* pWin = static_cast<IGraphicsWin*>(pGraphics);
-          if (pWin->mVkDevice && pWin->mVkSwapchain)
-          {
-            uint32_t imageIndex = 0;
-            vkAcquireNextImageKHR(pWin->mVkDevice, pWin->mVkSwapchain, UINT64_MAX, pWin->mImageAvailableSemaphore, VK_NULL_HANDLE, &imageIndex);
-            VkPresentInfoKHR presentInfo = {};
-            presentInfo.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
-            presentInfo.swapchainCount = 1;
-            presentInfo.pSwapchains = &pWin->mVkSwapchain;
-            presentInfo.pImageIndices = &imageIndex;
-            vkQueuePresentKHR(pWin->mPresentQueue, &presentInfo);
-          }
 #else
           pGraphics->Draw(rects);
 #endif
@@ -1148,9 +1133,8 @@ void* IGraphicsWin::OpenWindow(void* pParent)
 
   mPlugWnd = CreateWindowW(wndClassName, L"IPlug", WS_CHILD | WS_VISIBLE | WS_CLIPCHILDREN | WS_CLIPSIBLINGS, x, y, w, h, mParentWnd, 0, mHInstance, this);
 #if defined IGRAPHICS_VULKAN
-  CreateVulkanContext();
-  SetPlatformContext((void*) mVkSurface);
-  OnViewInitialized((void*) mVkSurface);
+  SetPlatformContext(mPlugWnd);
+  OnViewInitialized(mPlugWnd);
 #else
   HDC dc = GetDC(mPlugWnd);
   SetPlatformContext(dc);

--- a/Scripts/ci/build_deps.yml
+++ b/Scripts/ci/build_deps.yml
@@ -52,10 +52,10 @@ jobs:
     inputs:
       versionSpec: '3.8'
 
-  - bash: |
-      cd ./Dependencies/IGraphics
-      ./build-skia-win.sh $(buildConfiguration) $(buildPlatform)
-    displayName: Build SKIA
+    - bash: |
+        cd ./Dependencies/IGraphics
+        ./build-skia-win.sh $(buildConfiguration) $(buildPlatform) --vulkan
+      displayName: Build SKIA
 
   - bash: |
       cd ./Dependencies/Build

--- a/Scripts/ci/build_project-win.yml
+++ b/Scripts/ci/build_project-win.yml
@@ -31,6 +31,10 @@ steps:
       then
         cd ./${{parameters.path}}/${{parameters.name}}/config
         sed -i.bu 's/IGRAPHICS_NANOVG;IGRAPHICS_GL2/IGRAPHICS_SKIA;IGRAPHICS_GL2/' ${{parameters.name}}-win.props
+      elif [ $graphics = "SKIA_VULKAN" ]
+      then
+        cd ./${{parameters.path}}/${{parameters.name}}/config
+        sed -i.bu 's/IGRAPHICS_NANOVG;IGRAPHICS_GL2/IGRAPHICS_SKIA;IGRAPHICS_VULKAN/' ${{parameters.name}}-win.props
       fi
     displayName: Set graphics string to ${{parameters.graphics}}
 


### PR DESCRIPTION
## Summary
- add Vulkan option to Windows build scripts
- adjust dependency build to compile Skia with Vulkan
- fix Windows platform initialization for Vulkan surfaces

## Testing
- `bash -n Dependencies/IGraphics/build-skia-win.sh`
- `clang-format --dry-run IGraphics/Platforms/IGraphicsWin.cpp` *(fails: code should be clang-formatted)*
- `yamllint Scripts/ci/build_project-win.yml` *(fails: command not found)*
- `yamllint Scripts/ci/build_deps.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a463cc408329ae5f1f150ea64a2d