### PR TITLE
Improve Vulkan initialization and swapchain handling

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -120,6 +120,7 @@ public:
 
 #ifdef IGRAPHICS_VULKAN
   void UpdateVulkanSwapchain(VkSwapchainKHR swapchain, const std::vector<VkImage>& images);
+  VkResult CreateOrResizeVulkanSwapchain(uint32_t width, uint32_t height, VkSwapchainKHR& swapchain, std::vector<VkImage>& images);
 #endif
 
 protected:


### PR DESCRIPTION
## Summary
- Add comprehensive Vulkan result checks and swapchain recreation logic
- Prefer discrete GPUs and validate Vulkan extensions during device selection
- Enable Vulkan validation layers in debug builds

## Testing
- `cmake -S . -B build` *(fails: The source directory does not contain CMakeLists.txt)*

------
https://chatgpt.com/codex/tasks/task_e_68c6aca31410832996e2cc7667a5e13b