### PR TITLE
Clear Skia references after Vulkan teardown

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -549,6 +549,11 @@ void IGraphicsSkia::OnViewDestroyed()
   mVKSwapchain = nullptr;
   mVKQueue = nullptr;
   mVKSwapchainImages.clear();
+
+  // Release Skia references after Vulkan cleanup
+  mSurface = nullptr;
+  mScreenSurface = nullptr;
+  mGrContext = nullptr;
 #endif
 }
 


### PR DESCRIPTION
## Summary
- Clear Skia surfaces and context after Vulkan teardown to avoid lingering references

## Testing
- `g++ -std=c++17 -DIGRAPHICS_VULKAN -IIGraphics -I. -c IGraphics/Drawing/IGraphicsSkia.cpp` *(fails: IPlugConstants.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c6af35ca78832986eafd78cf11c8d5