### PR TITLE
Handle Vulkan swapchain recreation

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.h
+++ b/IGraphics/Drawing/IGraphicsSkia.h
@@ -195,6 +195,7 @@ private:
   void* mVKImageAvailableSemaphore = nullptr;
   void* mVKRenderFinishedSemaphore = nullptr;
   void* mVKInFlightFence = nullptr;
+  bool mVKSkipFrame = false;
 #endif
 
   static StaticStorage<Font> sFontCache;


### PR DESCRIPTION
## Summary
- recreate Vulkan swapchain when `vkAcquireNextImageKHR` or `vkQueuePresentKHR` returns `VK_ERROR_OUT_OF_DATE_KHR`/`VK_SUBOPTIMAL_KHR`
- skip the current frame and wait for idle before rebuilding the swapchain
- track skipped frames to avoid submitting/presenting invalid work

## Testing
- `clang-format -i IGraphics/Drawing/IGraphicsSkia.h IGraphics/Drawing/IGraphicsSkia.cpp`
- `g++ -std=c++17 -DIGRAPHICS_VULKAN -I. -IIGraphics -c IGraphics/Drawing/IGraphicsSkia.cpp` *(fails: IPlugConstants.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c6aff8312883299335025383cb00fa