### PR TITLE
Integrate platform Vulkan sync with Skia

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -14,15 +14,15 @@
 #include <windowsx.h>
 #include <winuser.h>
 
-#include "IGraphics_select.h"
 #include "IGraphicsWinFonts.h"
-#include <vector>
+#include "IGraphics_select.h"
 #include <string>
+#include <vector>
 
 #ifdef IGRAPHICS_VULKAN
-#define VK_USE_PLATFORM_WIN32_KHR
-#include <vulkan/vulkan.h>
-#include <vulkan/vulkan_win32.h>
+  #define VK_USE_PLATFORM_WIN32_KHR
+  #include <vulkan/vulkan.h>
+  #include <vulkan/vulkan_win32.h>
 #endif
 
 
@@ -47,21 +47,24 @@ struct VulkanContext
 #endif
 
 // Forward declare the OLE drop target helper (defined in IGraphicsWin_dnd.h)
-namespace DragAndDropHelpers { class DropTarget; }
+namespace DragAndDropHelpers
+{
+class DropTarget;
+}
 
 
 /** IGraphics platform class for Windows
-* @ingroup PlatformClasses */
+ * @ingroup PlatformClasses */
 class IGraphicsWin final : public IGRAPHICS_DRAW_CLASS
 {
   using InstalledFont = InstalledWinFont;
   using Font = WinFont;
-  
+
 public:
   IGraphicsWin(IGEditorDelegate& dlg, int w, int h, int fps, float scale);
   ~IGraphicsWin();
 
-  void SetWinModuleHandle(void* pInstance) override { mHInstance = (HINSTANCE) pInstance; }
+  void SetWinModuleHandle(void* pInstance) override { mHInstance = (HINSTANCE)pInstance; }
   void* GetWinModuleHandle() override { return mHInstance; }
 
   void ForceEndUserEdit() override;
@@ -71,12 +74,12 @@ public:
 
   void CheckTabletInput(UINT msg);
   void DestroyEditWindow();
-    
+
   void HideMouseCursor(bool hide, bool lock) override;
   void MoveMouseCursor(float x, float y) override;
   ECursor SetMouseCursor(ECursor cursorType) override;
-  
-  void GetMouseLocation(float& x, float&y) const override;
+
+  void GetMouseLocation(float& x, float& y) const override;
 
   EMsgBoxResult ShowMessageBox(const char* str, const char* title, EMsgBoxType type, IMsgBoxCompletionHandlerFunc completionHandler) override;
 
@@ -130,18 +133,17 @@ protected:
   void SetTooltip(const char* tooltip);
   void ShowTooltip();
   void HideTooltip();
-    
+
   HWND GetMainWnd();
   IRECT GetWindowRECT();
 
 private:
-
   // OLE drag & drop
   DragAndDropHelpers::DropTarget* mDropTarget = nullptr;
   bool mOLEInited = false;
 
   /** Called either in response to WM_TIMER tick or user message WM_VBLANK, triggered by VSYNC thread
-    * @param vBlankCount will allow redraws to get paced by the vblank message. Passing 0 is a WM_TIMER fallback. */
+   * @param vBlankCount will allow redraws to get paced by the vblank message. Passing 0 is a WM_TIMER fallback. */
   void OnDisplayTimer(int vBlankCount = 0);
 
   enum EParamEditMsg
@@ -165,7 +167,7 @@ private:
   void DeactivateGLContext() override;
 
 #ifdef IGRAPHICS_VULKAN
-  void CreateVulkanContext(); // Vulkan context management
+  bool CreateVulkanContext(); // Vulkan context management
   void DestroyVulkanContext();
   void ActivateVulkanContext();
   void DeactivateVulkanContext();
@@ -203,14 +205,14 @@ private:
   void StartVBlankThread(HWND hWnd);
   void StopVBlankThread();
   void VBlankNotify();
-    
-  HWND mVBlankWindow = 0; // Window to post messages to for every vsync
-  volatile bool mVBlankShutdown = false; // Flag to indiciate that the vsync thread should shutdown
-  HANDLE mVBlankThread = INVALID_HANDLE_VALUE; //ID of thread.
-  volatile DWORD mVBlankCount = 0; // running count of vblank events since the start of the window.
-  int mVBlankSkipUntil = 0; // support for skipping vblank notification if the last callback took  too long.  This helps keep the message pump clear in the case of overload.
+
+  HWND mVBlankWindow = 0;                      // Window to post messages to for every vsync
+  volatile bool mVBlankShutdown = false;       // Flag to indiciate that the vsync thread should shutdown
+  HANDLE mVBlankThread = INVALID_HANDLE_VALUE; // ID of thread.
+  volatile DWORD mVBlankCount = 0;             // running count of vblank events since the start of the window.
+  int mVBlankSkipUntil = 0;                    // support for skipping vblank notification if the last callback took  too long.  This helps keep the message pump clear in the case of overload.
   bool mVSYNCEnabled = false;
-  
+
   const IParam* mEditParam = nullptr;
   IText mEditText;
   IRECT mEditRECT;
@@ -222,7 +224,7 @@ private:
   int mTooltipIdx = -1;
 
   WDL_String mMainWndClassName;
-    
+
   static StaticStorage<InstalledFont> sPlatformFontCache;
   static StaticStorage<HFontHolder> sHFontCache;
 
@@ -231,5 +233,3 @@ private:
 
 END_IGRAPHICS_NAMESPACE
 END_IPLUG_NAMESPACE
-
-


### PR DESCRIPTION
## Summary
- Reuse Windows Vulkan semaphores and fence in Skia instead of creating duplicates
- Flush Skia drawing with Vulkan wait/signal semaphores and present after rendering completes
- Return a success flag from Vulkan context creation and abort window setup if initialization fails

## Testing
- `./run_clang_format.sh` *(fails: style=file missing)*
- `g++ -std=c++17 -DIGRAPHICS_VULKAN -DOS_WIN -c IGraphics/Platforms/IGraphicsWin.cpp` *(fails: Shlobj.h: No such file or directory)*
- `g++ -std=c++17 -DIGRAPHICS_VULKAN -DOS_WIN -c IGraphics/Drawing/IGraphicsSkia.cpp` *(fails: IGraphics.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a8d7d8a88329be79a8d5b97fb526