### PR TITLE
Fix Vulkan integration issues

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.h
+++ b/IGraphics/Drawing/IGraphicsSkia.h
@@ -13,6 +13,7 @@
   #define SK_GL
 #elif defined IGRAPHICS_VULKAN
   #define SK_VULKAN
+  #include <vulkan/vulkan.h>
 #endif
 
 #pragma warning(push)
@@ -183,18 +184,19 @@ private:
 #endif
 
 #ifdef IGRAPHICS_VULKAN
-  void* mVKInstance = nullptr;
-  void* mVKPhysicalDevice = nullptr;
-  void* mVKDevice = nullptr;
-  void* mVKSurface = nullptr;
-  void* mVKSwapchain = nullptr;
-  void* mVKQueue = nullptr;
+  VkInstance mVKInstance = VK_NULL_HANDLE;
+  VkPhysicalDevice mVKPhysicalDevice = VK_NULL_HANDLE;
+  VkDevice mVKDevice = VK_NULL_HANDLE;
+  VkSurfaceKHR mVKSurface = VK_NULL_HANDLE;
+  VkSwapchainKHR mVKSwapchain = VK_NULL_HANDLE;
+  VkQueue mVKQueue = VK_NULL_HANDLE;
   uint32_t mVKQueueFamily = 0;
-  std::vector<void*> mVKSwapchainImages;
+  std::vector<VkImage> mVKSwapchainImages;
   uint32_t mVKCurrentImage = 0;
-  void* mVKImageAvailableSemaphore = nullptr;
-  void* mVKRenderFinishedSemaphore = nullptr;
-  void* mVKInFlightFence = nullptr;
+  VkSemaphore mVKImageAvailableSemaphore = VK_NULL_HANDLE;
+  VkSemaphore mVKRenderFinishedSemaphore = VK_NULL_HANDLE;
+  VkFence mVKInFlightFence = VK_NULL_HANDLE;
+  VkFormat mVKSwapchainFormat = VK_FORMAT_B8G8R8A8_UNORM;
   bool mVKSkipFrame = false;
 #endif
 

--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -43,6 +43,7 @@ struct VulkanContext
   VkSemaphore renderFinishedSemaphore = VK_NULL_HANDLE;
   VkFence inFlightFence = VK_NULL_HANDLE;
   std::vector<VkImage>* swapchainImages = nullptr;
+  VkFormat format = VK_FORMAT_B8G8R8A8_UNORM;
 };
 #endif
 
@@ -123,7 +124,7 @@ public:
 
 #ifdef IGRAPHICS_VULKAN
   void UpdateVulkanSwapchain(VkSwapchainKHR swapchain, const std::vector<VkImage>& images);
-  VkResult CreateOrResizeVulkanSwapchain(uint32_t width, uint32_t height, VkSwapchainKHR& swapchain, std::vector<VkImage>& images);
+  VkResult CreateOrResizeVulkanSwapchain(uint32_t width, uint32_t height, VkSwapchainKHR& swapchain, std::vector<VkImage>& images, VkFormat& format);
 #endif
 
 protected:
@@ -182,6 +183,7 @@ private:
   VkSemaphore mRenderFinishedSemaphore = VK_NULL_HANDLE;
   VkFence mInFlightFence = VK_NULL_HANDLE;
   std::vector<VkImage> mVkSwapchainImages;
+  VkFormat mVkFormat = VK_FORMAT_B8G8R8A8_UNORM;
 #endif
 
 #ifdef IGRAPHICS_GL


### PR DESCRIPTION
## Summary
- use concrete Vulkan handle types and track swapchain format
- guard Windows-only Vulkan resize logic and skip frames on fence failure
- check validation layer availability and select swapchain settings at runtime

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68c6b427f3e083299534b5b6633eb950