### PR TITLE
Improve Vulkan backend robustness

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -555,20 +555,25 @@ void IGraphicsSkia::DrawResize()
   #if defined IGRAPHICS_VULKAN
     if (mVKDevice && mVKSurface)
     {
-      #if defined OS_WIN
+    #if defined OS_WIN
       if (auto* pWin = static_cast<IGraphicsWin*>(this))
       {
         VkSwapchainKHR swapchain = VK_NULL_HANDLE;
         std::vector<VkImage> images;
         VkFormat format = mVKSwapchainFormat;
-        if (pWin->CreateOrResizeVulkanSwapchain(w, h, swapchain, images, format) == VK_SUCCESS)
+        VkResult res = pWin->CreateOrResizeVulkanSwapchain(w, h, swapchain, images, format);
+        if (res == VK_SUCCESS)
         {
           mVKSwapchain = swapchain;
           mVKSwapchainImages = images;
           mVKSwapchainFormat = format;
         }
+        else
+        {
+          DBGMSG("CreateOrResizeVulkanSwapchain failed: %d\n", res);
+        }
       }
-      #endif
+    #endif
     }
   #endif
   }

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1161,15 +1161,22 @@ bool IGraphicsWin::CreateVulkanContext()
   vkGetPhysicalDeviceFeatures(mVkPhysicalDevice, &supportedFeatures);
 
   VkPhysicalDeviceFeatures enabledFeatures{};
-  if (!supportedFeatures.samplerAnisotropy || !supportedFeatures.textureCompressionBC)
+  if (!supportedFeatures.samplerAnisotropy)
   {
-    DBGMSG("Required Vulkan device features not supported\n");
+    DBGMSG("Required Vulkan device feature samplerAnisotropy not supported\n");
     DestroyVulkanContext();
     return false;
   }
 
   enabledFeatures.samplerAnisotropy = VK_TRUE;
-  enabledFeatures.textureCompressionBC = VK_TRUE;
+  if (supportedFeatures.textureCompressionBC)
+  {
+    enabledFeatures.textureCompressionBC = VK_TRUE;
+  }
+  else
+  {
+    DBGMSG("Optional Vulkan feature textureCompressionBC not supported\n");
+  }
 
   float priority = 1.f;
   VkDeviceQueueCreateInfo queueInfo{};
@@ -1395,8 +1402,9 @@ void IGraphicsWin::ActivateVulkanContext()
 
 void IGraphicsWin::DeactivateVulkanContext()
 {
-  if (mPresentQueue)
-    vkQueueWaitIdle(mPresentQueue);
+  // Vulkan does not require explicit context deactivation. Avoid
+  // blocking on the present queue here to prevent unnecessary stalls;
+  // required synchronization is handled via semaphores/fences.
 }
 #endif
 


### PR DESCRIPTION
## Summary
- relax Vulkan device feature requirements
- avoid blocking queue on Vulkan context deactivate
- log swap-chain resize failures

## Testing
- `clang-format -i IGraphics/Platforms/IGraphicsWin.cpp IGraphics/Drawing/IGraphicsSkia.cpp`
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68c6ba176d048329ac62e6bdb0b9727d