### PR TITLE
Handle invalid Skia directory before cloning

### DIFF
--- a/Dependencies/IGraphics/download-igraphics-libs.sh
+++ b/Dependencies/IGraphics/download-igraphics-libs.sh
@@ -113,8 +113,19 @@ fi
 #######################################################################
 # skia
 if [ -d "$SRC_DIR/skia" ]; then
-  echo "Found skia"
-else
+  if git -C "$SRC_DIR/skia" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "Found skia"
+  else
+    echo "Existing $SRC_DIR/skia is not a git repository."
+    read -p "Delete and re-clone Skia? [y/N] " yn
+    case $yn in
+      [Yy]* ) rm -rf "$SRC_DIR/skia";;
+      * ) echo "Cannot proceed without a clean Skia directory."; exit 1;;
+    esac
+  fi
+fi
+
+if [ ! -d "$SRC_DIR/skia" ]; then
   echo "Cloning Skia"
   git clone --depth 1 --branch $SKIA_VERSION $SKIA_URL "$SRC_DIR/skia"
   echo "Syncing Skia dependencies..."


### PR DESCRIPTION
## Summary
- Detect existing Build/src/skia that isn't a git repo and prompt for cleanup
- Clone Skia only after ensuring a clean directory and sync its dependencies

## Testing
- `bash -n Dependencies/IGraphics/download-igraphics-libs.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c6e5b47cd08329bce21cb405d92919