### PR TITLE
Preserve Skia git metadata

### DIFF
--- a/Dependencies/IGraphics/README.md
+++ b/Dependencies/IGraphics/README.md
@@ -15,6 +15,8 @@ $ cd ~/Dev/iPlug2/Dependencies/IGraphics
 $ ./download-igraphics-libs.sh
 ```
 
+After running this script, the Skia checkout retains its `.git` directory and remains a git repository, allowing further git operations if needed.
+
 ## Mac
 The build script **build-igraphics-libs-mac.sh** will build freetype as a static library (only required if you are using IGRAPHICS_FREETYPE with IGRAPHICS_NANOVG) and will install it in a unix style hierarchy in the folder **iPlug2/Dependencies/Build/mac**. Build settings defined in **iPlug2/common-mac.xcconfig**  will allow your plug-in project to link to these libraries. The libraries are built as universal binaries with x86_64 and arm64 architectures.
 

--- a/Dependencies/IGraphics/download-igraphics-libs.sh
+++ b/Dependencies/IGraphics/download-igraphics-libs.sh
@@ -132,7 +132,7 @@ if [ ! -d "$SRC_DIR/skia" ]; then
   (
     cd "$SRC_DIR/skia"
     python tools/git-sync-deps
-    rm -rf .git
+    # rm -rf .git  # Keep the Skia checkout as a git repository for easier updates
   )
 fi
 


### PR DESCRIPTION
## Summary
- stop deleting `.git` in `download-igraphics-libs.sh` so Skia remains a git repository
- document that the Skia checkout retains its repository metadata

## Testing
- `bash -n Dependencies/IGraphics/download-igraphics-libs.sh`
- `bash -n Dependencies/IGraphics/package-deps-src.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c6e86c037083299a41b4cda5955aca