### PR TITLE
Fix Windows Skia include order and Vulkan macro

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -55,9 +55,10 @@
   #include "include/ports/SkFontMgr_mac_ct.h"
 
 #elif defined OS_WIN
-  #include <windows.h>
-
-  #include "include/ports/SkTypeface_win.h"
+#ifndef LOGFONT
+#include "include/ports/SkTypeface_win.h"
+#endif
+#include <windows.h>
 
   #pragma comment(lib, "skia.lib")
 
@@ -88,6 +89,9 @@
   #include "include/gpu/ganesh/vk/GrVkDirectContext.h"
   #include "include/gpu/ganesh/vk/GrVkTypes.h"
   #include "include/gpu/vk/VulkanBackendContext.h"
+  #if defined(OS_WIN) && !defined(VK_USE_PLATFORM_WIN32_KHR)
+  #  define VK_USE_PLATFORM_WIN32_KHR
+  #endif
   #include <vulkan/vulkan.h>
   #if defined OS_WIN
     #include "../Platforms/IGraphicsWin.h"

--- a/IGraphics/Drawing/IGraphicsSkia.h
+++ b/IGraphics/Drawing/IGraphicsSkia.h
@@ -13,6 +13,9 @@
   #define SK_GL
 #elif defined IGRAPHICS_VULKAN
   #define SK_VULKAN
+  #if defined(OS_WIN) && !defined(VK_USE_PLATFORM_WIN32_KHR)
+  #  define VK_USE_PLATFORM_WIN32_KHR
+  #endif
   #include <vulkan/vulkan.h>
 
   struct VkSwapchainHolder


### PR DESCRIPTION
## Summary
- prevent LOGFONT redefinition by including SkTypeface_win before windows.h
- define VK_USE_PLATFORM_WIN32_KHR before Vulkan headers on Windows

## Testing
- `x86_64-w64-mingw32-g++ -c IGraphics/Drawing/IGraphicsSkia.cpp -I. -IIGraphics -IIGraphics/Drawing 2>&1 | head -n 20` *(fails: Either NO_IGRAPHICS or one and only one choice of graphics library must be defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c6fba4f64c8329b79a241add62117d