### PR TITLE
Provide Vulkan proc-address loader to Skia backend

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -508,6 +508,9 @@ void IGraphicsSkia::OnViewInitialized(void* pContext)
   mVKInFlightFence.handle = ctx->inFlightFence;
 
   skgpu::VulkanBackendContext backendContext = {};
+  backendContext.fGetProc = [](const char* name, VkInstance instance, VkDevice) {
+    return vkGetInstanceProcAddr(instance, name);
+  };
   backendContext.fInstance = mVKInstance;
   backendContext.fPhysicalDevice = mVKPhysicalDevice;
   backendContext.fDevice = mVKDevice;


### PR DESCRIPTION
## Summary
- Pass `vkGetInstanceProcAddr` to Skia's Vulkan backend via lambda, allowing context creation on Windows.

## Testing
- No tests were run due to user request.

------
https://chatgpt.com/codex/tasks/task_e_68c6fd94901083299f9a256a07d5dfb2