### PR TITLE
Prevent Windows GDI conflicts with Vulkan and Skia

### DIFF
--- a/IGraphics/Controls/Test/Skia/ISkParagraphControl.h
+++ b/IGraphics/Controls/Test/Skia/ISkParagraphControl.h
@@ -45,6 +45,9 @@
 #endif
 
 #ifdef OS_WIN
+  #if !defined(NOGDI)
+    #define NOGDI          // prevent <windows.h> from defining LOGFONT
+  #endif
   #include "include/ports/SkTypeface_win.h"
   #pragma comment(lib, "skparagraph.lib")
 #endif

--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -55,8 +55,9 @@
   #include "include/ports/SkFontMgr_mac_ct.h"
 
 #elif defined OS_WIN
-#ifndef LOGFONT
 #include "include/ports/SkTypeface_win.h"
+#if !defined(NOGDI)
+#  define NOGDI          // prevent <windows.h> from defining LOGFONT
 #endif
 #include <windows.h>
 

--- a/IGraphics/Drawing/IGraphicsSkia.h
+++ b/IGraphics/Drawing/IGraphicsSkia.h
@@ -16,6 +16,9 @@
   #if defined(OS_WIN) && !defined(VK_USE_PLATFORM_WIN32_KHR)
   #  define VK_USE_PLATFORM_WIN32_KHR
   #endif
+  #if defined(OS_WIN) && !defined(NOGDI)
+  #  define NOGDI          // prevent <windows.h> from defining LOGFONT
+  #endif
   #include <vulkan/vulkan.h>
 
   struct VkSwapchainHolder


### PR DESCRIPTION
## Summary
- Disable GDI definitions before including Vulkan on Windows
- Include Skia's Windows typeface port before including `<windows.h>`
- Define `NOGDI` before including Windows headers to avoid `LOGFONT` redefinition

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c70f1824dc8329bc91a4c89e726f05