### PR TITLE
Signal Vulkan fences when resizing swapchain

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -786,10 +786,20 @@ void IGraphicsSkia::EndFrame()
       return;
   }
 
+  VkPipelineStageFlags waitStage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+  VkSubmitInfo submitInfo{VK_STRUCTURE_TYPE_SUBMIT_INFO};
+  submitInfo.waitSemaphoreCount = 1;
+  submitInfo.pWaitSemaphores = &mVKRenderFinishedSemaphore.handle;
+  submitInfo.pWaitDstStageMask = &waitStage;
+  submitInfo.commandBufferCount = 0;
+  submitInfo.signalSemaphoreCount = 0;
+
+  vkQueueSubmit(mVKQueue, 1, &submitInfo, mVKInFlightFence.handle);
+
   VkPresentInfoKHR presentInfo{};
   presentInfo.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
-  presentInfo.waitSemaphoreCount = 1;
-  presentInfo.pWaitSemaphores = &mVKRenderFinishedSemaphore.handle;
+  presentInfo.waitSemaphoreCount = 0;
+  presentInfo.pWaitSemaphores = nullptr;
   presentInfo.swapchainCount = 1;
   presentInfo.pSwapchains = &mVKSwapchain.handle;
   presentInfo.pImageIndices = &mVKCurrentImage;

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1330,9 +1330,7 @@ VkResult IGraphicsWin::CreateOrResizeVulkanSwapchain(uint32_t width, uint32_t he
   VkResult res = VK_SUCCESS;
   if (mInFlightFence.handle)
   {
-    res = vkWaitForFences(mVkDevice, 1, &mInFlightFence.handle, VK_TRUE, UINT64_MAX);
-    if (res != VK_SUCCESS)
-      return res;
+    vkQueueWaitIdle(mPresentQueue);
     res = vkResetFences(mVkDevice, 1, &mInFlightFence.handle);
     if (res != VK_SUCCESS)
       return res;


### PR DESCRIPTION
## Summary
- avoid waiting on unsignaled fence when recreating Vulkan swapchain
- submit no-op to signal in-flight fence before presenting

## Testing
- `clang-format -i IGraphics/Drawing/IGraphicsSkia.cpp IGraphics/Platforms/IGraphicsWin.cpp`


------
https://chatgpt.com/codex/tasks/task_e_68c71d66c86c8329a2ba3176305f65fc