### PR TITLE
Signal Vulkan fence after timeout and swapchain resize

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -684,6 +684,8 @@ void IGraphicsSkia::BeginFrame()
     {
       if (fenceRes == VK_TIMEOUT)
         DBGMSG("vkWaitForFences timed out\n");
+      vkResetFences(mVKDevice, 1, &mVKInFlightFence);
+      vkQueueSubmit(mVKQueue, 0, nullptr, mVKInFlightFence); // ensure fence becomes signaled
       mVKSkipFrame = true;
       mScreenSurface.reset();
       return;

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1334,6 +1334,10 @@ VkResult IGraphicsWin::CreateOrResizeVulkanSwapchain(uint32_t width, uint32_t he
     res = vkResetFences(mVkDevice, 1, &mInFlightFence.handle);
     if (res != VK_SUCCESS)
       return res;
+    // ensure next BeginFrame sees the fence as signaled
+    res = vkQueueSubmit(mPresentQueue, 0, nullptr, mInFlightFence.handle);
+    if (res != VK_SUCCESS)
+      return res;
   }
 
   mVkSwapchain.Reset();


### PR DESCRIPTION
## Summary
- Ensure vkWaitForFences timeout resets and signals the in-flight fence
- Re-signal fence after swapchain creation/resizing so first BeginFrame proceeds

## Testing
- `clang-format -i IGraphics/Drawing/IGraphicsSkia.cpp IGraphics/Platforms/IGraphicsWin.cpp`
- `g++ -std=c++17 -I. -IIGraphics -fsyntax-only IGraphics/Drawing/IGraphicsSkia.cpp` *(fails: IGraphics.h missing; attempted)*

------
https://chatgpt.com/codex/tasks/task_e_68c734b71e548329834a64936ed55081