### PR TITLE
Fix Vulkan swapchain color type mismatch

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -736,7 +736,10 @@ void IGraphicsSkia::BeginFrame()
     imageInfo.fCurrentQueueFamily = mVKQueueFamily;
 
     auto backendRT = GrBackendRenderTargets::MakeVk(width, height, imageInfo);
-    mScreenSurface = SkSurfaces::WrapBackendRenderTarget(mGrContext.get(), backendRT, kTopLeft_GrSurfaceOrigin, kBGRA_8888_SkColorType, nullptr, nullptr);
+    SkColorType colorType = kRGBA_8888_SkColorType;
+    if (mVKSwapchainFormat == VK_FORMAT_B8G8R8A8_UNORM || mVKSwapchainFormat == VK_FORMAT_B8G8R8A8_SRGB)
+      colorType = kBGRA_8888_SkColorType;
+    mScreenSurface = SkSurfaces::WrapBackendRenderTarget(mGrContext.get(), backendRT, kTopLeft_GrSurfaceOrigin, colorType, nullptr, nullptr);
     assert(mScreenSurface);
   }
 #endif


### PR DESCRIPTION
## Summary
- select Skia color type based on Vulkan swapchain format to prevent surface creation failures

## Testing
- `clang++ -std=c++17 -fsyntax-only IGraphics/Drawing/IGraphicsSkia.cpp` *(fails: 'IGraphics.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c73e9b795883299e1f3ab292569819