### PR TITLE
Add transfer usage flags for Vulkan swapchain images

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -741,7 +741,7 @@ void IGraphicsSkia::BeginFrame()
     imageInfo.fImageLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
     imageInfo.fImageTiling = VK_IMAGE_TILING_OPTIMAL;
     imageInfo.fFormat = mVKSwapchainFormat;
-    imageInfo.fImageUsageFlags = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+    imageInfo.fImageUsageFlags = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     imageInfo.fSampleCount = 1;
     imageInfo.fLevelCount = 1;
     imageInfo.fCurrentQueueFamily = mVKQueueFamily;

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1397,7 +1397,7 @@ VkResult IGraphicsWin::CreateOrResizeVulkanSwapchain(uint32_t width, uint32_t he
   swapInfo.imageExtent.width = width;
   swapInfo.imageExtent.height = height;
   swapInfo.imageArrayLayers = 1;
-  swapInfo.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+  swapInfo.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
   swapInfo.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;
   swapInfo.preTransform = caps.currentTransform;
   swapInfo.compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;


### PR DESCRIPTION
## Summary
- Include VK_IMAGE_USAGE_TRANSFER_SRC_BIT and VK_IMAGE_USAGE_TRANSFER_DST_BIT when creating Vulkan swapchains
- Pass transfer usage flags to Skia when wrapping swapchain images

## Testing
- `g++ -std=c++17 -fsyntax-only IGraphics/Drawing/IGraphicsSkia.cpp` *(fails: IGraphics.h: No such file or directory)*
- `g++ -std=c++17 -fsyntax-only IGraphics/Platforms/IGraphicsWin.cpp` *(fails: Shlobj.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c74d4ff6e08329841a4d7675a2cdb5