### PR TITLE
Propagate Vulkan transfer usage flags

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -491,6 +491,7 @@ void IGraphicsSkia::OnViewInitialized(void* pContext)
   mVKQueue = ctx->queue;
   mVKQueueFamily = ctx->queueFamily;
   mVKSwapchainFormat = ctx->format;
+  mVKSwapchainUsageFlags = ctx->usageFlags;
   mVKSwapchainImages.clear();
   if (ctx->swapchainImages)
   {
@@ -574,7 +575,7 @@ void IGraphicsSkia::DrawResize()
         VkSwapchainKHR swapchain = VK_NULL_HANDLE;
         std::vector<VkImage> images;
         VkFormat format = mVKSwapchainFormat;
-        VkResult res = pWin->CreateOrResizeVulkanSwapchain(w, h, swapchain, images, format, mVKSubmissionPending);
+        VkResult res = pWin->CreateOrResizeVulkanSwapchain(w, h, swapchain, images, format, mVKSwapchainUsageFlags, mVKSubmissionPending);
         if (res == VK_SUCCESS)
         {
           mVKSwapchain = swapchain;
@@ -741,7 +742,7 @@ void IGraphicsSkia::BeginFrame()
     imageInfo.fImageLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
     imageInfo.fImageTiling = VK_IMAGE_TILING_OPTIMAL;
     imageInfo.fFormat = mVKSwapchainFormat;
-    imageInfo.fImageUsageFlags = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+    imageInfo.fImageUsageFlags = mVKSwapchainUsageFlags;
     imageInfo.fSampleCount = 1;
     imageInfo.fLevelCount = 1;
     imageInfo.fCurrentQueueFamily = mVKQueueFamily;

--- a/IGraphics/Drawing/IGraphicsSkia.h
+++ b/IGraphics/Drawing/IGraphicsSkia.h
@@ -251,6 +251,7 @@ private:
   VkSemaphore mVKRenderFinishedSemaphore = VK_NULL_HANDLE;
   VkFence mVKInFlightFence = VK_NULL_HANDLE;
   VkFormat mVKSwapchainFormat = VK_FORMAT_B8G8R8A8_UNORM;
+  VkImageUsageFlags mVKSwapchainUsageFlags = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
   bool mVKSkipFrame = false;
   bool mVKSubmissionPending = false;
 #endif

--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -44,6 +44,7 @@ struct VulkanContext
   VkFence inFlightFence = VK_NULL_HANDLE;
   std::vector<VkImage>* swapchainImages = nullptr;
   VkFormat format = VK_FORMAT_B8G8R8A8_UNORM;
+  VkImageUsageFlags usageFlags = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
 };
 #endif
 
@@ -123,7 +124,7 @@ public:
   DWORD OnVBlankRun();
 
 #ifdef IGRAPHICS_VULKAN
-  VkResult CreateOrResizeVulkanSwapchain(uint32_t width, uint32_t height, VkSwapchainKHR& swapchain, std::vector<VkImage>& images, VkFormat& format, bool& submissionPending);
+  VkResult CreateOrResizeVulkanSwapchain(uint32_t width, uint32_t height, VkSwapchainKHR& swapchain, std::vector<VkImage>& images, VkFormat& format, VkImageUsageFlags& usage, bool& submissionPending);
   bool RecreateVulkanContext();
 #endif
 
@@ -184,6 +185,7 @@ private:
   VkFenceHolder mInFlightFence;
   std::vector<VkImage> mVkSwapchainImages;
   VkFormat mVkFormat = VK_FORMAT_B8G8R8A8_UNORM;
+  VkImageUsageFlags mVkSwapchainUsageFlags = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
 #endif
 
 #ifdef IGRAPHICS_GL


### PR DESCRIPTION
## Summary
- track swapchain image usage flags through Vulkan context setup
- use actual image usage when creating Skia backend render targets

## Testing
- `clang-format -i IGraphics/Platforms/IGraphicsWin.h IGraphics/Drawing/IGraphicsSkia.h IGraphics/Drawing/IGraphicsSkia.cpp IGraphics/Platforms/IGraphicsWin.cpp`
- `g++ -fsyntax-only IGraphics/Drawing/IGraphicsSkia.cpp` *(fails: IGraphics.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c75205df708329b1a9f51554f3834d