### PR TITLE
Fix Skia backend render target state update

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -807,8 +807,8 @@ void IGraphicsSkia::BeginFrame()
     auto backendRT = GrBackendRenderTargets::MakeVk(width, height, imageInfo);
 
     auto colorState = skgpu::MutableTextureStates::MakeVulkan(VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, mVKQueueFamily);
-    backendRT.setMutableState(colorState);
     mGrContext->setBackendRenderTargetState(backendRT, colorState, nullptr, nullptr, nullptr);
+    backendRT.setMutableState(colorState);
 
     SkColorType colorType = kUnknown_SkColorType;
     switch (mVKSwapchainFormat)


### PR DESCRIPTION
## Summary
- set backend render target state before mutating backend layout in Skia begin frame

## Testing
- `cmake -S . -B build` *(fails: The source directory does not contain CMakeLists.txt)*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68c76b491e4483299f7a2882219316b5