### PR TITLE
Record Skia Vulkan present barrier

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -904,8 +904,8 @@ void IGraphicsSkia::EndFrame()
   {
     auto backendRT = SkSurfaces::GetBackendRenderTarget(mScreenSurface.get(), SkSurfaces::BackendHandleAccess::kFlushRead);
     auto presentState = skgpu::MutableTextureStates::MakeVulkan(VK_IMAGE_LAYOUT_PRESENT_SRC_KHR, mVKQueueFamily);
-    backendRT.setMutableState(presentState);
     mGrContext->setBackendRenderTargetState(backendRT, presentState, nullptr, nullptr, nullptr);
+    backendRT.setMutableState(presentState);
   }
 
   VkPipelineStageFlags waitStage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;


### PR DESCRIPTION
## Summary
- ensure Skia records a barrier when transitioning Vulkan images to present layout

## Testing
- `clang-format -i IGraphics/Drawing/IGraphicsSkia.cpp`
- `g++ -std=c++17 -IIGraphics -fsyntax-only IGraphics/Drawing/IGraphicsSkia.cpp` *(fails: IPlugConstants.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c76c41c6a8832989d8ad79881cf621