### PR TITLE
Add Vulkan swapchain image layout transition before present

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.h
+++ b/IGraphics/Drawing/IGraphicsSkia.h
@@ -244,6 +244,8 @@ private:
   VkSurfaceKHR mVKSurface = VK_NULL_HANDLE;
   VkSwapchainKHR mVKSwapchain = VK_NULL_HANDLE;
   VkQueue mVKQueue = VK_NULL_HANDLE;
+  VkCommandPool mVKCommandPool = VK_NULL_HANDLE;
+  VkCommandBuffer mVKCommandBuffer = VK_NULL_HANDLE;
   uint32_t mVKQueueFamily = 0;
   std::vector<VkImage> mVKSwapchainImages;
   uint32_t mVKCurrentImage = 0;


### PR DESCRIPTION
## Summary
- Transition Vulkan swapchain images from `COLOR_ATTACHMENT_OPTIMAL` to `PRESENT_SRC_KHR` before presentation
- Manage Vulkan command pool and command buffer for layout transitions
- Clean up Vulkan command resources on shutdown

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68c76f6527ac8329982d50979f0e0541