### PR TITLE
Ensure Vulkan swapchain and image validation

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1304,6 +1304,7 @@ void IGraphicsWin::DestroyVulkanContext()
 bool IGraphicsWin::RecreateVulkanContext()
 {
   OnViewDestroyed();
+  mVKSkipFrame = true;
   DestroyVulkanContext();
   if (!CreateVulkanContext())
     return false;


### PR DESCRIPTION
## Summary
- Guard BeginFrame against missing Vulkan swapchain or images
- Defer rendering when swapchain images are cleared during resize or context recreation

## Testing
- `g++ -fsyntax-only IGraphics/Drawing/IGraphicsSkia.cpp` *(fails: IGraphics.h: No such file or directory)*
- `g++ -fsyntax-only IGraphics/Platforms/IGraphicsWin.cpp` *(fails: Shlobj.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c7708f1b488329a5534abd4b15bb93