### PR TITLE
Expose Vulkan frame skip helper for Windows platform

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.h
+++ b/IGraphics/Drawing/IGraphicsSkia.h
@@ -199,6 +199,10 @@ protected:
   APIBitmap* LoadAPIBitmap(const char* fileNameOrResID, int scale, EResourceLocation location, const char* ext) override;
   APIBitmap* LoadAPIBitmap(const char* name, const void* pData, int dataSize, int scale) override;
 
+#ifdef IGRAPHICS_VULKAN
+  void SkipVKFrame() { mVKSkipFrame = true; }
+#endif
+
 private:
   void PrepareAndMeasureText(const IText& text, const char* str, IRECT& r, double& x, double& y, SkFont& font) const;
 

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1304,7 +1304,7 @@ void IGraphicsWin::DestroyVulkanContext()
 bool IGraphicsWin::RecreateVulkanContext()
 {
   OnViewDestroyed();
-  mVKSkipFrame = true;
+  SkipVKFrame();
   DestroyVulkanContext();
   if (!CreateVulkanContext())
     return false;


### PR DESCRIPTION
## Summary
- Add protected `SkipVKFrame` helper in `IGraphicsSkia` to set Vulkan frame skip flag
- Use new helper in `IGraphicsWin` when recreating the Vulkan context

## Testing
- `g++ -std=c++17 -DIGRAPHICS_VULKAN -DOS_WIN -fsyntax-only IGraphics/Platforms/IGraphicsWin.cpp` *(fails: Shlobj.h: No such file or directory)*
- `g++ -std=c++17 -DIGRAPHICS_VULKAN -fsyntax-only IGraphics/Drawing/IGraphicsSkia.cpp` *(fails: IGraphics.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c772a6cdc083298f3c8978da358beb