### PR TITLE
Guard Vulkan frames when swapchain resets

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -575,6 +575,7 @@ void IGraphicsSkia::DrawResize()
   auto w = static_cast<int>(std::ceil(static_cast<float>(WindowWidth()) * GetScreenScale()));
   auto h = static_cast<int>(std::ceil(static_cast<float>(WindowHeight()) * GetScreenScale()));
 #if defined IGRAPHICS_VULKAN
+  mVKSwapchainRecreated = true;
   if (mVKPhysicalDevice != VK_NULL_HANDLE && mVKSurface != VK_NULL_HANDLE)
   {
     VkSurfaceCapabilitiesKHR caps{};
@@ -879,6 +880,9 @@ void IGraphicsSkia::BeginFrame()
   }
 #endif
 
+#if defined IGRAPHICS_VULKAN
+  mVKSwapchainRecreated = false;
+#endif
   IGraphics::BeginFrame();
 }
 
@@ -910,7 +914,7 @@ void IGraphicsSkia::EndFrame()
   #endif
 #else // GPU
   #ifdef IGRAPHICS_VULKAN
-  if (mVKSkipFrame || mVKSwapchainImages.empty() || mVKCurrentImage >= mVKSwapchainImages.size())
+  if (mVKSkipFrame || mVKSwapchainRecreated || mVKSwapchainImages.empty() || mVKCurrentImage >= mVKSwapchainImages.size())
     return;
   #endif
   mSurface->draw(mScreenSurface->getCanvas(), 0.0, 0.0, nullptr);

--- a/IGraphics/Drawing/IGraphicsSkia.h
+++ b/IGraphics/Drawing/IGraphicsSkia.h
@@ -260,6 +260,7 @@ private:
   VkImageUsageFlags mVKSwapchainUsageFlags = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
   bool mVKSkipFrame = false;
   bool mVKSubmissionPending = false;
+  bool mVKSwapchainRecreated = false;
 #endif
 
   static StaticStorage<Font> sFontCache;


### PR DESCRIPTION
## Summary
- Track swapchain recreation to skip frames using invalid Vulkan images
- Clear the flag after acquiring a new swapchain image

## Testing
- `g++ -std=c++17 -fsyntax-only IGraphics/Drawing/IGraphicsSkia.cpp -I. -IIGraphics -IIPlug -IWDL -DIGRAPHICS_VULKAN -DOS_LINUX` *(fails: nanosvg.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c7800a038c8329a9bf54b3715cc15f