### PR TITLE
Fix Vulkan swapchain crash on resize

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -575,7 +575,7 @@ void IGraphicsSkia::DrawResize()
   auto w = static_cast<int>(std::ceil(static_cast<float>(WindowWidth()) * GetScreenScale()));
   auto h = static_cast<int>(std::ceil(static_cast<float>(WindowHeight()) * GetScreenScale()));
 #if defined IGRAPHICS_VULKAN
-  mVKSwapchainRecreated = true;
+  mVKSwapchainVersion++;
   if (mVKPhysicalDevice != VK_NULL_HANDLE && mVKSurface != VK_NULL_HANDLE)
   {
     VkSurfaceCapabilitiesKHR caps{};
@@ -683,6 +683,9 @@ void IGraphicsSkia::DrawResize()
 
 void IGraphicsSkia::BeginFrame()
 {
+#if defined IGRAPHICS_VULKAN
+  mVKFrameVersion = mVKSwapchainVersion;
+#endif
 #if defined IGRAPHICS_GL
   if (mGrContext.get())
   {
@@ -880,9 +883,6 @@ void IGraphicsSkia::BeginFrame()
   }
 #endif
 
-#if defined IGRAPHICS_VULKAN
-  mVKSwapchainRecreated = false;
-#endif
   IGraphics::BeginFrame();
 }
 
@@ -913,10 +913,10 @@ void IGraphicsSkia::EndFrame()
     #error NOT IMPLEMENTED
   #endif
 #else // GPU
-  #ifdef IGRAPHICS_VULKAN
-  if (mVKSkipFrame || mVKSwapchainRecreated || mVKSwapchainImages.empty() || mVKCurrentImage >= mVKSwapchainImages.size())
+#ifdef IGRAPHICS_VULKAN
+  if (mVKSkipFrame || mVKFrameVersion != mVKSwapchainVersion || mVKSwapchainImages.empty() || mVKCurrentImage >= mVKSwapchainImages.size())
     return;
-  #endif
+#endif
   mSurface->draw(mScreenSurface->getCanvas(), 0.0, 0.0, nullptr);
 
   #if defined IGRAPHICS_VULKAN

--- a/IGraphics/Drawing/IGraphicsSkia.h
+++ b/IGraphics/Drawing/IGraphicsSkia.h
@@ -3,6 +3,7 @@
 #include "IGraphics.h"
 #include "IPlugPlatform.h"
 #include <vector>
+#include <cstdint>
 
 // N.B. - this must be defined according to the skia build, not the iPlug build
 #if (defined OS_MAC || defined OS_IOS) && !defined IGRAPHICS_SKIA_NO_METAL
@@ -260,7 +261,8 @@ private:
   VkImageUsageFlags mVKSwapchainUsageFlags = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
   bool mVKSkipFrame = false;
   bool mVKSubmissionPending = false;
-  bool mVKSwapchainRecreated = false;
+  uint64_t mVKSwapchainVersion = 0;
+  uint64_t mVKFrameVersion = 0;
 #endif
 
   static StaticStorage<Font> sFontCache;


### PR DESCRIPTION
## Summary
- track Vulkan swapchain generations to detect mid-frame resize
- skip EndFrame when swapchain changes to avoid invalid image handles

## Testing
- `./Scripts/run_clang_format.sh` *(fails: ./../IPlug is not a directory)*
- `clang++ -std=c++17 -c IGraphics/Drawing/IGraphicsSkia.cpp -DIGRAPHICS_VULKAN -I.` *(fails: command not found: clang++)*

------
https://chatgpt.com/codex/tasks/task_e_68c78471d8bc83299b0b082f48ac573e