### PR TITLE
Guard Vulkan swap chain with mutex

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.h
+++ b/IGraphics/Drawing/IGraphicsSkia.h
@@ -5,6 +5,7 @@
 #include <vector>
 #include <cstdint>
 #include <limits>
+#include "mutex.h"
 
 // N.B. - this must be defined according to the skia build, not the iPlug build
 #if (defined OS_MAC || defined OS_IOS) && !defined IGRAPHICS_SKIA_NO_METAL
@@ -265,6 +266,7 @@ private:
   bool mVKSubmissionPending = false;
   uint64_t mVKSwapchainVersion = 0;
   uint64_t mVKFrameVersion = 0;
+  WDL_Mutex mVKSwapchainMutex;
 #endif
 
   static StaticStorage<Font> sFontCache;


### PR DESCRIPTION
## Summary
- add mutex protecting Vulkan swap-chain state
- lock swap-chain operations in DrawResize, BeginFrame, and EndFrame
- re-check swap-chain validity before submitting frame and wait for in-flight fence during resize

## Testing
- `g++ -std=c++17 -DIGRAPHICS_VULKAN -c IGraphics/Drawing/IGraphicsSkia.cpp -I./IGraphics -I./WDL` *(fails: IPlugConstants.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c78f3f6ca483299507b16bde4c90a7