### PR TITLE
Track Vulkan swapchain image layouts to avoid stale handles

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.h
+++ b/IGraphics/Drawing/IGraphicsSkia.h
@@ -256,6 +256,7 @@ private:
   VkCommandBuffer mVKCommandBuffer = VK_NULL_HANDLE;
   uint32_t mVKQueueFamily = 0;
   std::vector<VkImage> mVKSwapchainImages;
+  std::vector<VkImageLayout> mVKImageLayouts;
   uint32_t mVKCurrentImage = kInvalidImageIndex;
   VkSemaphore mVKImageAvailableSemaphore = VK_NULL_HANDLE;
   VkSemaphore mVKRenderFinishedSemaphore = VK_NULL_HANDLE;


### PR DESCRIPTION
## Summary
- track VkImageLayout state for each swapchain image
- update image layouts as they transition and reset on swapchain recreation
- avoid waiting on unsignaled semaphores when releasing images

## Testing
- `clang-format -i IGraphics/Drawing/IGraphicsSkia.h IGraphics/Drawing/IGraphicsSkia.cpp`
- `g++ -fsyntax-only -std=c++17 IGraphics/Drawing/IGraphicsSkia.cpp` *(fails: IGraphics.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c8164a279c83299468bc798bcf4de3