### PR TITLE
Avoid waiting on unsignaled Vulkan semaphore

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -1025,9 +1025,7 @@ void IGraphicsSkia::EndFrame()
   #if defined IGRAPHICS_VULKAN
   if (auto dContext = GrAsDirectContext(mScreenSurface->getCanvas()->recordingContext()))
   {
-    GrBackendSemaphore waitSemaphore = GrBackendSemaphores::MakeVk(mVKImageAvailableSemaphore);
     GrBackendSemaphore signalSemaphore = GrBackendSemaphores::MakeVk(mVKRenderFinishedSemaphore);
-    dContext->wait(1, &waitSemaphore, false);
     GrFlushInfo flushInfo{};
     flushInfo.fNumSemaphores = 1;
     flushInfo.fSignalSemaphores = &signalSemaphore;


### PR DESCRIPTION
## Summary
- skip redundant wait on image-available semaphore before flushing Skia

## Testing
- `clang-format --style=LLVM -n IGraphics/Drawing/IGraphicsSkia.cpp` *(fails: code should be clang-formatted)*

------
https://chatgpt.com/codex/tasks/task_e_68c81dd7e7288329a9521f800c2713c0