### PR TITLE
Clear stale swapchain images on Vulkan resize

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -595,6 +595,7 @@ void IGraphicsSkia::DrawResize()
     mVKSubmissionPending = false;
     mVKImageLayouts.clear();
   }
+  mVKSwapchainImages.clear();
   if (mVKPhysicalDevice != VK_NULL_HANDLE && mVKSurface != VK_NULL_HANDLE)
   {
     VkSurfaceCapabilitiesKHR caps{};


### PR DESCRIPTION
## Summary
- drop stale Vulkan swapchain image handles during resize to prevent invalid image usage

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68c823b60e088329a4b38a9f4c6565f5