### PR TITLE
Validate Vulkan swapchain image before use

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -842,6 +842,13 @@ void IGraphicsSkia::BeginFrame()
       mVKCurrentImage = kInvalidImageIndex;
       return;
     }
+    if (imageIndex >= mVKSwapchainImages.size() || mVKSwapchainImages[imageIndex] == VK_NULL_HANDLE)
+    {
+      DBGMSG("vkAcquireNextImageKHR returned invalid image (index %u)\n", imageIndex);
+      mVKSkipFrame = true;
+      mVKCurrentImage = kInvalidImageIndex;
+      return;
+    }
     VkResult fenceStatus = vkGetFenceStatus(mVKDevice, mVKInFlightFence);
     if (fenceStatus == VK_SUCCESS)
     {


### PR DESCRIPTION
## Summary
- validate swapchain image index and handle after vkAcquireNextImageKHR to prevent invalid VkImage usage

## Testing
- `g++ -std=c++17 -DIGRAPHICS_VULKAN -IIGraphics -c IGraphics/Drawing/IGraphicsSkia.cpp` *(fails: IGraphics.h requires additional dependencies)*


------
https://chatgpt.com/codex/tasks/task_e_68c826e3f2e8832990b2d92472e1a670