### PR TITLE
Add Vulkan swapchain image validation in debug builds

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.h
+++ b/IGraphics/Drawing/IGraphicsSkia.h
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <limits>
 #include <mutex>
+#include <unordered_set>
 #include <vector>
 
 // N.B. - this must be defined according to the skia build, not the iPlug build
@@ -268,6 +269,10 @@ private:
   uint64_t mVKSwapchainVersion = 0;
   uint64_t mVKFrameVersion = 0;
   std::mutex mVKSwapchainMutex;
+  #ifndef NDEBUG
+  std::unordered_set<VkImage> mVKDebugImages;
+  bool AssertValidSwapchainImage(VkImage image, const char* context);
+  #endif
 #endif
 
   static StaticStorage<Font> sFontCache;


### PR DESCRIPTION
## Summary
- track active Vulkan swapchain images in debug builds
- validate swapchain image handles in BeginFrame and EndFrame
- log and name images when recreating the swapchain

## Testing
- `clang-format -i IGraphics/Drawing/IGraphicsSkia.cpp IGraphics/Drawing/IGraphicsSkia.h`
- `clang++ -std=c++17 -DIGRAPHICS_VULKAN -IIGraphics -c IGraphics/Drawing/IGraphicsSkia.cpp` *(fails: 'IPlugConstants.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c82a5cd5bc8329b86524a9bfe0fdf1