### PR TITLE
Reset Skia surfaces before recreating Vulkan swapchain

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -631,6 +631,9 @@ void IGraphicsSkia::DrawResize()
   std::lock_guard<std::mutex> lock(mVKSwapchainMutex);
   mVKSkipFrame = true;
   mVKCurrentImage = kInvalidImageIndex;
+  mScreenSurface.reset();
+  mSurface.reset();
+  mCanvas = nullptr;
   uint64_t previousSwapchainVersion = mVKSwapchainVersion;
   mVKSwapchainVersion++;
   DBGMSG("DrawResize: swapchain version %llu -> %llu\n",


### PR DESCRIPTION
## Summary
- release the current Skia screen surface, offscreen surface, and canvas pointers before recreating the Vulkan swapchain
- avoid Skia retaining references to swapchain images that are about to be destroyed during a resize

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c84e22b88c8329b5961c3d72a625fd