### PR TITLE
Fix swapchain image layout tracking when skipping present

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -1052,10 +1052,11 @@ void IGraphicsSkia::BeginFrame()
       }
       else
       {
-        mVKImageLayouts[idx] = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
-        DBGMSG("BeginFrame: releaseImage marked index %u handle %p as present layout without submit\n",
+        mVKImageLayouts[idx] = tracked;
+        DBGMSG("BeginFrame: releaseImage kept index %u handle %p in layout %d without submit\n",
                idx,
-               (void*)releaseHandle);
+               (void*)releaseHandle,
+               (int)tracked);
       }
       mVKSubmissionPending = true;
       DBGMSG("BeginFrame: releaseImage set submissionPending for index %u\n", idx);


### PR DESCRIPTION
## Summary
- keep the tracked swapchain image layout unchanged when a release happens without presenting
- improve debug logging to reflect the retained layout state

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c884d7e3708329b3263b5b63353e83