### PR TITLE
Define NOGDI before VST3 SDK includes

### DIFF
--- a/IPlug/VST3/IPlugVST3.cpp
+++ b/IPlug/VST3/IPlugVST3.cpp
@@ -10,13 +10,13 @@
 
 #include <cstdio>
 
+#include "IPlugVST3.h"
+
 #include "pluginterfaces/base/ustring.h"
 #include "pluginterfaces/base/ibstream.h"
 #include "pluginterfaces/vst/ivstparameterchanges.h"
 #include "pluginterfaces/vst/ivstevents.h"
 #include "pluginterfaces/vst/ivstmidicontrollers.h"
-
-#include "IPlugVST3.h"
 
 using namespace iplug;
 using namespace Steinberg;

--- a/IPlug/VST3/IPlugVST3.h
+++ b/IPlug/VST3/IPlugVST3.h
@@ -17,6 +17,8 @@
  * @copydoc IPlugVST3
  */
 
+#include "IPlugVST3_Defs.h"
+
 #include <vector>
 
 #undef stricmp

--- a/IPlug/VST3/IPlugVST3_Common.h
+++ b/IPlug/VST3/IPlugVST3_Common.h
@@ -10,6 +10,8 @@
 
 #pragma once
 
+#include "IPlugVST3_Defs.h"
+
 #include "pluginterfaces/base/ibstream.h"
 #
 #include "IPlugAPIBase.h"

--- a/IPlug/VST3/IPlugVST3_Controller.h
+++ b/IPlug/VST3/IPlugVST3_Controller.h
@@ -16,6 +16,8 @@
  * @copydoc IPlugVST3Controller
  */
 
+#include "IPlugVST3_Defs.h"
+
 #undef stricmp
 #undef strnicmp
 #include "public.sdk/source/vst/vsteditcontroller.h"

--- a/IPlug/VST3/IPlugVST3_ControllerBase.h
+++ b/IPlug/VST3/IPlugVST3_ControllerBase.h
@@ -10,13 +10,14 @@
 
 #pragma once
 
+#include "IPlugVST3_Defs.h"
+
 #include "pluginterfaces/base/ibstream.h"
 #include "public.sdk/source/vst/vsteditcontroller.h"
 #include "pluginterfaces/vst/ivstchannelcontextinfo.h"
 
 #include "IPlugAPIBase.h"
 #include "IPlugVST3_Parameter.h"
-#include "IPlugVST3_Defs.h"
 
 #include "IPlugMidi.h"
 

--- a/IPlug/VST3/IPlugVST3_Defs.h
+++ b/IPlug/VST3/IPlugVST3_Defs.h
@@ -1,5 +1,11 @@
 #pragma once
 
+#include "IPlugPlatform.h"
+
+#if defined(OS_WIN) && !defined(NOGDI)
+  #define NOGDI
+#endif
+
 #ifndef VST3_NUM_MIDI_IN_CHANS
   #define VST3_NUM_MIDI_IN_CHANS 1
 #endif

--- a/IPlug/VST3/IPlugVST3_Parameter.h
+++ b/IPlug/VST3/IPlugVST3_Parameter.h
@@ -10,6 +10,8 @@
 
 #pragma once
 
+#include "IPlugVST3_Defs.h"
+
 #include "pluginterfaces/base/ustring.h"
 #include "public.sdk/source/vst/vstparameters.h"
 #include "base/source/fstring.h"

--- a/IPlug/VST3/IPlugVST3_Processor.h
+++ b/IPlug/VST3/IPlugVST3_Processor.h
@@ -11,6 +11,8 @@
 #ifndef _IPLUGAPI_
 #define _IPLUGAPI_
 
+#include "IPlugVST3_Defs.h"
+
 #undef stricmp
 #undef strnicmp
 #include "public.sdk/source/vst/vstaudioeffect.h"

--- a/IPlug/VST3/IPlugVST3_ProcessorBase.cpp
+++ b/IPlug/VST3/IPlugVST3_ProcessorBase.cpp
@@ -8,11 +8,12 @@
  ==============================================================================
  */
 
+#include "IPlugVST3_ProcessorBase.h"
+
 #include "pluginterfaces/vst/ivstparameterchanges.h"
 #include "pluginterfaces/vst/vstspeaker.h"
 #include "pluginterfaces/vst/ivstmidicontrollers.h"
 #include "public.sdk/source/vst/vsteventshelper.h"
-#include "IPlugVST3_ProcessorBase.h"
 
 using namespace iplug;
 using namespace Steinberg;

--- a/IPlug/VST3/IPlugVST3_ProcessorBase.h
+++ b/IPlug/VST3/IPlugVST3_ProcessorBase.h
@@ -11,13 +11,14 @@
 
 #pragma once
 
+#include "IPlugVST3_Defs.h"
+
 #include "public.sdk/source/vst/vstbus.h"
 #include "pluginterfaces/base/ustring.h"
 #include "pluginterfaces/vst/ivstevents.h"
 
 #include "IPlugAPIBase.h"
 #include "IPlugProcessor.h"
-#include "IPlugVST3_Defs.h"
 
 // Custom bus type function (in global namespace)
 #ifdef CUSTOM_BUSTYPE_FUNC

--- a/IPlug/VST3/IPlugVST3_View.h
+++ b/IPlug/VST3/IPlugVST3_View.h
@@ -9,6 +9,9 @@
 */
 
 #pragma once
+
+#include "IPlugVST3_Defs.h"
+
 #include "base/source/fstring.h"
 #include "pluginterfaces/gui/iplugviewcontentscalesupport.h"
 #include "pluginterfaces/base/keycodes.h"


### PR DESCRIPTION
## Summary
- ensure VST3 headers include the shared defs header before Steinberg SDK headers so NOGDI is defined in time
- define NOGDI in the shared VST3 defs and rely on IPlugPlatform for OS detection
- reorder VST3 source includes to pull in project headers before Steinberg SDK headers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c89dd32724832980b2d3b989a6def4