### PR TITLE
Include IPlugPlatform before Windows headers on Win

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -10,6 +10,8 @@
 
 #pragma once
 
+#include "IPlugPlatform.h"
+
 #include <windows.h>
 #include <windowsx.h>
 #include <winuser.h>

--- a/IGraphics/Platforms/IGraphicsWinFonts.h
+++ b/IGraphics/Platforms/IGraphicsWinFonts.h
@@ -10,6 +10,8 @@
 
 #pragma once
 
+#include "IPlugPlatform.h"
+
 #include <windows.h>
 
 #include "IGraphicsPrivate.h"

--- a/IPlug/IPlugPlatform.h
+++ b/IPlug/IPlugPlatform.h
@@ -17,6 +17,12 @@
 
 #ifdef _WIN32
   #define OS_WIN
+  #if !defined(UNICODE)
+    #define UNICODE
+  #endif
+  #if !defined(_UNICODE)
+    #define _UNICODE
+  #endif
 #elif defined __APPLE__
   #include <TargetConditionals.h>
   #if TARGET_OS_IPHONE


### PR DESCRIPTION
## Summary
- include `IPlugPlatform.h` before any Windows headers in the Win32 platform headers so UNICODE is defined prior to including <windows.h>
- pull `IPlugPlatform.h` into `IGraphicsWinFonts.h` to provide the same guard when that header is included directly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c8a3b1b9e083299d691927ca69998e