### PR TITLE
Define NOGDI for VST3 builds

### DIFF
--- a/IPlug/VST3/IPlugVST3.h
+++ b/IPlug/VST3/IPlugVST3.h
@@ -12,6 +12,10 @@
 #define _IPLUGAPI_
 // Only load one API class!
 
+#if defined(_WIN32) && !defined(NOGDI)
+  #define NOGDI // stop <windows.h> from declaring LOGFONT
+#endif
+
 /**
  * @file
  * @copydoc IPlugVST3

--- a/IPlug/VST3/IPlugVST3_Controller.h
+++ b/IPlug/VST3/IPlugVST3_Controller.h
@@ -11,6 +11,10 @@
 #ifndef _IPLUGAPI_
 #define _IPLUGAPI_
 
+#if defined(_WIN32) && !defined(NOGDI)
+  #define NOGDI // stop <windows.h> from declaring LOGFONT
+#endif
+
 /**
  * @file
  * @copydoc IPlugVST3Controller


### PR DESCRIPTION
## Summary
- define `NOGDI` before including the VST3 headers to prevent `LOGFONT` from being declared by `<windows.h>`

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c8ad8f9fc48329be98eb682bdb619c