### PR TITLE
Scope Windows NOGDI define around VST3 headers

### DIFF
--- a/IPlug/VST3/IPlugVST3.h
+++ b/IPlug/VST3/IPlugVST3.h
@@ -8,6 +8,11 @@
  ==============================================================================
 */
 
+#if defined(_WIN32) && !defined(NOGDI)
+  #define NOGDI
+  #define IPLUG_VST3_TEMP_NOGDI
+#endif
+
 #ifndef _IPLUGAPI_
 #define _IPLUGAPI_
 // Only load one API class!
@@ -27,6 +32,12 @@
 #include "pluginterfaces/vst/vsttypes.h"
 #include "pluginterfaces/vst/ivstcontextmenu.h"
 #include "pluginterfaces/vst/ivstchannelcontextinfo.h"
+
+#ifdef IPLUG_VST3_TEMP_NOGDI
+  #undef NOGDI          // allow GDI again
+  #include <wingdi.h>   // pull in AddFontMemResourceEx, LOGFONTW, etc.
+  #undef IPLUG_VST3_TEMP_NOGDI
+#endif
 
 #include "IPlugAPIBase.h"
 #include "IPlugProcessor.h"

--- a/IPlug/VST3/IPlugVST3_Controller.h
+++ b/IPlug/VST3/IPlugVST3_Controller.h
@@ -8,6 +8,11 @@
  ==============================================================================
 */
 
+#if defined(_WIN32) && !defined(NOGDI)
+  #define NOGDI
+  #define IPLUG_VST3_TEMP_NOGDI
+#endif
+
 #ifndef _IPLUGAPI_
 #define _IPLUGAPI_
 
@@ -20,6 +25,12 @@
 #undef strnicmp
 #include "public.sdk/source/vst/vsteditcontroller.h"
 #include "pluginterfaces/vst/ivstchannelcontextinfo.h"
+
+#ifdef IPLUG_VST3_TEMP_NOGDI
+  #undef NOGDI          // allow GDI again
+  #include <wingdi.h>   // pull in AddFontMemResourceEx, LOGFONTW, etc.
+  #undef IPLUG_VST3_TEMP_NOGDI
+#endif
 
 #include "IPlugAPIBase.h"
 


### PR DESCRIPTION
## Summary
- add a temporary NOGDI define at the top of the VST3 component and controller headers when building on Windows
- restore GDI access immediately after including Steinberg headers so Windows GDI types and functions remain available

## Testing
- not run (Windows-specific VST3 build is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68c8af724e008329a7754abb50c180d3