### PR TITLE
Avoid LOGFONT typedef clash with Skia on Windows

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -17,7 +17,21 @@
 #include <winuser.h>
 
 #include "IGraphicsWinFonts.h"
+
+#if defined(OS_WIN) && defined(IGRAPHICS_SKIA)
+  // Skia's SkTypeface_win.h unconditionally typedefs LOGFONT, which clashes with the
+  // definition provided by the Windows headers. Rename the symbol while Skia headers
+  // are included to avoid the redefinition.
+  #define LOGFONT IGRAPHICS_SKIA_WIN_LOGFONT
+  #define IGRAPHICS_REMAP_LOGFONT
+#endif
+
 #include "IGraphics_select.h"
+
+#ifdef IGRAPHICS_REMAP_LOGFONT
+  #undef LOGFONT
+  #undef IGRAPHICS_REMAP_LOGFONT
+#endif
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
## Summary
- remap the LOGFONT symbol when including Skia headers on Windows so SkTypeface_win.h no longer collides with the Windows typedef

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8b450f99c832999d179e97ae3171e