### PR TITLE
Refactor Skia Windows LOGFONT handling

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -14,6 +14,16 @@ In the meantime, you can read two academic papers that we wrote about the projec
 
 See [Skia Vulkan on Windows](SkiaVulkanWindows.md) for instructions on enabling the Skia renderer with Vulkan on Windows.
 
+## Windows and Skia header interoperability
+
+When working on the Windows build with the Skia backend, always include
+`IGraphics/Skia/SkTypefaceWinWrapper.h` instead of including Skia's
+`SkTypeface_win.h` directly. The wrapper guarantees that `<windows.h>` is
+included in a safe order and temporarily remaps the `LOGFONT` typedefs so the
+Skia declarations cannot collide with the Windows definitions. Avoid
+reintroducing ad-hoc `NOGDI` or `LOGFONT` macro workarounds elsewhere—use the
+wrapper instead to keep translation units consistent.
+
 <!--
 ## Introduction
 

--- a/IGraphics/Controls/Test/Skia/ISkParagraphControl.h
+++ b/IGraphics/Controls/Test/Skia/ISkParagraphControl.h
@@ -45,10 +45,7 @@
 #endif
 
 #ifdef OS_WIN
-  #if !defined(NOGDI)
-    #define NOGDI          // prevent <windows.h> from defining LOGFONT
-  #endif
-  #include "include/ports/SkTypeface_win.h"
+  #include "../../../Skia/SkTypefaceWinWrapper.h"
   #pragma comment(lib, "skparagraph.lib")
 #endif
 

--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -59,13 +59,7 @@
   #include "include/ports/SkFontMgr_mac_ct.h"
 
 #elif defined OS_WIN
-  #include "include/ports/SkTypeface_win.h"
-
-  #if !defined(NOGDI)
-    #define NOGDI // prevent <windows.h> from defining LOGFONT
-  #endif
-
-  #include <windows.h>
+  #include "../Skia/SkTypefaceWinWrapper.h"
 
   #pragma comment(lib, "skia.lib")
 

--- a/IGraphics/Drawing/IGraphicsSkia.h
+++ b/IGraphics/Drawing/IGraphicsSkia.h
@@ -20,9 +20,6 @@
   #if defined(OS_WIN) && !defined(VK_USE_PLATFORM_WIN32_KHR)
     #define VK_USE_PLATFORM_WIN32_KHR
   #endif
-  #if defined(OS_WIN) && !defined(NOGDI)
-    #define NOGDI // prevent <windows.h> from defining LOGFONT
-  #endif
   #include <vulkan/vulkan.h>
 
 struct VkSwapchainHolder

--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -18,20 +18,8 @@
 
 #include "IGraphicsWinFonts.h"
 
-#if defined(OS_WIN) && defined(IGRAPHICS_SKIA)
-  // Skia's SkTypeface_win.h unconditionally typedefs LOGFONT, which clashes with the
-  // definition provided by the Windows headers. Rename the symbol while Skia headers
-  // are included to avoid the redefinition.
-  #define LOGFONT IGRAPHICS_SKIA_WIN_LOGFONT
-  #define IGRAPHICS_REMAP_LOGFONT
-#endif
-
 #include "IGraphics_select.h"
 
-#ifdef IGRAPHICS_REMAP_LOGFONT
-  #undef LOGFONT
-  #undef IGRAPHICS_REMAP_LOGFONT
-#endif
 #include <string>
 #include <vector>
 

--- a/IGraphics/Skia/SkTypefaceWinWrapper.h
+++ b/IGraphics/Skia/SkTypefaceWinWrapper.h
@@ -1,0 +1,45 @@
+#pragma once
+
+/*
+ ===============================================================================
+
+  This file is part of the iPlug 2 library. Copyright (C) the iPlug 2 developers.
+
+  See LICENSE.txt for  more info.
+
+ ===============================================================================
+*/
+
+/**
+ * @file
+ * @brief Ensures SkTypeface_win.h can be included without LOGFONT collisions.
+ *
+ * Skia's SkTypeface_win.h unconditionally forward declares the Windows LOGFONT
+ * types. If <windows.h> has already been included, those typedefs collide with
+ * the real Windows definitions. Include this wrapper instead of the Skia header
+ * directly so the include order and temporary remapping are handled in one
+ * place.
+ */
+
+#if !defined(OS_WIN) && !defined(_WIN32)
+  #error "SkTypefaceWinWrapper.h should only be included when building for Windows."
+#endif
+
+#if defined(SkTypeface_win_DEFINED)
+  #error "SkTypeface_win.h was included before SkTypefaceWinWrapper.h. Include the wrapper first."
+#endif
+
+#define IGRAPHICS_SKIA_USING_SKTYPEFACE_WIN_WRAPPER 1
+
+#include <windows.h>
+
+#define LOGFONT  IGRAPHICS_SKIA_WRAPPER_LOGFONT
+#define LOGFONTW IGRAPHICS_SKIA_WRAPPER_LOGFONTW
+#define LOGFONTA IGRAPHICS_SKIA_WRAPPER_LOGFONTA
+
+#include "include/ports/SkTypeface_win.h"
+
+#undef LOGFONTA
+#undef LOGFONTW
+#undef LOGFONT
+


### PR DESCRIPTION
## Summary
- add SkTypefaceWinWrapper.h to centralize the Windows/Skia include order and LOGFONT remapping
- switch Skia Windows sources to include the wrapper instead of SkTypeface_win.h and drop local NOGDI hacks
- remove the old LOGFONT remap from IGraphicsWin.h and document the new wrapper in the developer README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c994edd1788329a79c2ace646cfae4