### PR TITLE
Fix Windows Vulkan text entry overlay

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -80,6 +80,7 @@ public:
 
   void CheckTabletInput(UINT msg);
   void DestroyEditWindow();
+  void UpdateTextEntryBounds();
 
   void HideMouseCursor(bool hide, bool lock) override;
   void MoveMouseCursor(float x, float y) override;


### PR DESCRIPTION
## Summary
- wrap the Windows text entry creation logic in Vulkan builds to use a popup window positioned in screen space so the control renders above the swapchain
- track the popup edit control as the host window moves or redraws by updating its bounds and responding to movement messages
- store the graphics instance pointer on the edit window itself to make the subclass procedure work for both child and popup hosts
- qualify Win32 ClientToScreen/GetWindow usages so the Vulkan text entry path builds cleanly on Windows

## Testing
- not run (Windows-specific change; Windows build tooling is unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68c99f0e2e248329a0a0e52fa0fbae21