### PR TITLE
Ensure VST3 view closes UI before release

### DIFF
--- a/IPlug/VST3/IPlugVST3_View.h
+++ b/IPlug/VST3/IPlugVST3_View.h
@@ -29,6 +29,9 @@ public:
   
   ~IPlugVST3View()
   {
+    if (mOwner.HasUI())
+      mOwner.CloseWindow();
+
     mOwner.release();
   }
   


### PR DESCRIPTION
## Summary
- close the editor window from the VST3 view destructor before releasing the owner

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c9b529e5cc83299b5375392b34a8e8