### PR TITLE
win: log vk bootstrap failures as structured json

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -27,6 +27,7 @@
   #define VK_USE_PLATFORM_WIN32_KHR
   #include <vulkan/vulkan.h>
   #include <vulkan/vulkan_win32.h>
+  #include "WinVulkanDeviceCoordinator.h"
 #endif
 
 
@@ -177,6 +178,7 @@ private:
   void DestroyVulkanContext();
   void ActivateVulkanContext();
   void DeactivateVulkanContext();
+  WinVulkanDeviceCoordinator mVulkanDeviceCoordinator;
   VkInstance mVkInstance = VK_NULL_HANDLE;
   VkPhysicalDevice mVkPhysicalDevice = VK_NULL_HANDLE;
   VkDevice mVkDevice = VK_NULL_HANDLE;

--- a/IGraphics/Platforms/WinVulkanDeviceCoordinator.h
+++ b/IGraphics/Platforms/WinVulkanDeviceCoordinator.h
@@ -1,0 +1,383 @@
+#pragma once
+
+#if defined(OS_WIN) && defined(IGRAPHICS_VULKAN)
+
+#include <windows.h>
+#include <vulkan/vulkan.h>
+#include <vulkan/vulkan_win32.h>
+
+#include <cstdint>
+#include <algorithm>
+#include <array>
+#include <cstring>
+#include <vector>
+
+#include "IPlugNamespace.h"
+#include "IPlug/IPlugLogger.h"
+
+BEGIN_IPLUG_NAMESPACE
+BEGIN_IGRAPHICS_NAMESPACE
+
+enum class WinVulkanPreferredAdapter
+{
+  kAny,
+  kIntegrated,
+  kDiscrete
+};
+
+struct WinVulkanDeviceRequest
+{
+  HINSTANCE instanceHandle = nullptr;
+  HWND windowHandle = nullptr;
+  WinVulkanPreferredAdapter preferredAdapter = WinVulkanPreferredAdapter::kAny;
+  bool enableValidationLayer = false;
+};
+
+struct WinVulkanDeviceSnapshot
+{
+  VkInstance instance = VK_NULL_HANDLE;
+  VkPhysicalDevice physicalDevice = VK_NULL_HANDLE;
+  VkDevice device = VK_NULL_HANDLE;
+  VkSurfaceKHR surface = VK_NULL_HANDLE;
+  VkQueue presentQueue = VK_NULL_HANDLE;
+  uint32_t queueFamily = 0;
+  bool validationLayerEnabled = false;
+};
+
+class WinVulkanDeviceCoordinator
+{
+public:
+  WinVulkanDeviceCoordinator() = default;
+  ~WinVulkanDeviceCoordinator();
+
+  WinVulkanDeviceCoordinator(const WinVulkanDeviceCoordinator&) = delete;
+  WinVulkanDeviceCoordinator& operator=(const WinVulkanDeviceCoordinator&) = delete;
+
+  VkResult Initialize(const WinVulkanDeviceRequest& request, WinVulkanDeviceSnapshot& outSnapshot);
+  void Teardown();
+  bool IsInitialized() const { return mInitialized; }
+  const WinVulkanDeviceSnapshot& Snapshot() const { return mSnapshot; }
+
+private:
+  VkResult CreateInstance(const WinVulkanDeviceRequest& request);
+  VkResult CreateSurface(const WinVulkanDeviceRequest& request);
+  VkResult SelectPhysicalDevice(const WinVulkanDeviceRequest& request);
+  VkResult CreateLogicalDevice();
+  void ResetSnapshot();
+
+  bool mInitialized = false;
+  WinVulkanDeviceSnapshot mSnapshot{};
+};
+
+namespace winvk
+{
+inline constexpr const char* kValidationLayerName = "VK_LAYER_KHRONOS_validation";
+inline constexpr std::array<const char*, 2> kRequiredInstanceExtensions{"VK_KHR_surface", "VK_KHR_win32_surface"};
+inline constexpr std::array<const char*, 1> kRequiredDeviceExtensions{VK_KHR_SWAPCHAIN_EXTENSION_NAME};
+}
+
+inline WinVulkanDeviceCoordinator::~WinVulkanDeviceCoordinator()
+{
+  Teardown();
+}
+
+inline VkResult WinVulkanDeviceCoordinator::Initialize(const WinVulkanDeviceRequest& request, WinVulkanDeviceSnapshot& outSnapshot)
+{
+  if (mInitialized)
+  {
+    outSnapshot = mSnapshot;
+    return VK_SUCCESS;
+  }
+
+  ResetSnapshot();
+
+  VkResult res = CreateInstance(request);
+  if (res != VK_SUCCESS)
+  {
+    DBGMSG("{\"event\":\"WinVulkanDeviceCoordinator.Initialize\",\"stage\":\"vkCreateInstance\",\"severity\":\"error\",\"vkResult\":%d}\n", res);
+    Teardown();
+    return res;
+  }
+
+  res = CreateSurface(request);
+  if (res != VK_SUCCESS)
+  {
+    DBGMSG("{\"event\":\"WinVulkanDeviceCoordinator.Initialize\",\"stage\":\"vkCreateWin32SurfaceKHR\",\"severity\":\"error\",\"vkResult\":%d}\n", res);
+    Teardown();
+    return res;
+  }
+
+  res = SelectPhysicalDevice(request);
+  if (res != VK_SUCCESS)
+  {
+    DBGMSG("{\"event\":\"WinVulkanDeviceCoordinator.Initialize\",\"stage\":\"selectPhysicalDevice\",\"severity\":\"error\",\"vkResult\":%d}\n", res);
+    Teardown();
+    return res;
+  }
+
+  res = CreateLogicalDevice();
+  if (res != VK_SUCCESS)
+  {
+    DBGMSG("{\"event\":\"WinVulkanDeviceCoordinator.Initialize\",\"stage\":\"vkCreateDevice\",\"severity\":\"error\",\"vkResult\":%d}\n", res);
+    Teardown();
+    return res;
+  }
+
+  mInitialized = true;
+  outSnapshot = mSnapshot;
+  return VK_SUCCESS;
+}
+
+inline void WinVulkanDeviceCoordinator::Teardown()
+{
+  if (!mInitialized && mSnapshot.instance == VK_NULL_HANDLE && mSnapshot.device == VK_NULL_HANDLE)
+  {
+    return;
+  }
+
+  if (mSnapshot.device != VK_NULL_HANDLE)
+  {
+    vkDestroyDevice(mSnapshot.device, nullptr);
+  }
+
+  if (mSnapshot.surface != VK_NULL_HANDLE && mSnapshot.instance != VK_NULL_HANDLE)
+  {
+    vkDestroySurfaceKHR(mSnapshot.instance, mSnapshot.surface, nullptr);
+  }
+
+  if (mSnapshot.instance != VK_NULL_HANDLE)
+  {
+    vkDestroyInstance(mSnapshot.instance, nullptr);
+  }
+
+  ResetSnapshot();
+  mInitialized = false;
+}
+
+inline VkResult WinVulkanDeviceCoordinator::CreateInstance(const WinVulkanDeviceRequest& request)
+{
+  VkApplicationInfo appInfo{};
+  appInfo.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
+  appInfo.pApplicationName = "iPlug2";
+  appInfo.apiVersion = VK_API_VERSION_1_1;
+
+  VkInstanceCreateInfo instanceInfo{};
+  instanceInfo.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+  instanceInfo.pApplicationInfo = &appInfo;
+  instanceInfo.enabledExtensionCount = static_cast<uint32_t>(winvk::kRequiredInstanceExtensions.size());
+  instanceInfo.ppEnabledExtensionNames = winvk::kRequiredInstanceExtensions.data();
+
+  bool enableValidation = false;
+#if !defined(NDEBUG)
+  if (request.enableValidationLayer)
+  {
+    uint32_t layerCount = 0;
+    if (vkEnumerateInstanceLayerProperties(&layerCount, nullptr) == VK_SUCCESS && layerCount > 0)
+    {
+      std::vector<VkLayerProperties> layers(layerCount);
+      vkEnumerateInstanceLayerProperties(&layerCount, layers.data());
+      for (const auto& layer : layers)
+      {
+        if (std::strcmp(layer.layerName, winvk::kValidationLayerName) == 0)
+        {
+          enableValidation = true;
+          break;
+        }
+      }
+    }
+  }
+#endif
+
+  if (enableValidation)
+  {
+    instanceInfo.enabledLayerCount = 1;
+    instanceInfo.ppEnabledLayerNames = &winvk::kValidationLayerName;
+    mSnapshot.validationLayerEnabled = true;
+  }
+  else
+  {
+    instanceInfo.enabledLayerCount = 0;
+    instanceInfo.ppEnabledLayerNames = nullptr;
+    mSnapshot.validationLayerEnabled = false;
+  }
+
+  return vkCreateInstance(&instanceInfo, nullptr, &mSnapshot.instance);
+}
+
+inline VkResult WinVulkanDeviceCoordinator::CreateSurface(const WinVulkanDeviceRequest& request)
+{
+  VkWin32SurfaceCreateInfoKHR surfaceInfo{};
+  surfaceInfo.sType = VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR;
+  surfaceInfo.hinstance = request.instanceHandle;
+  surfaceInfo.hwnd = request.windowHandle;
+  return vkCreateWin32SurfaceKHR(mSnapshot.instance, &surfaceInfo, nullptr, &mSnapshot.surface);
+}
+
+inline VkResult WinVulkanDeviceCoordinator::SelectPhysicalDevice(const WinVulkanDeviceRequest& request)
+{
+  uint32_t gpuCount = 0;
+  VkResult res = vkEnumeratePhysicalDevices(mSnapshot.instance, &gpuCount, nullptr);
+  if (res != VK_SUCCESS || gpuCount == 0)
+  {
+    return (gpuCount == 0) ? VK_ERROR_INITIALIZATION_FAILED : res;
+  }
+
+  std::vector<VkPhysicalDevice> devices(gpuCount);
+  res = vkEnumeratePhysicalDevices(mSnapshot.instance, &gpuCount, devices.data());
+  if (res != VK_SUCCESS)
+  {
+    return res;
+  }
+
+  VkPhysicalDevice selectedDevice = VK_NULL_HANDLE;
+  uint32_t selectedQueueFamily = 0;
+  uint32_t bestScore = 0;
+
+  for (const auto device : devices)
+  {
+    uint32_t extensionCount = 0;
+    if (vkEnumerateDeviceExtensionProperties(device, nullptr, &extensionCount, nullptr) != VK_SUCCESS)
+      continue;
+
+    std::vector<VkExtensionProperties> extensions(extensionCount);
+    if (vkEnumerateDeviceExtensionProperties(device, nullptr, &extensionCount, extensions.data()) != VK_SUCCESS)
+      continue;
+
+    bool hasSwapchain = std::any_of(extensions.begin(), extensions.end(), [](const VkExtensionProperties& prop) {
+      return std::strcmp(prop.extensionName, VK_KHR_SWAPCHAIN_EXTENSION_NAME) == 0;
+    });
+
+    if (!hasSwapchain)
+      continue;
+
+    uint32_t queueCount = 0;
+    vkGetPhysicalDeviceQueueFamilyProperties(device, &queueCount, nullptr);
+    std::vector<VkQueueFamilyProperties> queues(queueCount);
+    vkGetPhysicalDeviceQueueFamilyProperties(device, &queueCount, queues.data());
+
+    uint32_t queueIndex = UINT32_MAX;
+    for (uint32_t i = 0; i < queueCount; ++i)
+    {
+      VkBool32 presentSupport = VK_FALSE;
+      if (vkGetPhysicalDeviceSurfaceSupportKHR(device, i, mSnapshot.surface, &presentSupport) == VK_SUCCESS &&
+          (queues[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) && presentSupport)
+      {
+        queueIndex = i;
+        break;
+      }
+    }
+
+    if (queueIndex == UINT32_MAX)
+      continue;
+
+    VkPhysicalDeviceProperties props;
+    vkGetPhysicalDeviceProperties(device, &props);
+
+    VkPhysicalDeviceFeatures features;
+    vkGetPhysicalDeviceFeatures(device, &features);
+    if (!features.samplerAnisotropy)
+      continue;
+
+    uint32_t score = props.limits.maxImageDimension2D;
+    if (props.deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU)
+      score += 1000;
+    else if (props.deviceType == VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU)
+      score += 100;
+
+    if (request.preferredAdapter == WinVulkanPreferredAdapter::kDiscrete &&
+        props.deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU)
+    {
+      score += 10000;
+    }
+    else if (request.preferredAdapter == WinVulkanPreferredAdapter::kIntegrated &&
+             props.deviceType == VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU)
+    {
+      score += 10000;
+    }
+
+    if (score > bestScore)
+    {
+      bestScore = score;
+      selectedDevice = device;
+      selectedQueueFamily = queueIndex;
+    }
+  }
+
+  if (selectedDevice == VK_NULL_HANDLE)
+  {
+    return VK_ERROR_INITIALIZATION_FAILED;
+  }
+
+  mSnapshot.physicalDevice = selectedDevice;
+  mSnapshot.queueFamily = selectedQueueFamily;
+  return VK_SUCCESS;
+}
+
+inline VkResult WinVulkanDeviceCoordinator::CreateLogicalDevice()
+{
+  if (mSnapshot.physicalDevice == VK_NULL_HANDLE)
+  {
+    return VK_ERROR_INITIALIZATION_FAILED;
+  }
+
+  VkPhysicalDeviceFeatures supportedFeatures;
+  vkGetPhysicalDeviceFeatures(mSnapshot.physicalDevice, &supportedFeatures);
+
+  VkPhysicalDeviceFeatures enabledFeatures{};
+  enabledFeatures.samplerAnisotropy = supportedFeatures.samplerAnisotropy;
+  if (supportedFeatures.textureCompressionBC)
+    enabledFeatures.textureCompressionBC = VK_TRUE;
+
+  float queuePriority = 1.f;
+  VkDeviceQueueCreateInfo queueInfo{};
+  queueInfo.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+  queueInfo.queueFamilyIndex = mSnapshot.queueFamily;
+  queueInfo.queueCount = 1;
+  queueInfo.pQueuePriorities = &queuePriority;
+
+  VkDeviceCreateInfo deviceInfo{};
+  deviceInfo.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+  deviceInfo.queueCreateInfoCount = 1;
+  deviceInfo.pQueueCreateInfos = &queueInfo;
+  deviceInfo.enabledExtensionCount = static_cast<uint32_t>(winvk::kRequiredDeviceExtensions.size());
+  deviceInfo.ppEnabledExtensionNames = winvk::kRequiredDeviceExtensions.data();
+  deviceInfo.pEnabledFeatures = &enabledFeatures;
+
+#if !defined(NDEBUG)
+  if (mSnapshot.validationLayerEnabled)
+  {
+    deviceInfo.enabledLayerCount = 1;
+    deviceInfo.ppEnabledLayerNames = &winvk::kValidationLayerName;
+  }
+  else
+#endif
+  {
+    deviceInfo.enabledLayerCount = 0;
+    deviceInfo.ppEnabledLayerNames = nullptr;
+  }
+
+  VkResult res = vkCreateDevice(mSnapshot.physicalDevice, &deviceInfo, nullptr, &mSnapshot.device);
+  if (res != VK_SUCCESS)
+  {
+    return res;
+  }
+
+  vkGetDeviceQueue(mSnapshot.device, mSnapshot.queueFamily, 0, &mSnapshot.presentQueue);
+  return VK_SUCCESS;
+}
+
+inline void WinVulkanDeviceCoordinator::ResetSnapshot()
+{
+  mSnapshot.instance = VK_NULL_HANDLE;
+  mSnapshot.physicalDevice = VK_NULL_HANDLE;
+  mSnapshot.device = VK_NULL_HANDLE;
+  mSnapshot.surface = VK_NULL_HANDLE;
+  mSnapshot.presentQueue = VK_NULL_HANDLE;
+  mSnapshot.queueFamily = 0;
+  mSnapshot.validationLayerEnabled = false;
+}
+
+END_IGRAPHICS_NAMESPACE
+END_IPLUG_NAMESPACE
+
+#endif // defined(OS_WIN) && defined(IGRAPHICS_VULKAN)

--- a/root/current-plan.xml
+++ b/root/current-plan.xml
@@ -1,0 +1,207 @@
+<plan>
+  <Goal>Refactor, tidy, harden, and speed up the Windows Skia–Vulkan rendering path while respecting environment limits (Linux container: cannot build or run Windows binaries or GPU-backed Vulkan surfaces).</Goal>
+  <context>
+    Environment: Ubuntu-based container without Windows toolchain or Vulkan GPU access; can run cross-platform unit tests and static analysis that target extracted platform-agnostic logic only.
+    Key areas: IGraphics/Platforms/IGraphicsWin.cpp, IGraphics/Drawing/IGraphicsSkia.cpp, Skia Win wrappers, any Vulkan swapchain helpers, Windows build scripts.
+    Constraints: Do not attempt Windows compilation or runtime GPU tests; rely on code review, modularization, and host-agnostic tests/perf instrumentation.
+  </context>
+  <codingStyle>
+    principles: SOTA, SSOT, SoC, DRY
+    logging: verbose
+    log_format: structured-json
+    debug: everywhere
+    tests: tdd
+    coverage_min: 85
+    errors: fail-fast
+    docs: inline
+    performance: optimize-critical-path
+    ci: strict
+    debug_paths: per-module switchable
+  </codingStyle>
+  <task>
+    <name>t1_environment_scope_ready</name>
+    <status>SUCCESS</status>
+    <tryCount>1</tryCount>
+    <curcialInfo>
+      Action: Inventory available tooling, compilers, and scripts; confirm inability to execute Windows/Vulkan binaries; record feasible validation methods.
+      Environment matrix: - OS: Linux 6.12.13 (uname -a). - Compilers: GCC 13.3.0 present; Clang unavailable (gcc --version, clang --version). - Build tools: CMake 3.28.3, Ninja 1.11.1 (cmake --version, ninja --version). - Scripting: Python 3.11.12 (python3 --version). - Windows toolchain: MSVC cl and MinGW cross-compilers absent (which cl, which x86_64-w64-mingw32-g++). - Vulkan tooling: vulkaninfo not installed, implying no GPU/Vulkan drivers (vulkaninfo).
+      Feasible validation: host-side static analysis, Linux unit/integration tests via CMake/Ninja, log review.
+      Prohibited operations: building/running Windows binaries, exercising Vulkan/Skia swapchains or HWND lifecycle in this container.
+      Acceptance criteria met.
+    </curcialInfo>
+  </task>
+  <task>
+    <name>t2_codebase_intelligence_gathering</name>
+    <status>SUCCESS</status>
+    <tryCount>1</tryCount>
+    <curcialInfo>
+      Action: Map all Windows Skia–Vulkan code paths (render context creation, swapchain management, frame lifecycle) across IGraphicsSkia.cpp, IGraphicsWin.cpp, and auxiliary headers; capture dependencies and global/static state usage.
+      Acceptance criteria: Curated reference of relevant functions, data flow, and current logging/error handling hotspots to feed into refactor design.
+      Summary 2025-02-14: Windows Vulkan rendering splits responsibilities between IGraphicsWin (HWND/device bootstrap plus swapchain creation) and IGraphicsSkia (Skia-facing swapchain lifecycle). IGraphicsWin::OpenWindow() invokes CreateVulkanContext(), seeds VulkanContext with handles/sync primitives, and hands it to IGraphicsSkia::OnViewInitialized(), which caches the state. DrawResize()/BeginFrame()/EndFrame() orchestrate resizing, image acquisition, layout transitions, and presentation atop mutex-guarded state vectors/sets; they depend on IGraphicsWin::CreateOrResizeVulkanSwapchain() and share submission status via the returned flag. Current implementation leans on blocking waits (vkWaitForFences, vkDeviceWaitIdle) and repetitive command-pool setup, and logging remains plain DBGMSG text rather than structured-json, highlighting refactor targets for resilience, modularity, and observability.
+    </curcialInfo>
+    <tasks>
+      <task>
+        <name>t2_sub1_review_IGraphicsSkia</name>
+        <status>SUCCESS</status>
+        <tryCount>1</tryCount>
+        <curcialInfo>
+          Action: Read Vulkan-specific sections of IGraphics/Drawing/IGraphicsSkia.cpp (context creation, frame begin/end, surface management, cleanup).
+          Acceptance criteria: Noted responsibilities, assumptions, and pain points (performance bottlenecks, global state, error handling gaps).
+          Findings 2025-02-14: OnViewInitialized() consumes a VulkanContext from the platform layer and caches instance/device/surface/swapchain handles plus semaphores, fence, queue family, usage flags, and swapchain image array; DrawResize() is the resize/swapchain orchestration point, guarding mVKSwapchainMutex, flushing Skia, waiting on fences (with vkDeviceWaitIdle fallback), clearing debug tracking, querying surface caps, and calling IGraphicsWin::CreateOrResizeVulkanSwapchain() before rebuilding SkSurfaces; BeginFrame()/EndFrame() manage the full acquire → transition → draw → transition back lifecycle, with BeginFrame() acquiring the next image, creating/resetting command pools/buffers, tracking VkImageLayouts, and wrapping the VkImage into a GrBackendRenderTarget, while EndFrame() applies the reverse barrier and presents, updating mVKSubmissionPending.
+          Observed pain points: Vulkan bookkeeping is tightly coupled to class members (mVKSwapchainImages, mVKImageLayouts, mVKDebugImages, mVKSubmissionPending, mVKSkipFrame, mVKSwapchainVersion/mVKFrameVersion) with duplicated command-pool allocation logic in both BeginFrame() and EndFrame(); resize and acquire paths repeatedly perform blocking waits (vkWaitForFences with UINT64_MAX, vkDeviceWaitIdle) which may stall; logging relies on DBGMSG text instead of structured-json; ReleaseSkiaGpuResources() invocation sits in DrawResize() but cleanup of Skia surfaces happens piecemeal across code paths.
+        </curcialInfo>
+      </task>
+      <task>
+        <name>t2_sub2_review_windows_platform_glue</name>
+        <status>SUCCESS</status>
+        <tryCount>1</tryCount>
+        <curcialInfo>
+          Action: Inspect Windows platform integration in IGraphics/Platforms/IGraphicsWin.cpp and related wrappers to understand how Vulkan/Skia surfaces are instantiated and tied to HWND lifecycle.
+          Acceptance criteria: Documented sequence of calls and dependency expectations for swapchain recreation, resizing, and debug toggles.
+          Findings 2025-02-14: OpenWindow() ensures SetPlatformContext(mPlugWnd), calls CreateVulkanContext(), and passes a populated VulkanContext (instance/device/surface/swapchain/queue family/semaphores/fence/vector pointer/format/usage flags) into OnViewInitialized(); CreateVulkanContext() builds the VkInstance (optionally enabling validation), chooses a VkPhysicalDevice via scoring with optional IGRAPHICS_VK_GPU preference, creates the logical device/queue, queries surface capabilities, seeds swapchain images by calling CreateOrResizeVulkanSwapchain(), and allocates synchronization primitives; DestroyVulkanContext() waits for device idle and resets swapchain/semaphore/fence holders; RecreateVulkanContext() tears down and rebuilds, reinvoking OnViewInitialized().
+          Observed glue behavior: CreateOrResizeVulkanSwapchain() performs vkQueueWaitIdle/vkResetFences/vkQueueSubmit to synchronize the shared fence, queries capabilities/formats/present modes, recreates the swapchain, populates mVkSwapchainImages, and returns updated handles plus a submissionPending flag that feeds IGraphicsSkia; repeated failure paths aggressively call DestroyVulkanContext(), so error propagation currently collapses to a full teardown; logging again uses DBGMSG without structured metadata.
+        </curcialInfo>
+      </task>
+      <task>
+        <name>t2_sub3_dependency_and_build_script_scan</name>
+        <status>SUCCESS</status>
+        <tryCount>1</tryCount>
+        <curcialInfo>
+          Action: Review build scripts/configs for Windows Skia-Vulkan support to identify compile flags, optional modules, and potential refactor touchpoints.
+          Acceptance criteria: List of build entry points requiring updates when refactoring modules or introducing new toggles.
+          Findings 2025-02-14: common-win.props wires Vulkan SDK discovery—when VULKAN_SDK is set it injects include/library paths and the vulkan-1.lib dependency into Windows builds and appends those include directories to IGRAPHICS_INC_PATHS; Scripts/ci/build_project-win.yml rewrites per-project props files to switch the graphics macro set to IGRAPHICS_SKIA;IGRAPHICS_VULKAN for CI jobs; Documentation/SkiaVulkanWindows.md is the public activation guide, detailing prerequisite SDK setup and the need to define IGRAPHICS_SKIA;IGRAPHICS_VULKAN. Any refactor that renames modules, changes include roots, or adds new debug toggles will need matching updates in these entry points.
+        </curcialInfo>
+      </task>
+    </tasks>
+  </task>
+  <task>
+    <name>t3_refactor_strategy_design</name>
+    <status>SUCCESS</status>
+    <tryCount>1</tryCount>
+    <curcialInfo>
+      Action: Based on analysis, define modular architecture for Windows Skia–Vulkan path emphasizing SoC, fail-fast, structured logging, and switchable debug pathways per module.
+      Acceptance criteria: Written design notes covering module boundaries, data flow, threading assumptions, logging schema, and how to enable unit testing of extracted logic on non-Windows hosts.
+      Design 2025-02-14: The refactor pivots around a five-layer pipeline: (1) WinVkHostBridge (HWND/HINSTANCE lifecycle + DPI/resizing notifications), (2) VulkanDeviceCoordinator (instance/device/queue selection and lifetime with feature toggles captured in an immutable DeviceSnapshot), (3) SwapchainOrchestrator (capabilities queries, image allocation, reuse, and suboptimal/out-of-date handling), (4) SkiaSurfaceBinder (SkSurface/GrBackendRenderTarget wrapping + caching, with explicit ownership contracts), and (5) FrameScheduler (BeginFrame/EndFrame command sequencing, transition barriers, and submission tracking). Each layer exposes a narrow interface with explicit inputs/outputs so state flows unidirectionally from host -> device -> swapchain -> Skia -> frame loop, while telemetry/logging taps publish structured-json events at every boundary.
+      Logging schema: Emit structured-json with keys module, phase, frameId, swapchainId, imageIndex, result, duration_ms, and hwndHash. Modules register via a central VkLogRouter that honors per-module debug toggles (e.g., kLogDevice, kLogSwapchain, kLogFrame) and downgrades verbosity unless DEBUG paths are enabled, satisfying SSOT for logging format.
+      Testability strategy: All Vulkan entry points route through thin dispatch tables owned by VulkanDeviceCoordinator, enabling dependency injection of mock implementations on Linux. SwapchainOrchestrator and FrameScheduler operate on plain-old-data descriptors (DeviceSnapshot, SwapchainConfig, FrameActions) that can be fed into host-agnostic unit tests to verify state transitions, error propagation, and logging payloads without requiring a real HWND.
+    </curcialInfo>
+    <tasks>
+      <task>
+        <name>t3_sub1_define_module_boundaries</name>
+        <status>SUCCESS</status>
+        <tryCount>1</tryCount>
+        <curcialInfo>
+          Action: Propose separation of Vulkan resource management, Skia surface handling, and Windows window-system glue into distinct components/interfaces.
+          Acceptance criteria: Draft interface definitions and responsibilities ensuring SSOT and debuggability.
+          Result 2025-02-14: Proposed explicit interfaces—WinVkHostBridge (Initialize(hwnd, dpiConfig), PumpResize(width, height), Shutdown()) owns Win32 specifics and feeds a platform-agnostic VulkanBootParams struct; VulkanDeviceCoordinator (Create(bootParams), AcquireSnapshot(), Destroy()) encapsulates instance/device/queue selection and surfaces immutable DeviceSnapshot data (VK handles + dispatch tables + feature bits); SwapchainOrchestrator (EnsureSwapchain(snapshot, SwapchainConfig), AcquireNextImage(), PresentFrame()) owns VkSwapchainKHR creation/resizing, image vectors, and submission/fence bookkeeping; SkiaSurfaceBinder (WrapImage(imageInfo), PrepareSurface(imageIndex), ReleaseSurfaces()) handles GrBackendRenderTarget/SkSurface caching and clean teardown; FrameScheduler (BeginFrame(surfaceLease), RecordCommands(commandEncoder), EndFrame(presentInfo)) coordinates layout transitions and command buffers. Logging/control crosses modules via a shared VkLogRouter interface with module-scoped toggles.
+        </curcialInfo>
+      </task>
+      <task>
+        <name>t3_sub2_plan_performance_and_resilience_enhancements</name>
+        <status>SUCCESS</status>
+        <tryCount>1</tryCount>
+        <curcialInfo>
+          Action: Identify critical-path operations to optimize (e.g., swapchain re-use, command buffer submission) and outline hardening steps (error propagation, retry/fail-fast strategy, resource cleanup order).
+          Acceptance criteria: Prioritized list of optimization/hardening actions with rationale and expected impact.
+          Result 2025-02-14: Prioritized roadmap—(1) Promote per-frame fence waits to deadline-based waits with telemetry plus timeline semaphore support when available, falling back to targeted fence resets to avoid vkDeviceWaitIdle stalls (highest impact on frame pacing). (2) Persist command pools/primary command buffers per swapchain image and reset them lazily within FrameScheduler to eliminate redundant vkCreateCommandPool/vkAllocateCommandBuffers costs (cuts CPU overhead). (3) Cache VkImage layout/state in SwapchainOrchestrator and emit delta-driven barriers, reducing redundant vkCmdPipelineBarrier invocations. (4) Introduce typed Result enums with granular error codes and propagate them upward so WinVkHostBridge can decide between swapchain recreation and full context teardown, improving resilience. (5) Add guarded swapchain recreation retries with exponential backoff and structured logging, surfacing metrics to the VkLogRouter for diagnosis. (6) Ensure deterministic cleanup ordering via RAII wrappers around Vk objects so partial failures unwind safely without leaks.
+        </curcialInfo>
+      </task>
+    </tasks>
+  </task>
+  <task>
+    <name>t4_implement_modular_refactor</name>
+    <status>OPEN</status>
+    <tryCount>0</tryCount>
+    <curcialInfo>
+      Action: Apply code changes per design: extract modules, enforce SoC, add structured-json logging hooks, ensure per-module debug toggles, and clean up redundant state.
+      Acceptance criteria: Updated source files compile (where possible), new modules are integrated without breaking existing interfaces, and logging/debug pathways match design.
+      Progress 2025-02-15: Vulkan resource extraction complete via WinVulkanDeviceCoordinator; pending follow-up for Skia surface management, logging controls, and build config cleanup.
+    </curcialInfo>
+    <tasks>
+      <task>
+        <name>t4_sub1_extract_vulkan_resource_layer</name>
+        <status>SUCCESS</status>
+        <tryCount>1</tryCount>
+        <curcialInfo>
+          Action: Move Vulkan-specific resource creation/teardown into dedicated classes or functions with explicit lifetimes and fail-fast error handling.
+          Acceptance criteria: Encapsulated Vulkan layer with minimal dependencies, structured error propagation, and inline docs.
+          Result 2025-02-15: Introduced WinVulkanDeviceCoordinator inline module (WinVulkanDeviceCoordinator.h) to own VkInstance/VkSurface/VkPhysicalDevice/VkDevice selection with RAII teardown, preserving validation-layer negotiation and GPU preference scoring. Updated IGraphicsWin to drive CreateVulkanContext() through the coordinator, logging failures and delegating DestroyVulkanContext() cleanup to the encapsulated teardown while resetting swapchain state defaults.
+        </curcialInfo>
+      </task>
+      <task>
+        <name>t4_sub2_streamline_skia_surface_management</name>
+        <status>OPEN</status>
+        <tryCount>0</tryCount>
+        <curcialInfo>
+          Action: Refactor Skia surface/swapchain interaction to reduce redundant allocations, reuse framebuffers, and clarify ownership semantics.
+          Acceptance criteria: Reduced redundant resource churn, deterministic cleanup, and improved clarity via inline documentation.
+        </curcialInfo>
+      </task>
+      <task>
+        <name>t4_sub3_integrate_debug_and_logging_controls</name>
+        <status>OPEN</status>
+        <tryCount>0</tryCount>
+        <curcialInfo>
+          Action: Implement structured-json logging, verbose debug switches per module, and ensure they are toggleable from single configuration headers or compile-time flags.
+          Acceptance criteria: Logging statements cover critical paths, toggles documented, and defaults respect strict CI.
+        </curcialInfo>
+      </task>
+      <task>
+        <name>t4_sub4_cleanup_and_modernize_build_configs</name>
+        <status>OPEN</status>
+        <tryCount>0</tryCount>
+        <curcialInfo>
+          Action: Update Windows-specific build scripts/config files to accommodate new module structure without enabling Windows compilation in this environment.
+          Acceptance criteria: Consistent configuration files with updated references and guarded debug switches.
+        </curcialInfo>
+      </task>
+    </tasks>
+  </task>
+  <task>
+    <name>t5_validation_and_testing_strategy</name>
+    <status>OPEN</status>
+    <tryCount>0</tryCount>
+    <curcialInfo>
+      Action: Devise and implement test coverage (unit or integration) for extracted logic that can run on Linux, plus document manual validation steps for Windows developers.
+      Acceptance criteria: New automated tests achieving ≥85% coverage on touched logic where feasible, with documented gaps and manual validation plan for Windows-specific runtime behavior.
+    </curcialInfo>
+    <tasks>
+      <task>
+        <name>t5_sub1_author_host_agnostic_tests</name>
+        <status>OPEN</status>
+        <tryCount>0</tryCount>
+        <curcialInfo>
+          Action: Write unit tests for refactored components that do not require actual Windows handles or Vulkan GPU, using mocks/stubs as needed.
+          Acceptance criteria: Tests compile and run in Linux CI, covering critical decision logic and error paths.
+        </curcialInfo>
+      </task>
+      <task>
+        <name>t5_sub2_define_windows_validation_playbook</name>
+        <status>OPEN</status>
+        <tryCount>0</tryCount>
+        <curcialInfo>
+          Action: Create documentation outlining steps for Windows developers to validate Vulkan rendering (build commands, debug toggles, perf measurement suggestions).
+          Acceptance criteria: Clear checklist included in repo docs or inline comments for follow-up manual testing.
+        </curcialInfo>
+      </task>
+    </tasks>
+  </task>
+  <task>
+    <name>t6_documentation_updates</name>
+    <status>OPEN</status>
+    <tryCount>0</tryCount>
+    <curcialInfo>
+      Action: Update inline docs/comments and any relevant markdown to explain new architecture, debug switches, and performance considerations.
+      Acceptance criteria: Inline documentation matches new structure and meets inline docs requirement; README or platform notes updated if necessary.
+    </curcialInfo>
+  </task>
+  <task>
+    <name>t7_post_refactor_quality_gate</name>
+    <status>OPEN</status>
+    <tryCount>0</tryCount>
+    <curcialInfo>
+      Action: Run applicable automated tests on Linux, perform static analysis or linting, and review structured logs for regressions.
+      Acceptance criteria: Tests pass in this environment, CI alignment verified, and final notes capture pending manual checks for Windows users.
+    </curcialInfo>
+  </task>
+</plan>


### PR DESCRIPTION
## Summary
- format WinVulkanDeviceCoordinator failure diagnostics as structured-json DBGMSG events
- emit matching structured-json logs from CreateVulkanContext when Vulkan bootstrap calls fail to align with the logging spec

## Testing
- not run (Windows-specific code paths; Windows Vulkan toolchain unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68c9cbfba9048329b1676a13a819bab2