### PR TITLE
Fix missing includes for Vulkan builds

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.h
+++ b/IGraphics/Drawing/IGraphicsSkia.h
@@ -21,6 +21,7 @@
     #define VK_USE_PLATFORM_WIN32_KHR
   #endif
   #include <vulkan/vulkan.h>
+  #include "include/gpu/vk/GrVkTypes.h"
 
 struct VkSwapchainHolder
 {

--- a/IGraphics/Platforms/WinVulkanDeviceCoordinator.h
+++ b/IGraphics/Platforms/WinVulkanDeviceCoordinator.h
@@ -12,7 +12,7 @@
 #include <cstring>
 #include <vector>
 
-#include "IPlugNamespace.h"
+#include "IPlugPlatform.h"
 #include "IPlug/IPlugLogger.h"
 #include "VulkanLogging.h"
 


### PR DESCRIPTION
## Summary
- include IPlugPlatform instead of the non-existent IPlugNamespace header in the Vulkan device coordinator
- add the GrVkTypes include so GrVkImageInfo is available to the Skia Vulkan backend

## Testing
- not run (header-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cb44f5568c8329bd0fb9023b3f9b48