### PR TITLE
Resync swapchain layout tracking on acquire

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -1347,6 +1347,20 @@ void IGraphicsSkia::BeginFrame()
     }
     VkImage acquiredImage = (imageIndex < mVKSwapchainImages.size()) ? mVKSwapchainImages[imageIndex] : VK_NULL_HANDLE;
     VkImageLayout acquiredLayout = (imageIndex < mVKImageLayouts.size()) ? mVKImageLayouts[imageIndex] : VK_IMAGE_LAYOUT_UNDEFINED;
+    if (imageIndex < mVKImageLayouts.size() &&
+        acquiredLayout != VK_IMAGE_LAYOUT_UNDEFINED &&
+        acquiredLayout != VK_IMAGE_LAYOUT_PRESENT_SRC_KHR)
+    {
+      IGRAPHICS_VK_LOG("BeginFrame",
+                          "acquiredImageUnexpectedLayout",
+                          vulkanlog::Severity::kWarning,
+                          vulkanlog::MakeField("imageIndex", imageIndex),
+                           vulkanlog::MakeField("trackedLayout", static_cast<int>(acquiredLayout)),
+                           vulkanlog::MakeField("frameVersion", static_cast<uint64_t>(mVKFrameVersion)),
+                           vulkanlog::MakeField("swapchainVersion", static_cast<uint64_t>(mVKSwapchainVersion)));
+      acquiredLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+      mVKImageLayouts[imageIndex] = acquiredLayout;
+    }
     IGRAPHICS_VK_LOG("BeginFrame",
                         "acquiredImage",
                         vulkanlog::Severity::kDebug,
@@ -1477,13 +1491,17 @@ void IGraphicsSkia::BeginFrame()
       return;
     }
     VkResult waitRes = vkWaitForFences(mVKDevice, 1, &mVKInFlightFence, VK_TRUE, UINT64_MAX);
-    if (waitRes == VK_SUCCESS)
-      vkResetFences(mVKDevice, 1, &mVKInFlightFence);
-    else
+    if (waitRes != VK_SUCCESS)
+    {
       IGRAPHICS_VK_LOG("BeginFrame",
                           "waitForFencesFailed",
                           vulkanlog::Severity::kError,
                           vulkanlog::MakeField("vkResult", static_cast<int>(waitRes)));
+      mVKSkipFrame = true;
+      mVKCurrentImage = kInvalidImageIndex;
+      return;
+    }
+    vkResetFences(mVKDevice, 1, &mVKInFlightFence);
 
     mVKImageLayouts[imageIndex] = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     IGRAPHICS_VK_LOG("BeginFrame",
@@ -1739,14 +1757,17 @@ void IGraphicsSkia::EndFrame()
 
   VkResult submitRes = vkQueueSubmit(mVKQueue, 1, &submitInfo, mVKInFlightFence);
   bool previousPending = mVKSubmissionPending;
-  mVKImageLayouts[mVKCurrentImage] = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+  if (submitRes == VK_SUCCESS)
+  {
+    mVKImageLayouts[mVKCurrentImage] = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+  }
   bool newPending = (submitRes == VK_SUCCESS);
   IGRAPHICS_VK_LOG("EndFrame",
                       "layoutUpdated",
                       vulkanlog::Severity::kDebug,
                       vulkanlog::MakeField("imageIndex", static_cast<uint32_t>(mVKCurrentImage)),
                        vulkanlog::MakeHandleField("image", vulkanlog::HandleToUint64(swapImage)),
-                       vulkanlog::MakeField("layout", static_cast<int>(mVKImageLayouts[mVKCurrentImage])),
+                       vulkanlog::MakeField("layout", static_cast<int>((mVKCurrentImage < mVKImageLayouts.size()) ? mVKImageLayouts[mVKCurrentImage] : VK_IMAGE_LAYOUT_UNDEFINED)),
                        vulkanlog::MakeField("previousPending", previousPending),
                        vulkanlog::MakeField("newPending", newPending));
   mVKSubmissionPending = newPending;


### PR DESCRIPTION
## Summary
- detect unexpected tracked swapchain image layouts on acquisition and reset them to present so layout transitions run

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb503ca0248329a89c9c4b145ee9b8