### PR TITLE
Fix Vulkan layout transition stage mask

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -1444,7 +1444,7 @@ void IGraphicsSkia::BeginFrame()
     {
     case VK_IMAGE_LAYOUT_PRESENT_SRC_KHR:
       barrier.srcAccessMask = VK_ACCESS_MEMORY_READ_BIT;
-      srcStageMask = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
+      srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
       break;
     case VK_IMAGE_LAYOUT_UNDEFINED:
       barrier.srcAccessMask = 0;


### PR DESCRIPTION
## Summary
- ensure Vulkan swapchain image transitions from present to color attachment wait on the color output stage

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb5681f9708329a5ef67cc52dc75cf