### PR TITLE
Avoid waiting on unsignaled fence when preparing swapchain

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.h
+++ b/IGraphics/Drawing/IGraphicsSkia.h
@@ -269,6 +269,7 @@ private:
   uint64_t mVKFrameVersion = 0;
   std::mutex mVKSwapchainMutex;
   std::unordered_set<VkImage> mVKDebugImages;
+  bool PrepareCurrentSwapchainImageForFlush();
   void ResetVulkanSwapchainCaches();
   VkCommandBuffer EnsureVulkanCommandBuffer();
   sk_sp<SkSurface> EnsureSwapchainSurface(uint32_t imageIndex, int width, int height, const GrVkImageInfo& imageInfo);


### PR DESCRIPTION
## Summary
- wait for the in-flight fence during swapchain flush prep only when a submission is still pending
- check the fence reset result so we fail early instead of blocking when the fence is already unsignaled

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb586d6e68832998ca3958f9d54c36