### PR TITLE
Prevent Vulkan flush when swapchain image not prepared

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -880,8 +880,15 @@ void IGraphicsSkia::OnViewDestroyed()
 #elif defined IGRAPHICS_VULKAN
   if (mGrContext)
   {
-    PrepareCurrentSwapchainImageForFlush();
-    mGrContext->flushAndSubmit();
+    bool preparedForFlush = PrepareCurrentSwapchainImageForFlush();
+    if (preparedForFlush)
+    {
+      mGrContext->flushAndSubmit();
+    }
+    else
+    {
+      IGRAPHICS_VK_LOG_SIMPLE("OnViewDestroyed", "skipFlushNoPreparedSwapchainImage", vulkanlog::Severity::kInfo);
+    }
     ReleaseSkiaGpuResources(mGrContext.get());
     mGrContext->releaseResourcesAndAbandonContext();
   }
@@ -1066,8 +1073,15 @@ void IGraphicsSkia::DrawResize()
     }
     if (mGrContext)
     {
-      PrepareCurrentSwapchainImageForFlush();
-      mGrContext->flushAndSubmit();
+      bool preparedForFlush = PrepareCurrentSwapchainImageForFlush();
+      if (preparedForFlush)
+      {
+        mGrContext->flushAndSubmit();
+      }
+      else
+      {
+        IGRAPHICS_VK_LOG_SIMPLE("DrawResize", "skipFlushNoPreparedSwapchainImage", vulkanlog::Severity::kInfo);
+      }
       ReleaseSkiaGpuResources(mGrContext.get());
     }
     if (mVKCommandBuffer != VK_NULL_HANDLE)


### PR DESCRIPTION
## Summary
- guard DrawResize and OnViewDestroyed to skip Skia flush when the current swapchain image cannot be prepared
- add Vulkan log entries when the flush is skipped to aid debugging

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb670f2d5c8329b92eddf12dab583f