### PR TITLE
Fix Vulkan swapchain image layout transitions

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -363,8 +363,8 @@ bool IGraphicsSkia::PrepareCurrentSwapchainImageForFlush()
 
   VkImageMemoryBarrier barrier{};
   barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
-  barrier.srcAccessMask = VK_ACCESS_MEMORY_READ_BIT;
-  barrier.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+  barrier.srcAccessMask = 0;
+  barrier.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
   barrier.oldLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
   barrier.newLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
   barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
@@ -385,7 +385,7 @@ bool IGraphicsSkia::PrepareCurrentSwapchainImageForFlush()
                        vulkanlog::MakeField("newLayout", static_cast<int>(barrier.newLayout)));
 
   vkCmdPipelineBarrier(commandBuffer,
-                       VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                       VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
                        VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
                        0,
                        0,
@@ -1589,7 +1589,7 @@ void IGraphicsSkia::BeginFrame()
 
     VkImageMemoryBarrier barrier{};
     barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
-    barrier.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+    barrier.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
     barrier.oldLayout = mVKImageLayouts[imageIndex];
     barrier.newLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
@@ -1605,15 +1605,15 @@ void IGraphicsSkia::BeginFrame()
     switch (barrier.oldLayout)
     {
     case VK_IMAGE_LAYOUT_PRESENT_SRC_KHR:
-      barrier.srcAccessMask = VK_ACCESS_MEMORY_READ_BIT;
-      srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+      barrier.srcAccessMask = 0;
+      srcStageMask = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
       break;
     case VK_IMAGE_LAYOUT_UNDEFINED:
       barrier.srcAccessMask = 0;
       srcStageMask = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
       break;
     default:
-      barrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+      barrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
       srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
       break;
     }
@@ -1879,7 +1879,7 @@ void IGraphicsSkia::EndFrame()
 
   VkImageMemoryBarrier barrier{};
   barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
-  barrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+  barrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
   barrier.dstAccessMask = 0;
   barrier.oldLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
   barrier.newLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;


### PR DESCRIPTION
## Summary
- correct Vulkan present-to-render image barriers to use appropriate stage and access masks
- broaden color attachment access masks so layout tracking matches the actual GPU state when submitting work

## Testing
- not run (reason: no automated Vulkan validation available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cb6a24c1508329ad56d7b6006bbda5