### PR TITLE
Fix Vulkan swapchain image transition stages

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -385,7 +385,7 @@ bool IGraphicsSkia::PrepareCurrentSwapchainImageForFlush()
                        vulkanlog::MakeField("newLayout", static_cast<int>(barrier.newLayout)));
 
   vkCmdPipelineBarrier(commandBuffer,
-                       VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+                       VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
                        VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
                        0,
                        0,
@@ -1606,7 +1606,7 @@ void IGraphicsSkia::BeginFrame()
     {
     case VK_IMAGE_LAYOUT_PRESENT_SRC_KHR:
       barrier.srcAccessMask = 0;
-      srcStageMask = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
+      srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
       break;
     case VK_IMAGE_LAYOUT_UNDEFINED:
       barrier.srcAccessMask = 0;


### PR DESCRIPTION
## Summary
- use color attachment stage for Vulkan transitions from present to render
- ensure flush helper uses consistent pipeline stage masks when reacquiring swapchain images

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb6c80c68c8329a710fb2055395812