### PR TITLE
Ensure swapchain surface layout matches Skia flush

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -426,6 +426,17 @@ bool IGraphicsSkia::PrepareCurrentSwapchainImageForFlush()
   mVKImageLayouts[mVKCurrentImage] = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
   mVKSubmissionPending = false;
 
+  if (mGrContext && mScreenSurface)
+  {
+    auto backendRT = SkSurfaces::GetBackendRenderTarget(mScreenSurface.get(), SkSurfaces::BackendHandleAccess::kFlushRead);
+    if (backendRT.isValid())
+    {
+      auto colorState = skgpu::MutableTextureStates::MakeVulkan(VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, mVKQueueFamily);
+      mGrContext->setBackendRenderTargetState(backendRT, colorState, nullptr, nullptr, nullptr);
+      backendRT.setMutableState(colorState);
+    }
+  }
+
   IGRAPHICS_VK_LOG("PrepareCurrentSwapchainImageForFlush",
                       "imageLayoutUpdated",
                       vulkanlog::Severity::kDebug,


### PR DESCRIPTION
## Summary
- synchronize the Skia swapchain surface state with the Vulkan layout prepared for flushing
- update the backend render target state to color-attachment optimal before flushing during teardown

## Testing
- not run (reason: no automated Vulkan validation available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cb6f2ca2988329be7d0cd1fdea2306