### PR TITLE
Retain persistent window DC for Win GL

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -200,6 +200,7 @@ private:
   HGLRC mHGLRC = nullptr;
   HGLRC mStartHGLRC = nullptr;
   HDC mStartHDC = nullptr;
+  HDC mWindowDC = nullptr;
 #endif
 
   HINSTANCE mHInstance = nullptr;


### PR DESCRIPTION
## Summary
- cache the window device context for Windows OpenGL views instead of calling GetDC/ReleaseDC on every activation
- avoid redundant wglMakeCurrent calls when the desired context is already current and release the cached DC when the window closes

## Testing
- not run (Windows-specific change)


------
https://chatgpt.com/codex/tasks/task_e_68cb79d4077c832996a421f55f2ff72a