### PR TITLE
Disable vsync for Windows GL editors

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -200,6 +200,7 @@ private:
   HGLRC mHGLRC = nullptr;
   HGLRC mStartHGLRC = nullptr;
   HDC mStartHDC = nullptr;
+  HDC mWindowDC = nullptr;
 #endif
 
   HINSTANCE mHInstance = nullptr;


### PR DESCRIPTION
## Summary
- include <cstdint> and resolve the WGL swap-interval extension when creating a Windows OpenGL editor context
- disable swap interval on the freshly created context so multiple plugin windows no longer block each other during SwapBuffers

## Testing
- not run (Windows-specific change)

------
https://chatgpt.com/codex/tasks/task_e_68cb79d4077c832996a421f55f2ff72a