### PR TITLE
Ensure cached Skia bitmaps use raster images

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -20,6 +20,7 @@
 #include "include/core/SkSwizzle.h"
 #include "include/core/SkTypeface.h"
 #include "include/core/SkVertices.h"
+#include "include/core/SkImages.h"
 #include "include/effects/SkDashPathEffect.h"
 #include "include/effects/SkGradientShader.h"
 #include "include/effects/SkImageFilters.h"
@@ -472,6 +473,31 @@ void IGraphicsSkia::ResetVulkanSwapchainCaches()
 
 #pragma mark - Private Classes and Structs
 
+namespace
+{
+static sk_sp<SkImage> EnsureRasterImage(sk_sp<SkImage> image)
+{
+  if (!image)
+    return nullptr;
+
+  sk_sp<SkImage> raster = image->makeRasterImage();
+  if (raster)
+    return raster;
+
+  SkImageInfo info = SkImageInfo::MakeN32Premul(image->width(), image->height());
+  SkBitmap bitmap;
+
+  if (!bitmap.tryAllocPixels(info))
+    return image;
+
+  if (!image->readPixels(bitmap.pixmap(), 0, 0))
+    return image;
+
+  raster = SkImages::RasterFromBitmap(bitmap);
+  return raster ? raster : image;
+}
+} // namespace
+
 class IGraphicsSkia::Bitmap : public APIBitmap
 {
 public:
@@ -498,13 +524,9 @@ IGraphicsSkia::Bitmap::Bitmap(const char* path, double sourceScale)
 
   assert(data && "Unable to load file at path");
 
-  auto image = SkImages::DeferredFromEncodedData(data);
+  auto image = EnsureRasterImage(SkImages::DeferredFromEncodedData(data));
 
-#ifdef IGRAPHICS_CPU
-  image = image->makeRasterImage();
-#endif
-
-  mDrawable.mImage = image;
+  mDrawable.mImage = std::move(image);
 
   mDrawable.mIsSurface = false;
   SetBitmap(&mDrawable, mDrawable.mImage->width(), mDrawable.mImage->height(), sourceScale, 1.f);
@@ -513,13 +535,9 @@ IGraphicsSkia::Bitmap::Bitmap(const char* path, double sourceScale)
 IGraphicsSkia::Bitmap::Bitmap(const void* pData, int size, double sourceScale)
 {
   auto data = SkData::MakeWithoutCopy(pData, size);
-  auto image = SkImages::DeferredFromEncodedData(data);
+  auto image = EnsureRasterImage(SkImages::DeferredFromEncodedData(data));
 
-#ifdef IGRAPHICS_CPU
-  image = image->makeRasterImage();
-#endif
-
-  mDrawable.mImage = image;
+  mDrawable.mImage = std::move(image);
 
   mDrawable.mIsSurface = false;
   SetBitmap(&mDrawable, mDrawable.mImage->width(), mDrawable.mImage->height(), sourceScale, 1.f);
@@ -527,11 +545,7 @@ IGraphicsSkia::Bitmap::Bitmap(const void* pData, int size, double sourceScale)
 
 IGraphicsSkia::Bitmap::Bitmap(sk_sp<SkImage> image, double sourceScale)
 {
-#ifdef IGRAPHICS_CPU
-  mDrawable.mImage = image->makeRasterImage();
-#else
-  mDrawable.mImage = image;
-#endif
+  mDrawable.mImage = EnsureRasterImage(std::move(image));
 
   SetBitmap(&mDrawable, mDrawable.mImage->width(), mDrawable.mImage->height(), sourceScale, 1.f);
 }

--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -200,6 +200,7 @@ private:
   HGLRC mHGLRC = nullptr;
   HGLRC mStartHGLRC = nullptr;
   HDC mStartHDC = nullptr;
+  HDC mWindowDC = nullptr;
 #endif
 
   HINSTANCE mHInstance = nullptr;


### PR DESCRIPTION
## Summary
- add an internal helper that coerces SkImages into raster copies before storing them in Skia bitmaps
- make all Skia bitmap constructors use the raster helper so shared StaticStorage entries no longer retain GPU-backed resources

## Testing
- not run (Windows-specific change)

------
https://chatgpt.com/codex/tasks/task_e_68cb79d4077c832996a421f55f2ff72a