### PR TITLE
Restore SkImages detection via header presence

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -26,11 +26,30 @@
 
 #include "include/codec/SkCodec.h"
 
-#if __has_include("include/core/SkImages.h")
-  #include "include/core/SkImages.h"
-  #define IGRAPHICS_HAS_SKIMAGES 1
-#else
-  #define IGRAPHICS_HAS_SKIMAGES 0
+#if defined(__has_include)
+  #if __has_include("include/core/SkImages.h")
+    #include "include/core/SkImages.h"
+    #define IGRAPHICS_HAS_SKIMAGES 1
+  #endif
+#endif
+
+#if !defined(IGRAPHICS_HAS_SKIMAGES)
+  #if defined(__has_include)
+    #if __has_include("include/core/SkMilestone.h")
+      #include "include/core/SkMilestone.h"
+    #endif
+  #endif
+
+  #ifndef SK_MILESTONE
+    #define SK_MILESTONE 0
+  #endif
+
+  #if SK_MILESTONE >= 114
+    #include "include/core/SkImages.h"
+    #define IGRAPHICS_HAS_SKIMAGES 1
+  #else
+    #define IGRAPHICS_HAS_SKIMAGES 0
+  #endif
 #endif
 
 #include "include/effects/SkDashPathEffect.h"


### PR DESCRIPTION
## Summary
- prefer the SkImages header for feature detection so new helpers are used when available
- fall back to the SkMilestone-based detection when the header cannot be located and default to legacy behavior otherwise

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb935497008329bdd7d7965175c198