### PR TITLE
Fix Skia raster image creation for newer SDKs

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -514,17 +514,7 @@ static sk_sp<SkImage> MakeRasterCopyCompat(const SkPixmap& pixmap)
 #if IGRAPHICS_HAS_SKIMAGES
   return SkImages::RasterFromPixmap(pixmap, nullptr, nullptr);
 #else
-  const SkImageInfo& info = pixmap.info();
-  SkBitmap bitmap;
-
-  if (!bitmap.tryAllocPixels(info))
-    return nullptr;
-
-  if (!pixmap.readPixels(bitmap.pixmap()))
-    return nullptr;
-
-  bitmap.setImmutable();
-  return SkImage::MakeFromBitmap(bitmap);
+  return SkImage::MakeRasterCopy(pixmap);
 #endif
 }
 
@@ -552,7 +542,7 @@ static sk_sp<SkImage> DecodeImageFromData(sk_sp<SkData> data)
     return nullptr;
 
   bitmap.setImmutable();
-  return SkImage::MakeFromBitmap(bitmap);
+  return MakeRasterCopyCompat(bitmap.pixmap());
 }
 
 static sk_sp<SkImage> EnsureRasterImage(sk_sp<SkImage> image)
@@ -574,7 +564,7 @@ static sk_sp<SkImage> EnsureRasterImage(sk_sp<SkImage> image)
     return image;
 
   bitmap.setImmutable();
-  raster = SkImage::MakeFromBitmap(bitmap);
+  raster = MakeRasterCopyCompat(bitmap.pixmap());
 
   return raster ? raster : image;
 }


### PR DESCRIPTION
## Summary
- replace the fallback Skia raster image creation path to avoid removed SkImage::MakeFromBitmap calls
- funnel bitmap conversions through MakeRasterCopyCompat so newer Skia builds compile cleanly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb980be0f48329bbb960e7c1abfc01