### PR TITLE
Fix SkImage raster copy fallback for older Skia

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -514,7 +514,16 @@ static sk_sp<SkImage> MakeRasterCopyCompat(const SkPixmap& pixmap)
 #if IGRAPHICS_HAS_SKIMAGES
   return SkImages::RasterFromPixmap(pixmap, nullptr, nullptr);
 #else
-  return SkImage::MakeRasterCopy(pixmap);
+  SkBitmap bitmap;
+
+  if (!bitmap.tryAllocPixels(pixmap.info()))
+    return nullptr;
+
+  if (!pixmap.readPixels(bitmap.pixmap()))
+    return nullptr;
+
+  bitmap.setImmutable();
+  return SkImage::MakeFromBitmap(bitmap);
 #endif
 }
 


### PR DESCRIPTION
## Summary
- replace the legacy SkImage::MakeRasterCopy call with a bitmap-backed fallback when SkImages headers are unavailable

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb990675f48329aea871f9e4d74ed1