### PR TITLE
Fix SkImage compatibility for raster copies without MakeFromBitmap

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -514,16 +514,7 @@ static sk_sp<SkImage> MakeRasterCopyCompat(const SkPixmap& pixmap)
 #if IGRAPHICS_HAS_SKIMAGES
   return SkImages::RasterFromPixmap(pixmap, nullptr, nullptr);
 #else
-  SkBitmap bitmap;
-
-  if (!bitmap.tryAllocPixels(pixmap.info()))
-    return nullptr;
-
-  if (!pixmap.readPixels(bitmap.pixmap()))
-    return nullptr;
-
-  bitmap.setImmutable();
-  return SkImage::MakeFromBitmap(bitmap);
+  return SkImage::MakeRasterCopy(pixmap);
 #endif
 }
 


### PR DESCRIPTION
## Summary
- simplify the raster copy helper to rely on SkImage::MakeRasterCopy when SkImages::RasterFromPixmap is unavailable
- remove the compile-time trait that attempted to detect SkImage::MakeFromBitmap

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb99ce16488329b92774d8cd471024