### PR TITLE
Fix Windows sandbox context linkage

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -21,9 +21,14 @@
 
 #include "IGraphics_select.h"
 
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
+
+#if defined(OS_WIN)
+struct WdlWindowsSandboxContext;
+#endif
 
 #ifdef IGRAPHICS_VULKAN
   #define VK_USE_PLATFORM_WIN32_KHR
@@ -37,7 +42,7 @@ BEGIN_IPLUG_NAMESPACE
 BEGIN_IGRAPHICS_NAMESPACE
 
 #if defined(OS_WIN)
-struct WdlWindowsSandboxContext;
+using ::WdlWindowsSandboxContext;
 #endif
 
 #ifdef IGRAPHICS_VULKAN
@@ -77,16 +82,7 @@ public:
   IGraphicsWin(IGEditorDelegate& dlg, int w, int h, int fps, float scale);
   ~IGraphicsWin();
 
-  void SetWinModuleHandle(void* pInstance) override
-  {
-    mHInstance = (HINSTANCE) pInstance;
-#if IGRAPHICS_SANDBOX_WDL_WINDOWS
-    if (mSandboxContext)
-    {
-      mSandboxContext->module_handle = mHInstance;
-    }
-#endif
-  }
+  void SetWinModuleHandle(void* pInstance) override;
   void* GetWinModuleHandle() override { return mHInstance; }
 
   void ForceEndUserEdit() override;
@@ -257,17 +253,17 @@ private:
   int& WndClassRefCount();
   const wchar_t* WndClassName() const;
 
-#if defined(OS_WIN)
-  WdlWindowsSandboxContext* SandboxContext() const;
-#endif
-
 #if IGRAPHICS_SANDBOX_WIN_CLASS
   int mWndClassRefCount = 0;
   std::wstring mWndClassNameW;
 #endif
 
+#if defined(OS_WIN)
+  WdlWindowsSandboxContext* SandboxContext() const;
+#endif
+
 #if IGRAPHICS_SANDBOX_WDL_WINDOWS
-  WdlWindowsSandboxContext mSandboxContextStorage;
+  std::unique_ptr<WdlWindowsSandboxContext> mSandboxContextStorage;
 #endif
   WdlWindowsSandboxContext* mSandboxContext = nullptr;
 

--- a/IPlug/Sandbox/IPlugSandboxConfig.h
+++ b/IPlug/Sandbox/IPlugSandboxConfig.h
@@ -210,9 +210,9 @@ namespace iplug
 {
 namespace sandbox
 {
-inline WdlWindowsSandboxContext*& SandboxSharedWdlWindowsContext()
+inline ::WdlWindowsSandboxContext*& SandboxSharedWdlWindowsContext()
 {
-  thread_local WdlWindowsSandboxContext* context = nullptr;
+  thread_local ::WdlWindowsSandboxContext* context = nullptr;
   return context;
 }
 } // namespace sandbox
@@ -232,7 +232,7 @@ inline WdlWindowsSandboxContext*& SandboxSharedWdlWindowsContext()
     #define IPLUG_SANDBOX_WDL_WINDOWS_STORAGE
     #define IPLUG_SANDBOX_WDL_WINDOWS_EXTERN extern
     #define IPLUG_SANDBOX_WDL_WINDOWS_INIT nullptr
-    #define IPLUG_SANDBOX_WDL_WINDOWS_CONTEXT() static_cast<WdlWindowsSandboxContext*>(nullptr)
+    #define IPLUG_SANDBOX_WDL_WINDOWS_CONTEXT() static_cast<::WdlWindowsSandboxContext*>(nullptr)
     #define IPLUG_SANDBOX_SET_WDL_WINDOWS_CONTEXT(ctx)                                                              \
       do                                                                                                            \
       {                                                                                                             \

--- a/Plan/Current-Plan.xml
+++ b/Plan/Current-Plan.xml
@@ -123,12 +123,12 @@
     <task>
       <name>Implement sandboxed Windows path and regression coverage</name>
       <status>PROOF</status>
-      <tryCount>4</tryCount>
+      <tryCount>5</tryCount>
       <crucialInfo>
         Modify WDL Windows utilities to respect sandbox isolation and ensure documentation/tests communicate the new switch. Deliverable: merged code, updated docs, and regression strategy.
       </crucialInfo>
       <continue-info>
-        All implementation subtasks have landed; the latest fixes keep the UTF-8 TLS slot and sandbox thread-local pointer in sync during teardown and now ensure null-context scopes clear the shared macro so callbacks without an editor do not inherit stale sandbox state. Follow the validation checklist for manual QA until automated Windows coverage exists, then promote the task to SUCCESS.
+        Windows compile should now succeed after reworking IGraphicsWin to hold the sandbox context through a unique_ptr backed by the canonical global `::WdlWindowsSandboxContext`, ensuring every call site passes the raw pointer value rather than a namespace-local type. Await host confirmation from a Windows build and update regression notes once verified.
       </continue-info>
       <subtasks>
         <task>
@@ -190,9 +190,18 @@
           <crucialInfo>IGraphicsWin now owns a per-instance WdlWindowsSandboxContext, wraps menu, tooltip, clipboard, and cursor helpers in sandbox scopes, and routes file dialogs through the context-aware WDL APIs so each plug-in isolates its Windows state when the toggle is enabled. Property-prefix generation now uses manual hexadecimal formatting to avoid CRT-specific snprintf requirements during sandbox initialisation, sandbox scopes drive the shared macros so thread-local helpers stay consistent with the UTF-8 TLS slot, and compile-time assertions guarantee the scope guard remains non-copyable and non-assignable.</crucialInfo>
           <continue-info>Host/bootstrap layers still need review to ensure they set or forward sandbox contexts for non-IGraphics consumers; coordinate those follow-ups under the remaining implementation subtasks.</continue-info>
           <subtasks>
+            <task>
+              <name>Resolve Windows sandbox context type clashes after namespace refactor</name>
+              <status>PROOF</status>
+              <tryCount>3</tryCount>
+              <crucialInfo>Windows compilation reports ambiguous references to `WdlWindowsSandboxContext` between the WDL header and the IGraphics namespace forward declarations, along with constructor mismatches for `WdlWindowsSandboxScope` when passing IGraphicsWin storage. Reconcile the type declarations and scope helper signatures so both translation units agree on the canonical context type.</crucialInfo>
+              <continue-info>IGraphicsWin now instantiates and stores the sandbox context using the fully qualified `::WdlWindowsSandboxContext` pointer type to avoid namespace alias collisions. Request a Windows build to confirm the refactored pointers satisfy the WDL helper signatures and that the property registration helpers (`SetPropA`) still resolve as expected.</continue-info>
+              <subtasks>
+              </subtasks>
+            </task>
           </subtasks>
         </task>
-       
+
 
   </Tasks>
 

--- a/Plan/Plan-Summary.md
+++ b/Plan/Plan-Summary.md
@@ -1,19 +1,21 @@
-[x] Continued From Previous Snapshot: YES — Wrapped the sandbox context setter declaration so C builds no longer see a bare extern "C" token.
+[x] Continued From Previous Snapshot: YES — Followed up on the Windows sandbox plumbing so IGraphicsWin now references the global ::WdlWindowsSandboxContext explicitly to prevent namespace alias clashes reported by MSVC.
 -----------------
 [x] File Overview:
-- Num files Changed: 1
+- Num files Changed: 3
 - Num files Created: 0
-- Num lines Modified: 8
+- Num lines Modified: 22
 -----------------
 [x] List of Files changed/created:
-- IPlug/Sandbox/IPlugSandboxConfig.h
+- IGraphics/Platforms/IGraphicsWin.cpp
+- IGraphics/Platforms/IGraphicsWin.h
+- Plan/Current-Plan.xml
 -----------------
 [x] Current plan:
 - Audit Windows path integration points and shared resources — PREVIOUS STATUS: SUCCESS / CURRENT STATUS: SUCCESS
 - Design sandbox-aware Windows path abstraction — PREVIOUS STATUS: SUCCESS / CURRENT STATUS: SUCCESS
-- Implement sandboxed Windows path and regression coverage — PREVIOUS STATUS: PROOF / CURRENT STATUS: PROOF (header made C-compatible; Windows validation still pending.)
+- Implement sandboxed Windows path and regression coverage — PREVIOUS STATUS: PROOF / CURRENT STATUS: PROOF (fully qualified ::WdlWindowsSandboxContext pointers wired through IGraphicsWin; awaiting Windows build confirmation.)
 - FINAL CHECK — PREVIOUS STATUS: OPEN / CURRENT STATUS: OPEN
 -----------------
 [x] Message to User:
-Ensured `IPlugSandboxConfig.h` can be consumed from C by guarding the sandbox setter prototype with `__cplusplus`.
-Next step remains manual Windows validation before promoting the implementation task beyond PROOF.
+IGraphicsWin now drops the igraphics namespace alias and stores the sandbox context as a fully qualified ::WdlWindowsSandboxContext pointer, so WDL helpers receive the exact global type MSVC expects.
+A Windows verification build is still required to ensure the pointer conversions and SetPropA calls compile cleanly.


### PR DESCRIPTION
## Summary
- import the global `WdlWindowsSandboxContext` into the igraphics namespace and store the sandbox state in a `std::unique_ptr` so the header only needs a forward declaration
- initialize and destroy the sandbox context in the Windows implementation after moving `SetWinModuleHandle` to the cpp, keeping the stored pointer compatible with the WDL helpers
- return the global sandbox context pointer from the shared helper in `IPlugSandboxConfig` to eliminate namespace ambiguity for Windows builds

## Testing
- not run (Windows-only build environment)


------
https://chatgpt.com/codex/tasks/task_e_68ce112b3e14832980305ac689e3c52d