### PR TITLE
Fix sandbox file dialog defaults and legacy toggle

### DIFF
--- a/IPlug/Sandbox/WdlWindowsSandboxContext.h
+++ b/IPlug/Sandbox/WdlWindowsSandboxContext.h
@@ -152,6 +152,15 @@ static inline const char* WDL_UTF8_SandboxContextPropertyName(void)
 #if defined(_WIN32)
   #include <windows.h>
 
+  #if defined(__has_include)
+    #if __has_include("../../WDL/filebrowse.h")
+      #include "../../WDL/filebrowse.h"
+    #endif
+  #else
+    #include "../../WDL/filebrowse.h"
+  #endif
+
+  #if !defined(_WDL_FILEBROWSE_H_)
 extern "C"
 {
 bool WDL_ChooseFileForSave(HWND parent,
@@ -163,9 +172,9 @@ bool WDL_ChooseFileForSave(HWND parent,
                            bool preservecwd,
                            char* fn,
                            int fnsize,
-                           const char* dlgid = NULL,
-                           void* dlgProc = NULL,
-                           HINSTANCE hInstance = NULL);
+                           const char* dlgid,
+                           void* dlgProc,
+                           HINSTANCE hInstance);
 
 char* WDL_ChooseFileForOpen2(HWND parent,
                              const char* text,
@@ -175,10 +184,11 @@ char* WDL_ChooseFileForOpen2(HWND parent,
                              const char* defext,
                              bool preservecwd,
                              int allowmul,
-                             const char* dlgid = NULL,
-                             void* dlgProc = NULL,
-                             HINSTANCE hInstance = NULL);
+                             const char* dlgid,
+                             void* dlgProc,
+                             HINSTANCE hInstance);
 }
+  #endif
 
 #if defined(__cplusplus)
 extern "C"
@@ -258,5 +268,6 @@ const char* IPlugSandboxFallback_SandboxContextPropertyName(void);
     #define WDL_UTF8_GetSandboxContext IPlugSandboxFallback_GetUtf8SandboxContext
     #define WDL_UTF8_SandboxContextPropertyName IPlugSandboxFallback_SandboxContextPropertyName
   #endif
+
 #endif
 

--- a/Plan/Current-Plan.xml
+++ b/Plan/Current-Plan.xml
@@ -1,0 +1,51 @@
+<plan>
+  <Goal>Fix sandboxall-related Windows compilation errors in WDL file browsing utilities</Goal>
+
+  <Environment-Check>
+    <Action>Verify whether the Ubuntu container can build Windows-specific targets</Action>
+    <Acceptance>Environment supports building the repo</Acceptance>
+    <Rejection>Environment does not support building the repo</Rejection>
+    <Build-Test-Compatible>FALSE</Build-Test-Compatible>
+    <Notes>Ubuntu container lacks required Windows toolchain; build tests not runnable</Notes>
+  </Environment-Check>
+
+  <PHASE>PLAN-EXECUTION</PHASE>
+  <Build-Test-Compatible>FALSE</Build-Test-Compatible>
+  <context>
+    Address compilation issues triggered by sandboxall option: invalid const-to-nonconst conversion, redundant default arguments, and missing global flag.
+  </context>
+
+  <Tasks>
+    <task>
+      <name>Resolve Win7FileDialog addText constness issue</name>
+      <status>SUCCESS</status>
+      <tryCount>1</tryCount>
+      <crucialInfo>
+        Investigate addText signature; provide non-const overload or adjust call site.
+      </crucialInfo>
+      <continue-info/>
+      <subtasks/>
+    </task>
+    <task>
+      <name>Clean up filebrowse default arguments and sandbox flag</name>
+      <status>SUCCESS</status>
+      <tryCount>1</tryCount>
+      <crucialInfo>
+        Ensure declarations/definitions align; add missing legacy flag when sandboxall is enabled.
+      </crucialInfo>
+      <continue-info/>
+      <subtasks/>
+    </task>
+  </Tasks>
+
+  <Finalization>
+    <task>
+      <name>FINAL CHECK</name>
+      <status>SUCCESS</status>
+      <tryCount>1</tryCount>
+      <crucialInfo>
+        Perform code review only because build tests unavailable; ensure tasks satisfy goal before completion.
+      </crucialInfo>
+    </task>
+  </Finalization>
+</plan>

--- a/Plan/Plan-Summary.md
+++ b/Plan/Plan-Summary.md
@@ -1,0 +1,24 @@
+[x] Continued From Previous Snapshot: YES — Continued from initial sandboxall fix planning
+-----------------
+[x] File Overview:
+- Num files Changed: 5
+- Num files Created: 2
+- Num lines Modified: 161
+
+[x] List of Files changed/created:
+- WDL/win7filedialog.cpp
+- WDL/win7filedialog.h
+- WDL/filebrowse.cpp
+- WDL/filebrowse.h
+- IPlug/Sandbox/WdlWindowsSandboxContext.h
+- Plan/Current-Plan.xml
+- Plan/Plan-Summary.md
+
+-----------------
+[x] Current plan:
+- Resolve Win7FileDialog addText constness issue — PREVIOUS STATUS: OPEN / CURRENT STATUS: SUCCESS
+- Clean up filebrowse default arguments and sandbox flag — PREVIOUS STATUS: OPEN / CURRENT STATUS: SUCCESS
+- FINAL CHECK — PREVIOUS STATUS: OPEN / CURRENT STATUS: SUCCESS
+
+[x] Message to User:
+Updated WDL dialog utilities for sandboxall builds and finalized the plan; review code changes only (no build tests possible).

--- a/WDL/filebrowse.cpp
+++ b/WDL/filebrowse.cpp
@@ -34,6 +34,8 @@
 #endif
 
 #if defined(_WIN32)
+bool wdl_use_legacy_filebrowse = false;
+
 static bool wdl_filebrowse_should_use_legacy(WdlWindowsSandboxContext* context)
 {
 #if WDL_FILEBROWSE_HAS_SANDBOX_CONTEXT
@@ -48,8 +50,6 @@ static bool wdl_filebrowse_should_use_legacy(WdlWindowsSandboxContext* context)
 #endif
   return wdl_use_legacy_filebrowse;
 }
-
-bool wdl_use_legacy_filebrowse;
 #endif
 
 

--- a/WDL/filebrowse.h
+++ b/WDL/filebrowse.h
@@ -9,6 +9,10 @@
 
 struct WdlWindowsSandboxContext;
 
+#if defined(__cplusplus) && defined(_WIN32)
+extern bool wdl_use_legacy_filebrowse;
+#endif
+
 bool WDL_ChooseDirectory(HWND parent, const char *text, const char *initialdir, char *fn, int fnsize, bool preservecwd);
 bool WDL_ChooseFileForSaveCtx(struct WdlWindowsSandboxContext* context,
                                       HWND parent,

--- a/WDL/win7filedialog.cpp
+++ b/WDL/win7filedialog.cpp
@@ -173,7 +173,7 @@ void Win7FileDialog::setFolder(const char *folder, int def)
     m_fod->SetFolder(si);
 }
 
-void Win7FileDialog::addText(DWORD id, char *txt)
+void Win7FileDialog::addText(DWORD id, const char *txt)
 {
   if(m_fdc == NULL) return;
 #if defined(WDL_NO_SUPPORT_UTF8)
@@ -188,7 +188,7 @@ void Win7FileDialog::addText(DWORD id, char *txt)
 #endif
 }
 
-void Win7FileDialog::addCheckbox(char *name, DWORD id, int defval)
+void Win7FileDialog::addCheckbox(const char *name, DWORD id, int defval)
 {
   if(m_fdc == NULL) return;
 
@@ -204,7 +204,7 @@ void Win7FileDialog::addCheckbox(char *name, DWORD id, int defval)
 #endif
 }
 
-void Win7FileDialog::startGroup(DWORD id, char *label)
+void Win7FileDialog::startGroup(DWORD id, const char *label)
 {
   if(m_fdc == NULL) return;
 #if defined(WDL_NO_SUPPORT_UTF8)

--- a/WDL/win7filedialog.h
+++ b/WDL/win7filedialog.h
@@ -2182,9 +2182,9 @@ public:
 
   void addOptions(DWORD o);
 
-  void startGroup(DWORD id, char *label);
-  void addText(DWORD id, char *txt);
-  void addCheckbox(char *name, DWORD id, int defval);
+  void startGroup(DWORD id, const char *label);
+  void addText(DWORD id, const char *txt);
+  void addCheckbox(const char *name, DWORD id, int defval);
   void endGroup();
 
   int getState(DWORD id);


### PR DESCRIPTION
## Summary
- define the exported `wdl_use_legacy_filebrowse` toggle before it is read so sandbox builds can always link the legacy selection flag
- remove default arguments from the sandbox fallback declarations to avoid redefinition errors when the real WDL headers are present

## Testing
- not run (Windows-only build tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cea0efd8a883298bef6b50c54a5800