### PR TITLE
Fix Skia font cache storage visibility

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -674,17 +674,13 @@ struct IGraphicsSkia::Font
 };
 
 // Fonts
-namespace
-{
-#if IGRAPHICS_SANDBOX_SKIA_FONT_CACHE
-thread_local StaticStorage<IGraphicsSkia::Font> sFontCacheStorage;
-#else
-StaticStorage<IGraphicsSkia::Font> sFontCacheStorage;
-#endif
-} // namespace
-
 StaticStorage<IGraphicsSkia::Font>& IGraphicsSkia::FontCacheStorage()
 {
+#if IGRAPHICS_SANDBOX_SKIA_FONT_CACHE
+  thread_local StaticStorage<Font> sFontCacheStorage;
+#else
+  static StaticStorage<Font> sFontCacheStorage;
+#endif
   return sFontCacheStorage;
 }
 


### PR DESCRIPTION
## Summary
- define the Skia font cache storage inside FontCacheStorage so the private Font struct is never referenced externally

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf2d8e107c8329b0c68b27066de7d3