### PR TITLE
Isolate sandbox caches in IGraphics

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -677,11 +677,11 @@ struct IGraphicsSkia::Font
 StaticStorage<IGraphicsSkia::Font>& IGraphicsSkia::FontCacheStorage()
 {
 #if IGRAPHICS_SANDBOX_SKIA_FONT_CACHE
-  thread_local StaticStorage<Font> sFontCacheStorage;
+  return mFontCache;
 #else
   static StaticStorage<Font> sFontCacheStorage;
-#endif
   return sFontCacheStorage;
+#endif
 }
 
 #pragma mark - Utility conversions
@@ -888,6 +888,10 @@ IGraphicsSkia::IGraphicsSkia(IGEditorDelegate& dlg, int w, int h, int fps, float
 {
   mMainPath.setIsVolatile(true);
 
+#if IGRAPHICS_SANDBOX_FONT_FACTORY
+  mFontMgr = SFontMgrFactory();
+#endif
+
 #if defined IGRAPHICS_CPU
   DBGMSG("IGraphics Skia CPU @ %i FPS\n", fps);
 #elif defined IGRAPHICS_METAL
@@ -895,8 +899,10 @@ IGraphicsSkia::IGraphicsSkia(IGEditorDelegate& dlg, int w, int h, int fps, float
 #elif defined IGRAPHICS_GL
   DBGMSG("IGraphics Skia GL @ %i FPS\n", fps);
 #endif
+#if !IGRAPHICS_SANDBOX_SKIA_FONT_CACHE
   StaticStorage<Font>::Accessor storage{FontCacheStorage()};
   storage.Retain();
+#endif
 
 #if !defined IGRAPHICS_NO_SKIA_SKPARAGRAPH
   if (!mFontCollection)
@@ -918,18 +924,19 @@ IGraphicsSkia::~IGraphicsSkia()
   if (mFontCollection)
     mFontCollection->clearCaches();
 
-  {
-    StaticStorage<Font>::Accessor storage{FontCacheStorage()};
-    storage.Release();
-  }
-
   if (mTypefaceProvider)
     mTypefaceProvider->unref(); // pair with the manual ref
 
   mFontCollection.reset();
   mTypefaceProvider.reset();
-  mFontMgr.reset();
 #endif
+#if !IGRAPHICS_SANDBOX_SKIA_FONT_CACHE
+  {
+    StaticStorage<Font>::Accessor storage{FontCacheStorage()};
+    storage.Release();
+  }
+#endif
+  mFontMgr.reset();
 #ifdef IGRAPHICS_VULKAN
   if (mVKCommandBuffer != VK_NULL_HANDLE)
     vkFreeCommandBuffers(mVKDevice, mVKCommandPool, 1, &mVKCommandBuffer);
@@ -2258,12 +2265,18 @@ IColor IGraphicsSkia::GetPoint(int x, int y)
 
 sk_sp<SkFontMgr> IGraphicsSkia::SParagraphFontMgr()
 {
+#if IGRAPHICS_SANDBOX_FONT_FACTORY
+  if (!mFontMgr)
+    mFontMgr = SFontMgrFactory();
+  return mFontMgr;
+#else
   static std::once_flag flag;
   static sk_sp<SkFontMgr> mgr;
   std::call_once(flag, [] {
     mgr = SFontMgrFactory(); // SFontMgrFactory is already defined in your code
   });
   return mgr;
+#endif
 }
 
 bool IGraphicsSkia::LoadAPIFont(const char* fontID, const PlatformFontPtr& font)
@@ -2280,6 +2293,7 @@ bool IGraphicsSkia::LoadAPIFont(const char* fontID, const PlatformFontPtr& font)
   {
     auto wrappedData = SkData::MakeWithCopy(data->Get(), data->GetSize());
 
+    sk_sp<SkTypeface> typeFace;
 #if !defined IGRAPHICS_NO_SKIA_SKPARAGRAPH
 
     // if (!mFontCollection)
@@ -2294,9 +2308,17 @@ bool IGraphicsSkia::LoadAPIFont(const char* fontID, const PlatformFontPtr& font)
     // }
 
     // Create the typeface using our private font manager instance.
-    auto typeFace = mFontMgr->makeFromData(wrappedData);
+  #if IGRAPHICS_SANDBOX_FONT_FACTORY
+    typeFace = mFontMgr ? mFontMgr->makeFromData(wrappedData) : nullptr;
+  #else
+    typeFace = mFontMgr->makeFromData(wrappedData);
+  #endif
 #else
-    auto typeFace = SkFontMgrRefDefault()->makeFromData(wrappedData);
+  #if IGRAPHICS_SANDBOX_FONT_FACTORY
+    typeFace = mFontMgr ? mFontMgr->makeFromData(wrappedData) : nullptr;
+  #else
+    typeFace = SkFontMgrRefDefault()->makeFromData(wrappedData);
+  #endif
 #endif
 
     if (typeFace)

--- a/IGraphics/Drawing/IGraphicsSkia.h
+++ b/IGraphics/Drawing/IGraphicsSkia.h
@@ -75,6 +75,7 @@ struct VkFenceHolder
 #pragma warning(push)
 #pragma warning(disable : 4244)
 #include "include/core/SkCanvas.h"
+#include "include/core/SkFontMgr.h"
 #include "include/core/SkImage.h"
 #include "include/core/SkPath.h"
 #include "include/core/SkSurface.h"
@@ -220,6 +221,12 @@ private:
   SkMatrix mClipMatrix;
   SkMatrix mFinalMatrix;
 
+#if IGRAPHICS_SANDBOX_SKIA_FONT_CACHE
+  StaticStorage<Font> mFontCache;
+#endif
+
+  sk_sp<SkFontMgr> mFontMgr;
+
 #if defined OS_WIN && defined IGRAPHICS_CPU
   WDL_TypedBuf<uint8_t> mSurfaceMemory;
 #endif
@@ -232,8 +239,7 @@ private:
 #if !defined IGRAPHICS_NO_SKIA_SKPARAGRAPH
   sk_sp<skia::textlayout::FontCollection> mFontCollection;
   sk_sp<skia::textlayout::TypefaceFontProvider> mTypefaceProvider;
-  sk_sp<SkFontMgr> mFontMgr;
-  static sk_sp<SkFontMgr> SParagraphFontMgr();
+  sk_sp<SkFontMgr> SParagraphFontMgr();
 #endif
 
 #ifdef IGRAPHICS_METAL
@@ -276,7 +282,7 @@ private:
   bool AssertValidSwapchainImage(VkImage image, const char* context);
 #endif
 
-  static StaticStorage<Font>& FontCacheStorage();
+  StaticStorage<Font>& FontCacheStorage();
 };
 
 END_IGRAPHICS_NAMESPACE

--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -40,13 +40,28 @@ using VST3_API_BASE = iplug::IPlugVST3Controller;
 using namespace iplug;
 using namespace igraphics;
 
-#if IGRAPHICS_SANDBOX_IMAGE_CACHE
-thread_local StaticStorage<APIBitmap> sBitmapCache;
-thread_local StaticStorage<SVGHolder> sSVGCache;
-#else
+#if !IGRAPHICS_SANDBOX_IMAGE_CACHE
 static StaticStorage<APIBitmap> sBitmapCache;
 static StaticStorage<SVGHolder> sSVGCache;
 #endif
+
+StaticStorage<APIBitmap>& IGraphics::BitmapCache()
+{
+#if IGRAPHICS_SANDBOX_IMAGE_CACHE
+  return mBitmapCache;
+#else
+  return sBitmapCache;
+#endif
+}
+
+StaticStorage<SVGHolder>& IGraphics::SVGCache()
+{
+#if IGRAPHICS_SANDBOX_IMAGE_CACHE
+  return mSVGCache;
+#else
+  return sSVGCache;
+#endif
+}
 
 IGraphics::IGraphics(IGEditorDelegate& dlg, int w, int h, int fps, float scale)
 : mWidth(w)
@@ -57,10 +72,12 @@ IGraphics::IGraphics(IGEditorDelegate& dlg, int w, int h, int fps, float scale)
 , mMaxScale(DEFAULT_MAX_DRAW_SCALE)
 , mDelegate(&dlg)
 {
-  StaticStorage<APIBitmap>::Accessor bitmapStorage(sBitmapCache);
+#if !IGRAPHICS_SANDBOX_IMAGE_CACHE
+  StaticStorage<APIBitmap>::Accessor bitmapStorage(BitmapCache());
   bitmapStorage.Retain();
-  StaticStorage<SVGHolder>::Accessor svgStorage(sSVGCache);
+  StaticStorage<SVGHolder>::Accessor svgStorage(SVGCache());
   svgStorage.Retain();
+#endif
 }
 
 IGraphics::~IGraphics()
@@ -71,10 +88,12 @@ IGraphics::~IGraphics()
   mCursorHidden = false;
   RemoveAllControls();
     
-  StaticStorage<APIBitmap>::Accessor bitmapStorage(sBitmapCache);
+#if !IGRAPHICS_SANDBOX_IMAGE_CACHE
+  StaticStorage<APIBitmap>::Accessor bitmapStorage(BitmapCache());
   bitmapStorage.Release();
-  StaticStorage<SVGHolder>::Accessor svgStorage(sSVGCache);
+  StaticStorage<SVGHolder>::Accessor svgStorage(SVGCache());
   svgStorage.Release();
+#endif
 }
 
 void IGraphics::SetScreenScale(float scale)
@@ -1588,7 +1607,7 @@ void IGraphics::EnableLiveEdit(bool enable)
 #ifdef SVG_USE_SKIA
 ISVG IGraphics::LoadSVG(const char* fileName, const char* units, float dpi)
 {
-  StaticStorage<SVGHolder>::Accessor storage(sSVGCache);
+  StaticStorage<SVGHolder>::Accessor storage(SVGCache());
   SVGHolder* pHolder = storage.Find(fileName);
   
   if(!pHolder)
@@ -1609,7 +1628,7 @@ ISVG IGraphics::LoadSVG(const char* fileName, const char* units, float dpi)
 
 ISVG IGraphics::LoadSVG(const char* name, const void* pData, int dataSize, const char* units, float dpi)
 {
-  StaticStorage<SVGHolder>::Accessor storage(sSVGCache);
+  StaticStorage<SVGHolder>::Accessor storage(SVGCache());
   SVGHolder* pHolder = storage.Find(name);
 
   if (!pHolder)
@@ -1650,7 +1669,7 @@ ISVG IGraphics::LoadSVG(const char* name, const void* pData, int dataSize, const
 #else
 ISVG IGraphics::LoadSVG(const char* fileName, const char* units, float dpi)
 {
-  StaticStorage<SVGHolder>::Accessor storage(sSVGCache);
+  StaticStorage<SVGHolder>::Accessor storage(SVGCache());
   SVGHolder* pHolder = storage.Find(fileName);
 
   if(!pHolder)
@@ -1671,7 +1690,7 @@ ISVG IGraphics::LoadSVG(const char* fileName, const char* units, float dpi)
 
 ISVG IGraphics::LoadSVG(const char* name, const void* pData, int dataSize, const char* units, float dpi)
 {
-  StaticStorage<SVGHolder>::Accessor storage(sSVGCache);
+  StaticStorage<SVGHolder>::Accessor storage(SVGCache());
   SVGHolder* pHolder = storage.Find(name);
 
   if (!pHolder)
@@ -1754,7 +1773,7 @@ IBitmap IGraphics::LoadBitmap(const char* name, int nStates, bool framesAreHoriz
   if (targetScale == 0)
     targetScale = GetRoundedScreenScale();
 
-  StaticStorage<APIBitmap>::Accessor storage(sBitmapCache);
+  StaticStorage<APIBitmap>::Accessor storage(BitmapCache());
   APIBitmap* pAPIBitmap = storage.Find(name, targetScale);
 
   // If the bitmap is not already cached at the targetScale
@@ -1816,7 +1835,7 @@ IBitmap IGraphics::LoadBitmap(const char *name, const void *pData, int dataSize,
   if (targetScale == 0)
     targetScale = GetRoundedScreenScale();
 
-  StaticStorage<APIBitmap>::Accessor storage(sBitmapCache);
+  StaticStorage<APIBitmap>::Accessor storage(BitmapCache());
   APIBitmap* pAPIBitmap = storage.Find(name, targetScale);
 
   // If the bitmap is not already cached at the targetScale
@@ -1864,13 +1883,13 @@ IBitmap IGraphics::LoadBitmap(const char *name, const void *pData, int dataSize,
 
 void IGraphics::ReleaseBitmap(const IBitmap &bitmap)
 {
-  StaticStorage<APIBitmap>::Accessor storage(sBitmapCache);
+  StaticStorage<APIBitmap>::Accessor storage(BitmapCache());
   storage.Remove(bitmap.GetAPIBitmap());
 }
 
 void IGraphics::RetainBitmap(const IBitmap& bitmap, const char* cacheName)
 {
-  StaticStorage<APIBitmap>::Accessor storage(sBitmapCache);
+  StaticStorage<APIBitmap>::Accessor storage(BitmapCache());
   storage.Add(bitmap.GetAPIBitmap(), cacheName, bitmap.GetScale());
 }
 
@@ -1928,7 +1947,7 @@ EResourceLocation IGraphics::SearchImageResource(const char* name, const char* t
 
 APIBitmap* IGraphics::SearchBitmapInCache(const char* name, int targetScale, int& sourceScale)
 {
-  StaticStorage<APIBitmap>::Accessor storage(sBitmapCache);
+  StaticStorage<APIBitmap>::Accessor storage(BitmapCache());
     
   for (sourceScale = targetScale; sourceScale > 0; SearchNextScale(sourceScale, targetScale))
   {

--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -1803,6 +1803,9 @@ protected:
 #pragma mark -
 
 private:
+  StaticStorage<APIBitmap>& BitmapCache();
+  StaticStorage<SVGHolder>& SVGCache();
+
   void ClearMouseOver()
   {
     mMouseOver = nullptr;
@@ -1865,7 +1868,12 @@ private:
   IKeyHandlerFunc mKeyHandlerFunc = nullptr;
   IDisplayTickFunc mDisplayTickFunc = nullptr;
   IUIAppearanceChangedFunc mAppearanceChangedFunc = nullptr;
-  
+
+#if IGRAPHICS_SANDBOX_IMAGE_CACHE
+  StaticStorage<APIBitmap> mBitmapCache;
+  StaticStorage<SVGHolder> mSVGCache;
+#endif
+
 protected:
   IGEditorDelegate* mDelegate;
   bool mCursorHidden = false;


### PR DESCRIPTION
## Summary
- Scope the bitmap and SVG caches to the owning IGraphics instance when sandbox image caching is enabled while keeping the shared storage path for legacy builds.
- Convert the Skia font cache and font-manager helpers to per-instance members in sandbox builds so editors no longer share thread-local singletons.

## Testing
- Not run (not requested).

------
https://chatgpt.com/codex/tasks/task_e_68cf320386f0832984ad7816b9f91212