### PR TITLE
Handle Vulkan present out-of-date with bounded fence wait

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -2524,8 +2524,46 @@ void IGraphicsSkia::EndFrame()
                        vulkanlog::MakeHandleField("image", vulkanlog::HandleToUint64(swapImage)));
   if (res == VK_ERROR_OUT_OF_DATE_KHR || res == VK_SUBOPTIMAL_KHR)
   {
-    vkWaitForFences(mVKDevice, 1, &mVKInFlightFence, VK_TRUE, UINT64_MAX);
-    lock.unlock();
+    uint64_t waitedNs = 0;
+    VkResult waitVkResult = VK_SUCCESS;
+    FenceWaitOutcome waitOutcome = WaitForFenceWithinBudget(mVKDevice,
+                                                            mVKInFlightFence,
+                                                            kVKFrameWaitBudgetNs,
+                                                            kVKFrameWaitPollNs,
+                                                            waitedNs,
+                                                            waitVkResult);
+    if (waitOutcome == FenceWaitOutcome::kTimeout)
+    {
+      IGRAPHICS_VK_LOG("EndFrame",
+                          "presentOutOfDateTimeout",
+                          vulkanlog::Severity::kWarning,
+                          vulkanlog::MakeField("waitedNs", waitedNs),
+                          vulkanlog::MakeField("budgetNs", static_cast<uint64_t>(kVKFrameWaitBudgetNs)));
+      mVKSkipFrame = true;
+      ResetVulkanSwapchainCaches();
+      mScreenSurface.reset();
+      mVKCurrentImage = kInvalidImageIndex;
+      if (lock.owns_lock())
+        lock.unlock();
+      return;
+    }
+    if (waitOutcome == FenceWaitOutcome::kError)
+    {
+      IGRAPHICS_VK_LOG("EndFrame",
+                          "presentOutOfDateWaitFailed",
+                          vulkanlog::Severity::kError,
+                          vulkanlog::MakeField("vkResult", static_cast<int>(waitVkResult)),
+                          vulkanlog::MakeField("waitedNs", waitedNs));
+      mVKSkipFrame = true;
+      ResetVulkanSwapchainCaches();
+      mScreenSurface.reset();
+      mVKCurrentImage = kInvalidImageIndex;
+      if (lock.owns_lock())
+        lock.unlock();
+      return;
+    }
+    if (lock.owns_lock())
+      lock.unlock();
     DrawResize();
     return;
   }


### PR DESCRIPTION
## Summary
- replace the blocking vkWaitForFences call in EndFrame with the bounded WaitForFenceWithinBudget helper
- log and gracefully skip frames when the bounded fence wait times out or errors, clearing swapchain caches and leaving the fence unsignaled so the message pump can proceed

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf5862cdac8329b087ccd85b357a10