### PR TITLE
Handle removal of container child controls

### DIFF
--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -195,6 +195,26 @@ void IGraphics::RemoveControl(int idx)
 
 void IGraphics::RemoveControl(IControl* pControl)
 {
+  if(!pControl)
+    return;
+
+  std::vector<IControl*> childControls;
+
+  if(auto* pContainer = pControl->As<IContainerBase>())
+  {
+    childControls.reserve(pContainer->NChildren());
+
+    pContainer->ForAllChildrenFunc([&](int, IControl* pChild) {
+      if(pChild)
+        childControls.push_back(pChild);
+    });
+  }
+
+  for(IControl* pChild : childControls)
+  {
+    RemoveControl(pChild);
+  }
+
   if(ControlIsCaptured(pControl))
     ReleaseMouseCapture();
   


### PR DESCRIPTION
## Summary
- collect container children before removing controls so child controls are cleaned up
- guard against null control removal while preserving hover/text-entry cleanup

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf67a8b6f483298a776901010e6f78