### PR TITLE
Fix control removal to use recursive path

### DIFF
--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -155,37 +155,22 @@ void IGraphics::SetScaleConstraints(float lo, float hi)
 
 void IGraphics::RemoveControlWithTag(int ctrlTag)
 {
-  mControls.DeletePtr(GetControlWithTag(ctrlTag), true);
-  mCtrlTags.erase(ctrlTag);
-  SetAllControlsDirty();
+  IControl* pControl = GetControlWithTag(ctrlTag);
+
+  if(!pControl)
+    return;
+
+  RemoveControl(pControl);
 }
 
 void IGraphics::RemoveControls(int fromIdx)
 {
-  int idx = NControls()-1;
-  while (idx >= fromIdx)
+  while (NControls() > fromIdx)
   {
-    IControl* pControl = GetControl(idx);
-    
-    if(ControlIsCaptured(pControl))
-      ReleaseMouseCapture();
+    IControl* pControl = GetControl(NControls()-1);
 
-    if(pControl == mMouseOver)
-      ClearMouseOver();
-
-    if(pControl == mInTextEntry)
-      ClearInTextEntryControl();
-
-    if(pControl == mInPopupMenu)
-      mInPopupMenu = nullptr;
-    
-    if(pControl->GetTag() > kNoTag)
-      mCtrlTags.erase(pControl->GetTag());
-    
-    mControls.Delete(idx--, true);
+    RemoveControl(pControl);
   }
-  
-  SetAllControlsDirty();
 }
 
 void IGraphics::RemoveControl(int idx)


### PR DESCRIPTION
## Summary
- ensure RemoveControlWithTag fetches the control and delegates to RemoveControl for consistent cleanup
- update RemoveControls to use RemoveControl so recursive container child detachment occurs for range removals

## Testing
- cmake -S . -B build *(fails: repository has no top-level CMakeLists.txt)*

------
https://chatgpt.com/codex/tasks/task_e_68cf6cc203e88329aaa065be35985598