### PR TITLE
Share Vulkan context struct between Win and Skia

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -114,6 +114,7 @@
   #endif
 
 #elif defined IGRAPHICS_VULKAN
+  #include "../Platforms/VulkanContext.h"
   #include "include/gpu/MutableTextureState.h"
   #include "include/gpu/ganesh/vk/GrVkBackendSemaphore.h"
   #include "include/gpu/ganesh/vk/GrVkBackendSurface.h"

--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -139,7 +139,7 @@ using namespace iplug;
 using namespace igraphics;
 
 #if defined IGRAPHICS_VULKAN
-using PlatformVulkanContext = ::iplug::igraphics::VulkanContext;
+using PlatformVulkanContext = ::iplug::igraphics::PlatformVulkanContext;
 #endif
 
 extern std::map<std::string, MTLTexturePtr> gTextureMap;

--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -138,6 +138,10 @@
 using namespace iplug;
 using namespace igraphics;
 
+#if defined IGRAPHICS_VULKAN
+using PlatformVulkanContext = ::iplug::igraphics::VulkanContext;
+#endif
+
 extern std::map<std::string, MTLTexturePtr> gTextureMap;
 
 #if defined IGRAPHICS_VULKAN
@@ -1144,7 +1148,7 @@ void IGraphicsSkia::OnViewInitialized(void* pContext)
   mMTLCommandQueue = (void*)commandQueue;
   mMTLLayer = pContext;
 #elif defined IGRAPHICS_VULKAN
-  VulkanContext* ctx = static_cast<VulkanContext*>(pContext);
+  PlatformVulkanContext* ctx = static_cast<PlatformVulkanContext*>(pContext);
 
   mVKInstance = ctx->instance;
   mVKPhysicalDevice = ctx->physicalDevice;

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1403,7 +1403,7 @@ bool IGraphicsWin::RecreateVulkanContext()
   DestroyVulkanContext();
   if (!CreateVulkanContext())
     return false;
-  VulkanContext ctx;
+  ::iplug::igraphics::PlatformVulkanContext ctx;
   ctx.instance = VulkanInstance();
   ctx.physicalDevice = VulkanPhysicalDevice();
   ctx.device = VulkanDevice();
@@ -1849,7 +1849,7 @@ void* IGraphicsWin::OpenWindow(void* pParent)
     DBGMSG("IGraphicsWin::OpenWindow failed to initialize Vulkan context for class %ls", className);
     return nullptr;
   }
-  VulkanContext ctx;
+  ::iplug::igraphics::PlatformVulkanContext ctx;
   ctx.instance = VulkanInstance();
   ctx.physicalDevice = VulkanPhysicalDevice();
   ctx.device = VulkanDevice();

--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -33,10 +33,6 @@
 BEGIN_IPLUG_NAMESPACE
 BEGIN_IGRAPHICS_NAMESPACE
 
-#ifdef IGRAPHICS_VULKAN
-using VulkanContext = ::iplug::igraphics::VulkanContext;
-#endif
-
 // Forward declare the OLE drop target helper (defined in IGraphicsWin_dnd.h)
 namespace DragAndDropHelpers
 {

--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -25,9 +25,7 @@
 #include <vector>
 
 #ifdef IGRAPHICS_VULKAN
-  #define VK_USE_PLATFORM_WIN32_KHR
-  #include <vulkan/vulkan.h>
-  #include <vulkan/vulkan_win32.h>
+  #include "VulkanContext.h"
   #include "WinVulkanDeviceCoordinator.h"
 #endif
 
@@ -36,25 +34,7 @@ BEGIN_IPLUG_NAMESPACE
 BEGIN_IGRAPHICS_NAMESPACE
 
 #ifdef IGRAPHICS_VULKAN
-struct VulkanContext
-{
-  VkInstance instance = VK_NULL_HANDLE;
-  VkPhysicalDevice physicalDevice = VK_NULL_HANDLE;
-  VkDevice device = VK_NULL_HANDLE;
-  VkSurfaceKHR surface = VK_NULL_HANDLE;
-  VkSwapchainKHR swapchain = VK_NULL_HANDLE;
-  VkQueue queue = VK_NULL_HANDLE;
-  uint32_t queueFamily = 0;
-  VkSemaphore imageAvailableSemaphore = VK_NULL_HANDLE;
-  VkSemaphore renderFinishedSemaphore = VK_NULL_HANDLE;
-  VkFence inFlightFence = VK_NULL_HANDLE;
-  std::vector<VkImage>* swapchainImages = nullptr;
-  VkFormat format = VK_FORMAT_B8G8R8A8_UNORM;
-  VkImageUsageFlags usageFlags = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-#if IGRAPHICS_SANDBOX_LOGGING
-  const vulkanlog::LoggerContext* loggerContext = nullptr;
-#endif
-};
+using VulkanContext = ::iplug::igraphics::VulkanContext;
 #endif
 
 // Forward declare the OLE drop target helper (defined in IGraphicsWin_dnd.h)

--- a/IGraphics/Platforms/VulkanContext.h
+++ b/IGraphics/Platforms/VulkanContext.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "IPlugPlatform.h"
+
+#if defined(IGRAPHICS_VULKAN)
+  #if defined(OS_WIN) && !defined(VK_USE_PLATFORM_WIN32_KHR)
+    #define VK_USE_PLATFORM_WIN32_KHR
+  #endif
+  #include <vulkan/vulkan.h>
+  #if defined(OS_WIN)
+    #include <vulkan/vulkan_win32.h>
+  #endif
+  #include <vector>
+
+namespace iplug {
+namespace igraphics {
+
+#if IGRAPHICS_SANDBOX_LOGGING
+namespace vulkanlog
+{
+struct LoggerContext;
+}
+#endif
+
+struct VulkanContext
+{
+  VkInstance instance = VK_NULL_HANDLE;
+  VkPhysicalDevice physicalDevice = VK_NULL_HANDLE;
+  VkDevice device = VK_NULL_HANDLE;
+  VkSurfaceKHR surface = VK_NULL_HANDLE;
+  VkSwapchainKHR swapchain = VK_NULL_HANDLE;
+  VkQueue queue = VK_NULL_HANDLE;
+  uint32_t queueFamily = 0;
+  VkSemaphore imageAvailableSemaphore = VK_NULL_HANDLE;
+  VkSemaphore renderFinishedSemaphore = VK_NULL_HANDLE;
+  VkFence inFlightFence = VK_NULL_HANDLE;
+  std::vector<VkImage>* swapchainImages = nullptr;
+  VkFormat format = VK_FORMAT_B8G8R8A8_UNORM;
+  VkImageUsageFlags usageFlags = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+#if IGRAPHICS_SANDBOX_LOGGING
+  const vulkanlog::LoggerContext* loggerContext = nullptr;
+#endif
+};
+
+} // namespace igraphics
+} // namespace iplug
+
+#endif // defined(IGRAPHICS_VULKAN)

--- a/IGraphics/Platforms/VulkanContext.h
+++ b/IGraphics/Platforms/VulkanContext.h
@@ -22,7 +22,7 @@ struct LoggerContext;
 }
 #endif
 
-struct VulkanContext
+struct PlatformVulkanContext
 {
   VkInstance instance = VK_NULL_HANDLE;
   VkPhysicalDevice physicalDevice = VK_NULL_HANDLE;
@@ -41,6 +41,8 @@ struct VulkanContext
   const vulkanlog::LoggerContext* loggerContext = nullptr;
 #endif
 };
+
+using VulkanContext = PlatformVulkanContext;
 
 } // namespace igraphics
 } // namespace iplug

--- a/Plan/Current-Plan.xml
+++ b/Plan/Current-Plan.xml
@@ -348,11 +348,12 @@
     <task>
       <name>FIX_VULKAN_CTX_COMPILATION_ERRORS</name>
       <status>AWAIT-CHILDREN-TASK-SUCCESS</status>
-      <tryCount>1</tryCount>
+      <tryCount>2</tryCount>
       <crucialInfo>Windows Skia/Vulkan builds fail because ctx is undefined throughout IGraphicsSkia Vulkan paths,
       VulkanContext references use pointer-to-member syntax errors, Vulkan image vectors receive mismatched arguments,
       and related helper declarations lack headers. Centralized the VulkanContext definition so both IGraphicsWin and
-      IGraphicsSkia see the same struct, restoring ctx visibility and ensuring swapchain image vectors receive VkImage handles.</crucialInfo>
+      IGraphicsSkia see the same struct, restoring ctx visibility, and added a dedicated PlatformVulkanContext alias in
+      IGraphicsSkia.cpp so references resolve cleanly even with the renderer's VulkanContext() accessors.</crucialInfo>
       <continue-info>Focus on authoring the remote validation recipe for Windows builds once the outstanding verification subtask completes.</continue-info>
       <subtasks>
         <task>
@@ -365,8 +366,8 @@
         <task>
           <name>Correct VulkanContext definitions</name>
           <status>SUCCESS</status>
-          <tryCount>1</tryCount>
-          <crucialInfo>Shared header keeps the VkImage vector pointer and semaphore/fence handles consistent, while aliasing in IGraphicsWin.h avoids pointer-to-member parsing errors triggered by the nested namespace lookup.</crucialInfo>
+          <tryCount>2</tryCount>
+          <crucialInfo>Shared header keeps the VkImage vector pointer and semaphore/fence handles consistent; additional PlatformVulkanContext alias inside IGraphicsSkia.cpp disambiguates the struct from member accessors to prevent pointer-to-member parsing errors.</crucialInfo>
           <continue-info>Confirm that any additional Vulkan helpers include the shared header instead of re-declaring the struct.</continue-info>
         </task>
         <task>

--- a/Plan/Current-Plan.xml
+++ b/Plan/Current-Plan.xml
@@ -11,6 +11,8 @@
     Scope every toggle marked UNSANDBOXED for the Windows Skia/Vulkan path in Plan/Sandbox-Report-Initial.md.
     Each task must reach implementation-ready clarity with file-level touchpoints, state management notes,
     logging/telemetry expectations, and validation approach even though Windows builds cannot run here.
+    New requirement: address the Skia/Vulkan compilation failures where ctx is undefined, VulkanContext usage
+    is mis-specified, and VkImage push_back arguments do not match, restoring a clean Windows build.
   </context>
   <Tasks>
     <task>
@@ -340,6 +342,39 @@
           <tryCount>1</tryCount>
           <crucialInfo>ResolveVerbosity consults the active context so updates take effect immediately across log events.</crucialInfo>
           <continue-info>Global fallback remains available via ResetVerbosity for non-sandbox runs.</continue-info>
+        </task>
+      </subtasks>
+    </task>
+    <task>
+      <name>FIX_VULKAN_CTX_COMPILATION_ERRORS</name>
+      <status>AWAIT-CHILDREN-TASK-SUCCESS</status>
+      <tryCount>1</tryCount>
+      <crucialInfo>Windows Skia/Vulkan builds fail because ctx is undefined throughout IGraphicsSkia Vulkan paths,
+      VulkanContext references use pointer-to-member syntax errors, Vulkan image vectors receive mismatched arguments,
+      and related helper declarations lack headers. Centralized the VulkanContext definition so both IGraphicsWin and
+      IGraphicsSkia see the same struct, restoring ctx visibility and ensuring swapchain image vectors receive VkImage handles.</crucialInfo>
+      <continue-info>Focus on authoring the remote validation recipe for Windows builds once the outstanding verification subtask completes.</continue-info>
+      <subtasks>
+        <task>
+          <name>Trace ctx data flow regression</name>
+          <status>SUCCESS</status>
+          <tryCount>1</tryCount>
+          <crucialInfo>Identified that ctx originated from the Windows Vulkan bootstrap but the struct lived only in IGraphicsWin.h; promoted the definition into a shared Platforms/VulkanContext.h include consumed by both the window and Skia renderer to restore pointer scope.</crucialInfo>
+          <continue-info>Monitor additional sources (e.g. Linux Vulkan) in case they require the shared header during future work.</continue-info>
+        </task>
+        <task>
+          <name>Correct VulkanContext definitions</name>
+          <status>SUCCESS</status>
+          <tryCount>1</tryCount>
+          <crucialInfo>Shared header keeps the VkImage vector pointer and semaphore/fence handles consistent, while aliasing in IGraphicsWin.h avoids pointer-to-member parsing errors triggered by the nested namespace lookup.</crucialInfo>
+          <continue-info>Confirm that any additional Vulkan helpers include the shared header instead of re-declaring the struct.</continue-info>
+        </task>
+        <task>
+          <name>Verify Windows Skia/Vulkan compile</name>
+          <status>OPEN</status>
+          <tryCount>0</tryCount>
+          <crucialInfo>Create a code-review validation plan covering clang-cl/msvc builds since local toolchain unavailable; document assumptions.</crucialInfo>
+          <continue-info>Record steps/flags future agent must run to confirm once Windows environment is available.</continue-info>
         </task>
       </subtasks>
     </task>

--- a/Plan/Current-Plan.xml
+++ b/Plan/Current-Plan.xml
@@ -348,12 +348,12 @@
     <task>
       <name>FIX_VULKAN_CTX_COMPILATION_ERRORS</name>
       <status>AWAIT-CHILDREN-TASK-SUCCESS</status>
-      <tryCount>2</tryCount>
+      <tryCount>3</tryCount>
       <crucialInfo>Windows Skia/Vulkan builds fail because ctx is undefined throughout IGraphicsSkia Vulkan paths,
       VulkanContext references use pointer-to-member syntax errors, Vulkan image vectors receive mismatched arguments,
       and related helper declarations lack headers. Centralized the VulkanContext definition so both IGraphicsWin and
-      IGraphicsSkia see the same struct, restoring ctx visibility, and added a dedicated PlatformVulkanContext alias in
-      IGraphicsSkia.cpp so references resolve cleanly even with the renderer's VulkanContext() accessors.</crucialInfo>
+      IGraphicsSkia see the same struct, then renamed it to PlatformVulkanContext with a compatibility alias so the
+      renderer can reference the shared state without triggering the VulkanContext() accessor collision.</crucialInfo>
       <continue-info>Focus on authoring the remote validation recipe for Windows builds once the outstanding verification subtask completes.</continue-info>
       <subtasks>
         <task>
@@ -366,8 +366,8 @@
         <task>
           <name>Correct VulkanContext definitions</name>
           <status>SUCCESS</status>
-          <tryCount>2</tryCount>
-          <crucialInfo>Shared header keeps the VkImage vector pointer and semaphore/fence handles consistent; additional PlatformVulkanContext alias inside IGraphicsSkia.cpp disambiguates the struct from member accessors to prevent pointer-to-member parsing errors.</crucialInfo>
+          <tryCount>3</tryCount>
+          <crucialInfo>Shared header keeps the VkImage vector pointer and semaphore/fence handles consistent; struct now lives as PlatformVulkanContext with a legacy VulkanContext alias so downstream callers keep compiling while Skia disambiguates its accessor methods.</crucialInfo>
           <continue-info>Confirm that any additional Vulkan helpers include the shared header instead of re-declaring the struct.</continue-info>
         </task>
         <task>

--- a/Plan/Current-Plan.xml
+++ b/Plan/Current-Plan.xml
@@ -367,7 +367,7 @@
           <name>Correct VulkanContext definitions</name>
           <status>SUCCESS</status>
           <tryCount>3</tryCount>
-          <crucialInfo>Shared header keeps the VkImage vector pointer and semaphore/fence handles consistent; struct now lives as PlatformVulkanContext with a legacy VulkanContext alias so downstream callers keep compiling while Skia disambiguates its accessor methods.</crucialInfo>
+          <crucialInfo>Shared header keeps the VkImage vector pointer and semaphore/fence handles consistent; struct now lives as PlatformVulkanContext with a legacy VulkanContext alias so downstream callers keep compiling while Skia disambiguates its accessor methods. Windows bootstrap now instantiates PlatformVulkanContext explicitly to avoid the VulkanContext() member accessor collisions that previously yielded pointer-to-member syntax errors.</crucialInfo>
           <continue-info>Confirm that any additional Vulkan helpers include the shared header instead of re-declaring the struct.</continue-info>
         </task>
         <task>

--- a/Plan/Plan-Summary.md
+++ b/Plan/Plan-Summary.md
@@ -1,19 +1,16 @@
-[x] Continued From Previous Snapshot: YES — Continued PLAN-EXECUTION by sandboxing Skia Vulkan context storage, enforcing draw umbrella cache isolation, and refreshing the Windows sandbox documentation.
+[x] Continued From Previous Snapshot: YES — Updated PLAN-EXECUTION scope to include repairing Skia/Vulkan Windows compilation failures introduced by ctx/VulkanContext regressions.
 -----------------
 [x] File Overview:
-- Num files Changed: 7
+- Num files Changed: 4
 - Num files Created: 1
-- Num lines Modified: 353
+- Num lines Modified: 111
 
 [x] List of Files changed/created:
-- Documentation/WindowsSandbox.md
-- IGraphics/Drawing/IGraphicsSkia.cpp
-- IGraphics/Drawing/IGraphicsSkia.h
-- IGraphics/IGraphics.cpp
-- IGraphics/IGraphics.h
 - Plan/Current-Plan.xml
 - Plan/Plan-Summary.md
-- Plan/State-of-Sandbox-Report.md
+- IGraphics/Drawing/IGraphicsSkia.cpp
+- IGraphics/Platforms/IGraphicsWin.h
+- IGraphics/Platforms/VulkanContext.h
 
 -----------------
 [x] Current plan:
@@ -28,7 +25,8 @@
 - IGRAPHICS_SANDBOX_LOGGING — PREVIOUS STATUS: OPEN / CURRENT STATUS: SUCCESS
 - IGRAPHICS_SANDBOX_VK_LOGGER — PREVIOUS STATUS: OPEN / CURRENT STATUS: SUCCESS
 - IGRAPHICS_SANDBOX_VK_LOG_LEVEL — PREVIOUS STATUS: OPEN / CURRENT STATUS: SUCCESS
+- FIX_VULKAN_CTX_COMPILATION_ERRORS — PREVIOUS STATUS: N/A / CURRENT STATUS: AWAIT-CHILDREN-TASK-SUCCESS
 - FINAL CHECK — PREVIOUS STATUS: OPEN / CURRENT STATUS: OPEN
 
 [x] Message to User:
-Sandbox builds now route Skia's Vulkan command pools, swapchain images, and semaphores through per-instance storage while allowing legacy runs to keep the shared singleton when the toggle is disabled. The draw umbrella switch automatically promotes bitmap/SVG caches to renderer-owned storage, and the Windows sandbox guide documents the new expectations for hosts awaiting Windows validation.
+Shared the VulkanContext struct between the Windows platform layer and Skia renderer so ctx resolves during compilation; next step is to document the Windows validation path for the outstanding verification subtask.

--- a/Plan/Plan-Summary.md
+++ b/Plan/Plan-Summary.md
@@ -1,13 +1,16 @@
 [x] Continued From Previous Snapshot: YES — Updated PLAN-EXECUTION scope to include repairing Skia/Vulkan Windows compilation failures introduced by ctx/VulkanContext regressions.
 -----------------
 [x] File Overview:
-- Num files Changed: 2
+- Num files Changed: 5
 - Num files Created: 0
-- Num lines Modified: 15
+- Num lines Modified: 28
 
 [x] List of Files changed/created:
 - Plan/Current-Plan.xml
+- IGraphics/Platforms/VulkanContext.h
 - IGraphics/Drawing/IGraphicsSkia.cpp
+- IGraphics/Platforms/IGraphicsWin.h
+- Plan/Plan-Summary.md
 
 -----------------
 [x] Current plan:
@@ -26,4 +29,4 @@
 - FINAL CHECK — PREVIOUS STATUS: OPEN / CURRENT STATUS: OPEN
 
 [x] Message to User:
-Scoped alias in IGraphicsSkia now disambiguates the shared VulkanContext struct from the renderer accessors so the ctx pointer compiles cleanly; remaining follow-up is outlining the Windows validation steps for the open verification subtask.
+Shared Vulkan struct now lives as PlatformVulkanContext with a legacy alias, letting Skia consume the Windows bootstrap data without member name clashes; next step remains drafting the Windows validation recipe for the open verification subtask.

--- a/Plan/Plan-Summary.md
+++ b/Plan/Plan-Summary.md
@@ -1,16 +1,13 @@
 [x] Continued From Previous Snapshot: YES — Updated PLAN-EXECUTION scope to include repairing Skia/Vulkan Windows compilation failures introduced by ctx/VulkanContext regressions.
 -----------------
 [x] File Overview:
-- Num files Changed: 4
-- Num files Created: 1
-- Num lines Modified: 111
+- Num files Changed: 2
+- Num files Created: 0
+- Num lines Modified: 15
 
 [x] List of Files changed/created:
 - Plan/Current-Plan.xml
-- Plan/Plan-Summary.md
 - IGraphics/Drawing/IGraphicsSkia.cpp
-- IGraphics/Platforms/IGraphicsWin.h
-- IGraphics/Platforms/VulkanContext.h
 
 -----------------
 [x] Current plan:
@@ -29,4 +26,4 @@
 - FINAL CHECK — PREVIOUS STATUS: OPEN / CURRENT STATUS: OPEN
 
 [x] Message to User:
-Shared the VulkanContext struct between the Windows platform layer and Skia renderer so ctx resolves during compilation; next step is to document the Windows validation path for the outstanding verification subtask.
+Scoped alias in IGraphicsSkia now disambiguates the shared VulkanContext struct from the renderer accessors so the ctx pointer compiles cleanly; remaining follow-up is outlining the Windows validation steps for the open verification subtask.

--- a/Plan/Plan-Summary.md
+++ b/Plan/Plan-Summary.md
@@ -1,16 +1,13 @@
 [x] Continued From Previous Snapshot: YES — Updated PLAN-EXECUTION scope to include repairing Skia/Vulkan Windows compilation failures introduced by ctx/VulkanContext regressions.
 -----------------
 [x] File Overview:
-- Num files Changed: 5
+- Num files Changed: 2
 - Num files Created: 0
-- Num lines Modified: 28
+- Num lines Modified: 6
 
 [x] List of Files changed/created:
 - Plan/Current-Plan.xml
-- IGraphics/Platforms/VulkanContext.h
-- IGraphics/Drawing/IGraphicsSkia.cpp
-- IGraphics/Platforms/IGraphicsWin.h
-- Plan/Plan-Summary.md
+- IGraphics/Platforms/IGraphicsWin.cpp
 
 -----------------
 [x] Current plan:
@@ -29,4 +26,4 @@
 - FINAL CHECK — PREVIOUS STATUS: OPEN / CURRENT STATUS: OPEN
 
 [x] Message to User:
-Shared Vulkan struct now lives as PlatformVulkanContext with a legacy alias, letting Skia consume the Windows bootstrap data without member name clashes; next step remains drafting the Windows validation recipe for the open verification subtask.
+Windows Vulkan bootstrap now instantiates PlatformVulkanContext explicitly so the shared header resolves without colliding with Skia’s VulkanContext() accessors; plan context updated to record the fix while the Windows validation recipe task remains open.


### PR DESCRIPTION
## Summary
- create a shared `IGraphics/Platforms/VulkanContext.h` so both the Windows platform layer and Skia renderer consume the same `VulkanContext` definition
- include the shared header in the Skia Vulkan compilation path and adjust the Windows header to reference it
- update the plan documentation to mark the ctx/VulkanContext investigation subtasks complete and record the new shared header

## Testing
- not run (Windows Vulkan toolchain unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d052b175308329bcc75ff5344e299a