### PR TITLE
Update plan to address Vulkan ctx compilation errors

### DIFF
--- a/Plan/Current-Plan.xml
+++ b/Plan/Current-Plan.xml
@@ -11,6 +11,8 @@
     Scope every toggle marked UNSANDBOXED for the Windows Skia/Vulkan path in Plan/Sandbox-Report-Initial.md.
     Each task must reach implementation-ready clarity with file-level touchpoints, state management notes,
     logging/telemetry expectations, and validation approach even though Windows builds cannot run here.
+    New requirement: address the Skia/Vulkan compilation failures where ctx is undefined, VulkanContext usage
+    is mis-specified, and VkImage push_back arguments do not match, restoring a clean Windows build.
   </context>
   <Tasks>
     <task>
@@ -340,6 +342,38 @@
           <tryCount>1</tryCount>
           <crucialInfo>ResolveVerbosity consults the active context so updates take effect immediately across log events.</crucialInfo>
           <continue-info>Global fallback remains available via ResetVerbosity for non-sandbox runs.</continue-info>
+        </task>
+      </subtasks>
+    </task>
+    <task>
+      <name>FIX_VULKAN_CTX_COMPILATION_ERRORS</name>
+      <status>OPEN</status>
+      <tryCount>0</tryCount>
+      <crucialInfo>Windows Skia/Vulkan builds fail because ctx is undefined throughout IGraphicsSkia Vulkan paths,
+      VulkanContext references use pointer-to-member syntax errors, Vulkan image vectors receive mismatched arguments,
+      and related helper declarations lack headers.</crucialInfo>
+      <continue-info>Focus on IGraphicsSkia_win, Vulkan context helpers, and associated headers to restore compilation</continue-info>
+      <subtasks>
+        <task>
+          <name>Trace ctx data flow regression</name>
+          <status>OPEN</status>
+          <tryCount>0</tryCount>
+          <crucialInfo>Map where ctx should originate within IGraphicsSkia::VulkanContext and document missing includes or scope errors.</crucialInfo>
+          <continue-info>Inspect CreateSwapChain/ResizeSwapChain definitions and headers for ctx visibility.</continue-info>
+        </task>
+        <task>
+          <name>Correct VulkanContext definitions</name>
+          <status>OPEN</status>
+          <tryCount>0</tryCount>
+          <crucialInfo>Fix VulkanContext struct/member declarations, ensure VkImage containers push VkImage handles, and resolve syntax errors.</crucialInfo>
+          <continue-info>Adjust header/implementation to pass ctx references consistently and include required Vulkan headers.</continue-info>
+        </task>
+        <task>
+          <name>Verify Windows Skia/Vulkan compile</name>
+          <status>OPEN</status>
+          <tryCount>0</tryCount>
+          <crucialInfo>Create a code-review validation plan covering clang-cl/msvc builds since local toolchain unavailable; document assumptions.</crucialInfo>
+          <continue-info>Record steps/flags future agent must run to confirm once Windows environment is available.</continue-info>
         </task>
       </subtasks>
     </task>

--- a/Plan/Plan-Summary.md
+++ b/Plan/Plan-Summary.md
@@ -1,19 +1,13 @@
-[x] Continued From Previous Snapshot: YES — Continued PLAN-EXECUTION by sandboxing Skia Vulkan context storage, enforcing draw umbrella cache isolation, and refreshing the Windows sandbox documentation.
+[x] Continued From Previous Snapshot: YES — Updated PLAN-EXECUTION scope to include repairing Skia/Vulkan Windows compilation failures introduced by ctx/VulkanContext regressions.
 -----------------
 [x] File Overview:
-- Num files Changed: 7
-- Num files Created: 1
-- Num lines Modified: 353
+- Num files Changed: 2
+- Num files Created: 0
+- Num lines Modified: 51
 
 [x] List of Files changed/created:
-- Documentation/WindowsSandbox.md
-- IGraphics/Drawing/IGraphicsSkia.cpp
-- IGraphics/Drawing/IGraphicsSkia.h
-- IGraphics/IGraphics.cpp
-- IGraphics/IGraphics.h
 - Plan/Current-Plan.xml
 - Plan/Plan-Summary.md
-- Plan/State-of-Sandbox-Report.md
 
 -----------------
 [x] Current plan:
@@ -28,7 +22,8 @@
 - IGRAPHICS_SANDBOX_LOGGING — PREVIOUS STATUS: OPEN / CURRENT STATUS: SUCCESS
 - IGRAPHICS_SANDBOX_VK_LOGGER — PREVIOUS STATUS: OPEN / CURRENT STATUS: SUCCESS
 - IGRAPHICS_SANDBOX_VK_LOG_LEVEL — PREVIOUS STATUS: OPEN / CURRENT STATUS: SUCCESS
+- FIX_VULKAN_CTX_COMPILATION_ERRORS — PREVIOUS STATUS: N/A / CURRENT STATUS: OPEN
 - FINAL CHECK — PREVIOUS STATUS: OPEN / CURRENT STATUS: OPEN
 
 [x] Message to User:
-Sandbox builds now route Skia's Vulkan command pools, swapchain images, and semaphores through per-instance storage while allowing legacy runs to keep the shared singleton when the toggle is disabled. The draw umbrella switch automatically promotes bitmap/SVG caches to renderer-owned storage, and the Windows sandbox guide documents the new expectations for hosts awaiting Windows validation.
+Recorded a new task grouping to restore the Windows Skia/Vulkan toolchain: we still lack local Windows builds, so the plan now traces ctx scope regressions, corrects VulkanContext/VkImage definitions, and captures follow-up validation guidance once the proper toolchain is available.


### PR DESCRIPTION
## Summary
- note the new Windows Skia/Vulkan compilation failures in the plan context
- add an open task hierarchy to resolve the ctx/VulkanContext build errors and validation follow-up
- refresh the plan summary to reflect the added scope and open work

## Testing
- not run (plan documentation update)


------
https://chatgpt.com/codex/tasks/task_e_68d052b175308329bcc75ff5344e299a