### PR TITLE
Call ReleaseCapture on Windows when releasing mouse

### DIFF
--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -37,6 +37,10 @@ using VST3_API_BASE = iplug::IPlugVST3Controller;
 #include "ITextEntryControl.h"
 #include "IBubbleControl.h"
 
+#ifdef OS_WIN
+#include <windows.h>
+#endif
+
 using namespace iplug;
 using namespace igraphics;
 
@@ -1341,6 +1345,9 @@ void IGraphics::ReleaseMouseCapture()
   mCapturedMap.clear();
   if (mCursorHidden)
     HideMouseCursor(false);
+#ifdef OS_WIN
+  ::ReleaseCapture();
+#endif
 }
 
 int IGraphics::GetMouseControlIdx(float x, float y, bool mouseOver)


### PR DESCRIPTION
## Summary
- include <windows.h> in IGraphics.cpp when building on Windows
- call ::ReleaseCapture() in IGraphics::ReleaseMouseCapture() to release OS-level capture

## Testing
- not run (Windows build required)

------
https://chatgpt.com/codex/tasks/task_e_68d084866fd083298552b8e644783503