### PR TITLE
Handle capture changes on Windows

### DIFF
--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -14,6 +14,10 @@
 #pragma warning(disable:4244) // float conversion
 #include "nanosvg.h"
 
+#ifdef OS_WIN
+#include <windows.h>
+#endif
+
 #if defined VST3_API
 #include "pluginterfaces/base/ustring.h"
 #include "IPlugVST3.h"
@@ -1339,6 +1343,12 @@ void IGraphics::OnDropMultiple(const std::vector<const char*>& paths, float x, f
 void IGraphics::ReleaseMouseCapture()
 {
   mCapturedMap.clear();
+#ifdef OS_WIN
+  if (::GetCapture() == static_cast<HWND>(GetWindow()))
+  {
+    ::ReleaseCapture();
+  }
+#endif
   if (mCursorHidden)
     HideMouseCursor(false);
 }

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -512,6 +512,10 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
     pGraphics->OnMouseOut();
     return 0;
   }
+  case WM_CAPTURECHANGED: {
+    pGraphics->ReleaseMouseCapture();
+    return 0;
+  }
   case WM_LBUTTONUP:
   case WM_RBUTTONUP: {
     ReleaseCapture();


### PR DESCRIPTION
## Summary
- release IGraphics mouse capture when Windows sends WM_CAPTURECHANGED to drop pending drags
- ensure IGraphics::ReleaseMouseCapture also clears the Win32 capture when the graphics window owns it

## Testing
- not run (Windows-only build required)

------
https://chatgpt.com/codex/tasks/task_e_68d0894748f483298bd767122eb8aab5