### PR TITLE
Ensure mouse capture release occurs before clearing state on Windows

### DIFF
--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -1342,13 +1342,13 @@ void IGraphics::OnDropMultiple(const std::vector<const char*>& paths, float x, f
 
 void IGraphics::ReleaseMouseCapture()
 {
-  mCapturedMap.clear();
 #ifdef OS_WIN
   if (::GetCapture() == static_cast<HWND>(GetWindow()))
   {
     ::ReleaseCapture();
   }
 #endif
+  mCapturedMap.clear();
   if (mCursorHidden)
     HideMouseCursor(false);
 }


### PR DESCRIPTION
## Summary
- ensure ReleaseMouseCapture releases the Win32 capture handle if still owned by the view before clearing internal state

## Testing
- not run (Windows-specific build not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d08c3205148329a10094bbb16d0d46