### PR TITLE
Guard Windows mouse capture release

### DIFF
--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -1343,9 +1343,12 @@ void IGraphics::OnDropMultiple(const std::vector<const char*>& paths, float x, f
 void IGraphics::ReleaseMouseCapture()
 {
 #ifdef OS_WIN
-  if (::GetCapture() == static_cast<HWND>(GetWindow()))
+  if (auto window = static_cast<HWND>(GetWindow()))
   {
-    ::ReleaseCapture();
+    if (::GetCapture() == window)
+    {
+      ::ReleaseCapture();
+    }
   }
 #endif
   mCapturedMap.clear();


### PR DESCRIPTION
## Summary
- prevent releasing mouse capture on Windows unless the plug-in window currently owns it to avoid clearing capture state for other windows

## Testing
- not run (Windows-specific behavior cannot be validated in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d08ecb9f6c8329ab2161e9dd4a0bf0