### PR TITLE
Fix Win32 mouse capture release ordering

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -518,10 +518,14 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
   }
   case WM_LBUTTONUP:
   case WM_RBUTTONUP: {
-    ReleaseCapture();
+    const bool hadCapture = (GetCapture() == hWnd);
     IMouseInfo info = pGraphics->GetMouseInfo(lParam, wParam);
     std::vector<IMouseInfo> list{info};
     pGraphics->OnMouseUp(list);
+    if (hadCapture && GetCapture() == hWnd)
+    {
+      ReleaseCapture();
+    }
     return 0;
   }
   case WM_LBUTTONDBLCLK:


### PR DESCRIPTION
## Summary
- defer ReleaseCapture() until after the UI processes WM_*BUTTONUP so captured controls receive OnMouseUp
- only release capture if the window still owns it after handling the mouse-up event

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0904b8ae88329bc5867a591b44d27