### PR TITLE
Fix Windows mouse capture release timing

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -382,10 +382,15 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
   }
   case WM_LBUTTONUP:
   case WM_RBUTTONUP: {
-    ReleaseCapture();
     IMouseInfo info = pGraphics->GetMouseInfo(lParam, wParam);
     std::vector<IMouseInfo> list{info};
     pGraphics->OnMouseUp(list);
+    ReleaseCapture();
+    return 0;
+  }
+  case WM_CAPTURECHANGED: {
+    // Preserve the captured control until OnMouseUp() completes so that
+    // EndInformHostOfParamChangeFromUI() is triggered as expected.
     return 0;
   }
   case WM_LBUTTONDBLCLK:


### PR DESCRIPTION
## Summary
- keep the Win32 capture active while dispatching OnMouseUp so captured controls can finish notifying their parameters
- ignore WM_CAPTURECHANGED for capture-map lifetime management and let OnMouseUp clear the entry

## Testing
- cmake -S . -B build *(fails: The source directory "/workspace/iPlug2" does not appear to contain CMakeLists.txt.)*


------
https://chatgpt.com/codex/tasks/task_e_68d098dd1154832980cf5328c192c03e