### PR TITLE
Handle capture loss on Windows

### DIFF
--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -1301,6 +1301,35 @@ void IGraphics::OnDropMultiple(const std::vector<const char*>& paths, float x, f
   if (pControl) pControl->OnDropMultiple(paths);
 }
 
+void IGraphics::HandleCaptureLoss()
+{
+  if (!ControlIsCaptured())
+    return;
+
+  std::vector<IMouseInfo> points;
+  points.reserve(mCapturedMap.size());
+
+  for (auto& capture : mCapturedMap)
+  {
+    IMouseInfo info;
+    info.x = mCursorX;
+    info.y = mCursorY;
+    info.ms = IMouseMod(false, false, false, false, false, capture.first);
+    points.push_back(info);
+  }
+
+#ifndef NDEBUG
+  DBGMSG("IGraphics::HandleCaptureLoss() releasing %zu capture(s)\n", points.size());
+#endif
+
+  OnMouseUp(points);
+
+  mCapturedMap.clear();
+
+  if (mCursorHidden)
+    HideMouseCursor(false);
+}
+
 void IGraphics::ReleaseMouseCapture()
 {
   mCapturedMap.clear();

--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -1606,6 +1606,9 @@ public:
   /** Used to tell the graphics context to stop tracking mouse interaction with a control */
   void ReleaseMouseCapture();
 
+  /** Called when the platform loses mouse capture unexpectedly to finish outstanding gestures. */
+  void HandleCaptureLoss();
+
   /** @return \c true if the context has mouse overs enabled */
   bool MouseOverEnabled() const { return mEnableMouseOver; }
 

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -380,17 +380,22 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
     pGraphics->OnMouseOut();
     return 0;
   }
+  case WM_CAPTURECHANGED: {
+    if (HWND(lParam) != hWnd && pGraphics->ControlIsCaptured())
+    {
+#ifndef NDEBUG
+      DBGMSG("IGraphicsWin::WndProc() lost capture to %p\n", reinterpret_cast<void*>(HWND(lParam)));
+#endif
+      pGraphics->HandleCaptureLoss();
+    }
+    return 0;
+  }
   case WM_LBUTTONUP:
   case WM_RBUTTONUP: {
     IMouseInfo info = pGraphics->GetMouseInfo(lParam, wParam);
     std::vector<IMouseInfo> list{info};
     pGraphics->OnMouseUp(list);
     ReleaseCapture();
-    return 0;
-  }
-  case WM_CAPTURECHANGED: {
-    // Preserve the captured control until OnMouseUp() completes so that
-    // EndInformHostOfParamChangeFromUI() is triggered as expected.
     return 0;
   }
   case WM_LBUTTONDBLCLK:


### PR DESCRIPTION
## Summary
- add an IGraphics helper that finalizes captured controls when capture is lost unexpectedly
- use the helper from the Windows WndProc WM_CAPTURECHANGED path so host automation completes even if capture is stolen
- emit debug logging for capture changes when building without NDEBUG

## Testing
- not run (Windows-specific message handling change)


------
https://chatgpt.com/codex/tasks/task_e_68d09df9b4608329a3839f5a78bb6850