### PR TITLE
Refine mouse capture release handling

### DIFF
--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -1077,35 +1077,43 @@ void IGraphics::OnMouseDown(const std::vector<IMouseInfo>& points)
   }
 }
 
+void IGraphics::FinishCaptureForTouch(const IMouseInfo& info)
+{
+  const IMouseMod& mod = info.ms;
+  auto itr = mCapturedMap.find(mod.touchID);
+
+  if (itr == mCapturedMap.end())
+    return;
+
+  IControl* pCapturedControl = itr->second;
+
+  if (pCapturedControl)
+  {
+    pCapturedControl->OnMouseUp(info.x, info.y, mod);
+
+    const int nVals = pCapturedControl->NVals();
+
+    for (int v = 0; v < nVals; v++)
+    {
+      const int paramIdx = pCapturedControl->GetParamIdx(v);
+
+      if (paramIdx > kNoParameter)
+        GetDelegate()->EndInformHostOfParamChangeFromUI(paramIdx);
+    }
+  }
+
+  mCapturedMap.erase(itr);
+}
+
 void IGraphics::OnMouseUp(const std::vector<IMouseInfo>& points)
 {
 //  Trace("IGraphics::OnMouseUp", __LINE__, "x:%0.2f, y:%0.2f, mod:LRSCA: %i%i%i%i%i", x, y, mod.L, mod.R, mod.S, mod.C, mod.A);
-  
+
   if (ControlIsCaptured())
   {
     for (auto& point : points)
     {
-      float x = point.x;
-      float y = point.y;
-      const IMouseMod& mod = point.ms;
-      auto itr = mCapturedMap.find(mod.touchID);
-      
-      if(itr != mCapturedMap.end())
-      {
-        IControl* pCapturedControl = itr->second;
-      
-        pCapturedControl->OnMouseUp(x, y, mod);
-      
-        int nVals = pCapturedControl->NVals();
-
-        for (int v = 0; v < nVals; v++)
-        {
-          if (pCapturedControl->GetParamIdx(v) > kNoParameter)
-            GetDelegate()->EndInformHostOfParamChangeFromUI(pCapturedControl->GetParamIdx(v));
-        }
-        
-        mCapturedMap.erase(mod.touchID);
-      }
+      FinishCaptureForTouch(point);
     }
   }
 
@@ -1324,15 +1332,34 @@ void IGraphics::HandleCaptureLoss()
 
   OnMouseUp(points);
 
-  mCapturedMap.clear();
-
   if (mCursorHidden)
     HideMouseCursor(false);
 }
 
 void IGraphics::ReleaseMouseCapture()
 {
-  mCapturedMap.clear();
+  if (ControlIsCaptured())
+  {
+    std::vector<ITouchID> touchIDs;
+    touchIDs.reserve(mCapturedMap.size());
+
+    for (const auto& capture : mCapturedMap)
+    {
+      touchIDs.push_back(capture.first);
+    }
+
+    for (ITouchID touchID : touchIDs)
+    {
+      IMouseInfo info;
+      info.x = mCursorX;
+      info.y = mCursorY;
+      info.ms = IMouseMod(false, false, false, false, false, touchID);
+      FinishCaptureForTouch(info);
+    }
+
+    mCapturedMap.clear();
+  }
+
   if (mCursorHidden)
     HideMouseCursor(false);
 }

--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -1251,7 +1251,10 @@ private:
    * @param bounds \todo
    * @param scale \todo */
   void Draw(const IRECT& bounds, float scale);
-  
+
+  /** Finish any capture for a specific touch/mouse interaction, notifying the control and host. */
+  void FinishCaptureForTouch(const IMouseInfo& info);
+
   /** \todo
    * @param pControl \todo
    * @param bounds \todo
@@ -1608,7 +1611,7 @@ public:
 
   /** Called when the platform loses mouse capture unexpectedly to finish outstanding gestures. */
   void HandleCaptureLoss();
-
+ 
   /** @return \c true if the context has mouse overs enabled */
   bool MouseOverEnabled() const { return mEnableMouseOver; }
 


### PR DESCRIPTION
## Summary
- extract the shared mouse-up cleanup logic into a new FinishCaptureForTouch helper
- reuse the helper from ReleaseMouseCapture so forced releases notify controls and hosts
- rely on the helper when capture is lost to avoid bypassing parameter end notifications

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0a3ccd590832989733a3f4252e351