### PR TITLE
Release captured controls when OS steals mouse capture

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -386,7 +386,7 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
 #ifndef NDEBUG
       DBGMSG("IGraphicsWin::WndProc() lost capture to %p\n", reinterpret_cast<void*>(HWND(lParam)));
 #endif
-      pGraphics->HandleCaptureLoss();
+      pGraphics->ReleaseMouseCapture();
     }
     return 0;
   }


### PR DESCRIPTION
## Summary
- call ReleaseMouseCapture when WM_CAPTURECHANGED indicates the window lost capture to another HWND
- keep debug logging so capture churn can be observed in non-release builds

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0a5006dfc83299701a0b5c98a3095