### PR TITLE
Fix Win32 mouse capture lifecycle

### DIFF
--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -1077,36 +1077,46 @@ void IGraphics::OnMouseDown(const std::vector<IMouseInfo>& points)
   }
 }
 
+void IGraphics::FinishCaptureForTouch(ITouchID touchID, const IMouseInfo* pInfo)
+{
+  auto itr = mCapturedMap.find(touchID);
+
+  if (itr == mCapturedMap.end())
+    return;
+
+  IControl* pCapturedControl = itr->second;
+
+  if (pCapturedControl)
+  {
+    float x = pInfo ? pInfo->x : mCursorX;
+    float y = pInfo ? pInfo->y : mCursorY;
+    IMouseMod mod = pInfo ? pInfo->ms : IMouseMod(false, false, false, false, false, touchID);
+    mod.touchID = touchID;
+
+    pCapturedControl->OnMouseUp(x, y, mod);
+
+    const int nVals = pCapturedControl->NVals();
+
+    for (int v = 0; v < nVals; v++)
+    {
+      const int paramIdx = pCapturedControl->GetParamIdx(v);
+
+      if (paramIdx > kNoParameter)
+        GetDelegate()->EndInformHostOfParamChangeFromUI(paramIdx);
+    }
+  }
+
+  mCapturedMap.erase(itr);
+}
+
 void IGraphics::OnMouseUp(const std::vector<IMouseInfo>& points)
 {
 //  Trace("IGraphics::OnMouseUp", __LINE__, "x:%0.2f, y:%0.2f, mod:LRSCA: %i%i%i%i%i", x, y, mod.L, mod.R, mod.S, mod.C, mod.A);
-  
+
   if (ControlIsCaptured())
   {
-    for (auto& point : points)
-    {
-      float x = point.x;
-      float y = point.y;
-      const IMouseMod& mod = point.ms;
-      auto itr = mCapturedMap.find(mod.touchID);
-      
-      if(itr != mCapturedMap.end())
-      {
-        IControl* pCapturedControl = itr->second;
-      
-        pCapturedControl->OnMouseUp(x, y, mod);
-      
-        int nVals = pCapturedControl->NVals();
-
-        for (int v = 0; v < nVals; v++)
-        {
-          if (pCapturedControl->GetParamIdx(v) > kNoParameter)
-            GetDelegate()->EndInformHostOfParamChangeFromUI(pCapturedControl->GetParamIdx(v));
-        }
-        
-        mCapturedMap.erase(mod.touchID);
-      }
-    }
+    for (const auto& point : points)
+      FinishCaptureForTouch(point.ms.touchID, &point);
   }
 
   if (mResizingInProcess)
@@ -1303,7 +1313,18 @@ void IGraphics::OnDropMultiple(const std::vector<const char*>& paths, float x, f
 
 void IGraphics::ReleaseMouseCapture()
 {
-  mCapturedMap.clear();
+  if (ControlIsCaptured())
+  {
+    std::vector<ITouchID> touchIDs;
+    touchIDs.reserve(mCapturedMap.size());
+
+    for (const auto& capture : mCapturedMap)
+      touchIDs.push_back(capture.first);
+
+    for (auto touchID : touchIDs)
+      FinishCaptureForTouch(touchID);
+  }
+
   if (mCursorHidden)
     HideMouseCursor(false);
 }

--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -1084,6 +1084,9 @@ void IGraphics::OnMouseDown(const std::vector<IMouseInfo>& points)
         }
       }
 
+      if (pCaptureInfo)
+        pCaptureInfo->sawMouseDown = true;
+
       pCapturedControl->OnMouseDown(x, y, mod);
     }
   }
@@ -1099,7 +1102,7 @@ void IGraphics::FinishCaptureForTouch(ITouchID touchID, const IMouseInfo* pInfo)
   CapturedControl capture = itr->second;
   IControl* pCapturedControl = capture.pControl;
 
-  if (pCapturedControl)
+  if (pCapturedControl && capture.sawMouseDown)
   {
     float x = pInfo ? pInfo->x : mCursorX;
     float y = pInfo ? pInfo->y : mCursorY;

--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -1010,7 +1010,9 @@ void IGraphics::OnMouseDown(const std::vector<IMouseInfo>& points)
     const IMouseMod& mod = point.ms;
     
     IControl* pCapturedControl = GetMouseControl(x, y, true, false, mod.touchID);
-    
+    auto captureItr = mCapturedMap.find(mod.touchID);
+    CapturedControl* pCaptureInfo = captureItr != mCapturedMap.end() ? &captureItr->second : nullptr;
+
     if (pCapturedControl)
     {
       int nVals = pCapturedControl->NVals();
@@ -1066,10 +1068,20 @@ void IGraphics::OnMouseDown(const std::vector<IMouseInfo>& points)
       }
 #endif
 
+      bool beganInformHost = false;
       for (int v = 0; v < nVals; v++)
       {
         if (pCapturedControl->GetParamIdx(v) > kNoParameter)
+        {
+          if (!beganInformHost)
+          {
+            if (pCaptureInfo)
+              pCaptureInfo->beganInformHost = true;
+
+            beganInformHost = true;
+          }
           GetDelegate()->BeginInformHostOfParamChangeFromUI(pCapturedControl->GetParamIdx(v));
+        }
       }
 
       pCapturedControl->OnMouseDown(x, y, mod);
@@ -1084,7 +1096,8 @@ void IGraphics::FinishCaptureForTouch(ITouchID touchID, const IMouseInfo* pInfo)
   if (itr == mCapturedMap.end())
     return;
 
-  IControl* pCapturedControl = itr->second;
+  CapturedControl capture = itr->second;
+  IControl* pCapturedControl = capture.pControl;
 
   if (pCapturedControl)
   {
@@ -1095,14 +1108,17 @@ void IGraphics::FinishCaptureForTouch(ITouchID touchID, const IMouseInfo* pInfo)
 
     pCapturedControl->OnMouseUp(x, y, mod);
 
-    const int nVals = pCapturedControl->NVals();
-
-    for (int v = 0; v < nVals; v++)
+    if (capture.beganInformHost)
     {
-      const int paramIdx = pCapturedControl->GetParamIdx(v);
+      const int nVals = pCapturedControl->NVals();
 
-      if (paramIdx > kNoParameter)
-        GetDelegate()->EndInformHostOfParamChangeFromUI(paramIdx);
+      for (int v = 0; v < nVals; v++)
+      {
+        const int paramIdx = pCapturedControl->GetParamIdx(v);
+
+        if (paramIdx > kNoParameter)
+          GetDelegate()->EndInformHostOfParamChangeFromUI(paramIdx);
+      }
     }
   }
 
@@ -1143,7 +1159,7 @@ void IGraphics::OnTouchCancelled(const std::vector<IMouseInfo>& points)
       
       if(itr != mCapturedMap.end())
       {
-        IControl* pCapturedControl = itr->second;
+        IControl* pCapturedControl = itr->second.pControl;
         pCapturedControl->OnTouchCancelled(x, y, mod);
         mCapturedMap.erase(mod.touchID); // remove from captured list
         
@@ -1211,7 +1227,7 @@ void IGraphics::OnMouseDrag(const std::vector<IMouseInfo>& points)
       
       if (itr != mCapturedMap.end())
       {
-        IControl* pCapturedControl = itr->second;
+        IControl* pCapturedControl = itr->second.pControl;
 
         if (textEntry && pCapturedControl != textEntry)
             pCapturedControl = nullptr;
@@ -1327,6 +1343,8 @@ void IGraphics::ReleaseMouseCapture()
 
   if (mCursorHidden)
     HideMouseCursor(false);
+
+  PlatformReleaseMouseCapture();
 }
 
 int IGraphics::GetMouseControlIdx(float x, float y, bool mouseOver)
@@ -1370,11 +1388,11 @@ IControl* IGraphics::GetMouseControl(float x, float y, bool capture, bool mouseO
   IControl* pControl = nullptr;
 
   auto itr = mCapturedMap.find(touchID);
-  
+
   if(ControlIsCaptured() && itr != mCapturedMap.end())
   {
-    pControl = itr->second;
-    
+    pControl = itr->second.pControl;
+
     if(pControl)
       return pControl;
   }
@@ -1415,7 +1433,7 @@ IControl* IGraphics::GetMouseControl(float x, float y, bool capture, bool mouseO
         return nullptr;
     }
     
-    mCapturedMap.insert(std::make_pair(touchID, pControl));
+    mCapturedMap.insert(std::make_pair(touchID, CapturedControl{pControl, false}));
     
 //    DBGMSG("ADD - NCONTROLS captured = %lu\n", mCapturedMap.size());
   }

--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -10,6 +10,8 @@
 
 #include "IGraphics.h"
 
+#include <cinttypes>
+
 #define NANOSVG_IMPLEMENTATION
 #pragma warning(disable:4244) // float conversion
 #include "nanosvg.h"
@@ -1088,6 +1090,10 @@ void IGraphics::OnMouseDown(const std::vector<IMouseInfo>& points)
         pCaptureInfo->sawMouseDown = true;
 
       pCapturedControl->OnMouseDown(x, y, mod);
+#ifndef NDEBUG
+      DBGMSG("IGraphics::OnMouseDown capture touch=%" PRIuPTR " tag=%d count=%zu\n", static_cast<uintptr_t>(mod.touchID),
+             pCapturedControl->GetTag(), mCapturedMap.size());
+#endif
     }
   }
 }
@@ -1101,6 +1107,12 @@ void IGraphics::FinishCaptureForTouch(ITouchID touchID, const IMouseInfo* pInfo)
 
   CapturedControl capture = itr->second;
   IControl* pCapturedControl = capture.pControl;
+
+#ifndef NDEBUG
+  DBGMSG("IGraphics::FinishCaptureForTouch begin touch=%" PRIuPTR " tag=%d beganHost=%d sawDown=%d count=%zu\n",
+         static_cast<uintptr_t>(touchID), pCapturedControl ? pCapturedControl->GetTag() : kNoTag, capture.beganInformHost,
+         capture.sawMouseDown, mCapturedMap.size());
+#endif
 
   if (pCapturedControl && capture.sawMouseDown)
   {
@@ -1125,7 +1137,14 @@ void IGraphics::FinishCaptureForTouch(ITouchID touchID, const IMouseInfo* pInfo)
     }
   }
 
+  PlatformOnCaptureFinished(touchID);
+
   mCapturedMap.erase(itr);
+
+#ifndef NDEBUG
+  DBGMSG("IGraphics::FinishCaptureForTouch end touch=%" PRIuPTR " remaining=%zu\n", static_cast<uintptr_t>(touchID),
+         mCapturedMap.size());
+#endif
 }
 
 void IGraphics::OnMouseUp(const std::vector<IMouseInfo>& points)
@@ -1164,9 +1183,14 @@ void IGraphics::OnTouchCancelled(const std::vector<IMouseInfo>& points)
       {
         IControl* pCapturedControl = itr->second.pControl;
         pCapturedControl->OnTouchCancelled(x, y, mod);
+        PlatformOnCaptureFinished(mod.touchID);
         mCapturedMap.erase(mod.touchID); // remove from captured list
-        
+
         //        DBGMSG("DEL - NCONTROLS captured = %lu\n", mCapturedMap.size());
+#ifndef NDEBUG
+        DBGMSG("IGraphics::OnTouchCancelled touch=%" PRIuPTR " tag=%d count=%zu\n", static_cast<uintptr_t>(mod.touchID),
+               pCapturedControl ? pCapturedControl->GetTag() : kNoTag, mCapturedMap.size());
+#endif
       }
     }
   }
@@ -1332,6 +1356,9 @@ void IGraphics::OnDropMultiple(const std::vector<const char*>& paths, float x, f
 
 void IGraphics::ReleaseMouseCapture()
 {
+#ifndef NDEBUG
+  DBGMSG("IGraphics::ReleaseMouseCapture begin captured=%d count=%zu\n", ControlIsCaptured(), mCapturedMap.size());
+#endif
   if (ControlIsCaptured())
   {
     std::vector<ITouchID> touchIDs;
@@ -1348,6 +1375,10 @@ void IGraphics::ReleaseMouseCapture()
     HideMouseCursor(false);
 
   PlatformReleaseMouseCapture();
+
+#ifndef NDEBUG
+  DBGMSG("IGraphics::ReleaseMouseCapture end captured=%d count=%zu\n", ControlIsCaptured(), mCapturedMap.size());
+#endif
 }
 
 int IGraphics::GetMouseControlIdx(float x, float y, bool mouseOver)
@@ -1435,10 +1466,14 @@ IControl* IGraphics::GetMouseControl(float x, float y, bool capture, bool mouseO
       if (alreadyCaptured && !pControl->GetWantsMultiTouch())
         return nullptr;
     }
-    
+
     mCapturedMap.insert(std::make_pair(touchID, CapturedControl{pControl, false}));
-    
+
 //    DBGMSG("ADD - NCONTROLS captured = %lu\n", mCapturedMap.size());
+#ifndef NDEBUG
+    DBGMSG("IGraphics::GetMouseControl capture touch=%" PRIuPTR " tag=%d count=%zu\n", static_cast<uintptr_t>(touchID),
+           pControl->GetTag(), mCapturedMap.size());
+#endif
   }
   
   if (mouseOver)

--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -1422,14 +1422,14 @@ public:
    * @return \c true is the control is already captured */
   bool ControlIsCaptured(IControl* pControl) const
   {
-    return std::find_if(std::begin(mCapturedMap), std::end(mCapturedMap), [pControl](auto&& press) { return press.second == pControl; }) != mCapturedMap.end();
+    return std::find_if(std::begin(mCapturedMap), std::end(mCapturedMap), [pControl](auto&& press) { return press.second.pControl == pControl; }) != mCapturedMap.end();
   }
 
   /** Populate a vector with the touchIDs active on pControl */
   void GetTouches(IControl* pControl, std::vector<ITouchID>& touchesOnThisControl) const
   {
     for (auto i = mCapturedMap.begin(), j = mCapturedMap.end(); i != j; ++i)
-      if (i->second == pControl)
+      if (i->second.pControl == pControl)
         touchesOnThisControl.push_back(i->first);
   }
   
@@ -1723,6 +1723,8 @@ protected:
    * @return APIBitmap* Drawing API bitmap abstraction */
   virtual APIBitmap* LoadAPIBitmap(const char* fileNameOrResID, int scale, EResourceLocation location, const char* ext) = 0;
 
+  virtual void PlatformReleaseMouseCapture() {}
+
   /** Drawing API method to load a bitmap from binary data, called internally
    * @param name CString for the name of the resource
    * @param pData Raw pointer to the binary data
@@ -1839,7 +1841,13 @@ private:
   std::vector<EGestureType> mRegisteredGestures; // All the types of gesture registered with the graphics context
   IRECTList mGestureRegions; // Rectangular regions linked to gestures (excluding IControls)
   std::unordered_map<int, IGestureFunc> mGestureRegionFuncs; // Map of gesture region index to gesture function
-  std::unordered_map<ITouchID, IControl*> mCapturedMap; // associative array of touch ids to control pointers, the same control can be touched multiple times
+  struct CapturedControl
+  {
+    IControl* pControl = nullptr;
+    bool beganInformHost = false;
+  };
+
+  std::unordered_map<ITouchID, CapturedControl> mCapturedMap; // associative array of touch ids to control pointers, the same control can be touched multiple times
   IControl* mMouseOver = nullptr;
   IControl* mInTextEntry = nullptr;
   IControl* mInPopupMenu = nullptr;

--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -1845,6 +1845,7 @@ private:
   {
     IControl* pControl = nullptr;
     bool beganInformHost = false;
+    bool sawMouseDown = false;
   };
 
   std::unordered_map<ITouchID, CapturedControl> mCapturedMap; // associative array of touch ids to control pointers, the same control can be touched multiple times

--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -1417,6 +1417,9 @@ public:
   
   /** Check to see if any control is captured */
   bool ControlIsCaptured() const { return mCapturedMap.size() > 0; }
+
+  /** Debug helper to count captured controls */
+  size_t GetCaptureCount() const { return mCapturedMap.size(); }
   
   /** Check to see if the control is already captured
    * @return \c true is the control is already captured */
@@ -1724,6 +1727,7 @@ protected:
   virtual APIBitmap* LoadAPIBitmap(const char* fileNameOrResID, int scale, EResourceLocation location, const char* ext) = 0;
 
   virtual void PlatformReleaseMouseCapture() {}
+  virtual void PlatformOnCaptureFinished(ITouchID) {}
 
   /** Drawing API method to load a bitmap from binary data, called internally
    * @param name CString for the name of the resource

--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -1800,6 +1800,7 @@ protected:
   virtual float GetBackingPixelScale() const { return GetScreenScale() * GetDrawScale(); };
 
   IMatrix GetTransformMatrix() const { return mTransform; }
+  void FinishCaptureForTouch(ITouchID touchID, const IMouseInfo* pInfo = nullptr);
 #pragma mark -
 
 private:

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -384,9 +384,6 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
     if (pGraphics->ControlIsCaptured())
       pGraphics->ReleaseMouseCapture();
 
-    if (GetCapture() == hWnd)
-      ReleaseCapture();
-
     return 0;
   }
   case WM_CAPTURECHANGED: {
@@ -1016,6 +1013,12 @@ void IGraphicsWin::GetMouseLocation(float& x, float& y) const
 
   x = p.x / scale;
   y = p.y / scale;
+}
+
+void IGraphicsWin::PlatformReleaseMouseCapture()
+{
+  if (mPlugWnd && GetCapture() == mPlugWnd)
+    ReleaseCapture();
 }
 
 #ifdef IGRAPHICS_GL
@@ -1755,9 +1758,6 @@ void IGraphicsWin::CloseWindow()
   {
     if (ControlIsCaptured())
       ReleaseMouseCapture();
-
-    if (GetCapture() == mPlugWnd)
-      ReleaseCapture();
 
     if (mVSYNCEnabled)
       StopVBlankThread();

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -380,12 +380,24 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
     pGraphics->OnMouseOut();
     return 0;
   }
+  case WM_CAPTURECHANGED: {
+    if (pGraphics->ControlIsCaptured())
+    {
+      const HWND newCapture = reinterpret_cast<HWND>(lParam);
+
+      if (newCapture != hWnd)
+        pGraphics->ReleaseMouseCapture();
+    }
+
+    return 0;
+  }
   case WM_LBUTTONUP:
   case WM_RBUTTONUP: {
-    ReleaseCapture();
     IMouseInfo info = pGraphics->GetMouseInfo(lParam, wParam);
     std::vector<IMouseInfo> list{info};
     pGraphics->OnMouseUp(list);
+    if (GetCapture() == hWnd)
+      ReleaseCapture();
     return 0;
   }
   case WM_LBUTTONDBLCLK:
@@ -1732,6 +1744,9 @@ void IGraphicsWin::CloseWindow()
 {
   if (mPlugWnd)
   {
+    if (ControlIsCaptured())
+      ReleaseMouseCapture();
+
     if (mVSYNCEnabled)
       StopVBlankThread();
     else

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -26,6 +26,7 @@
 
 #include <VersionHelpers.h>
 #include <algorithm>
+#include <cinttypes>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
@@ -308,6 +309,10 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
     }
     SetFocus(hWnd); // Added to get keyboard focus again when user clicks in window
     SetCapture(hWnd);
+#ifndef NDEBUG
+    DBGMSG("IGraphicsWin::WndProc WM_*BUTTONDOWN hwnd=%p osCapture=%p count=%zu\n", hWnd, GetCapture(),
+           pGraphics->GetCaptureCount());
+#endif
     IMouseInfo info = pGraphics->GetMouseInfo(lParam, wParam);
     std::vector<IMouseInfo> list{info};
     pGraphics->OnMouseDown(list);
@@ -381,16 +386,45 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
     return 0;
   }
   case WM_CANCELMODE: {
-    if (pGraphics->ControlIsCaptured() || GetCapture() == hWnd)
+    const HWND osCapture = GetCapture();
+#ifndef NDEBUG
+    DBGMSG("IGraphicsWin::WndProc WM_CANCELMODE hwnd=%p osCapture=%p captured=%d count=%zu\n", hWnd, osCapture,
+           pGraphics->ControlIsCaptured(), pGraphics->GetCaptureCount());
+#endif
+    const bool hadCapture = pGraphics->ControlIsCaptured() || osCapture == hWnd;
+    if (hadCapture)
+    {
+#ifndef NDEBUG
+      DBGMSG("IGraphicsWin::WndProc WM_CANCELMODE calling ReleaseMouseCapture\n");
+#endif
       pGraphics->ReleaseMouseCapture();
+#ifndef NDEBUG
+      DBGMSG("IGraphicsWin::WndProc WM_CANCELMODE done osCapture=%p captured=%d count=%zu\n", GetCapture(),
+             pGraphics->ControlIsCaptured(), pGraphics->GetCaptureCount());
+#endif
+    }
 
     return 0;
   }
   case WM_CAPTURECHANGED: {
     const HWND newCapture = reinterpret_cast<HWND>(lParam);
 
-    if (newCapture != hWnd && (pGraphics->ControlIsCaptured() || GetCapture() == hWnd))
+    const bool hadCapture = (newCapture != hWnd) && (pGraphics->ControlIsCaptured() || GetCapture() == hWnd);
+#ifndef NDEBUG
+    DBGMSG("IGraphicsWin::WndProc WM_CAPTURECHANGED hwnd=%p new=%p osCapture=%p captured=%d count=%zu\n", hWnd, newCapture,
+           GetCapture(), pGraphics->ControlIsCaptured(), pGraphics->GetCaptureCount());
+#endif
+    if (hadCapture)
+    {
+#ifndef NDEBUG
+      DBGMSG("IGraphicsWin::WndProc WM_CAPTURECHANGED calling ReleaseMouseCapture\n");
+#endif
       pGraphics->ReleaseMouseCapture();
+#ifndef NDEBUG
+      DBGMSG("IGraphicsWin::WndProc WM_CAPTURECHANGED done osCapture=%p captured=%d count=%zu\n", GetCapture(),
+             pGraphics->ControlIsCaptured(), pGraphics->GetCaptureCount());
+#endif
+    }
 
     return 0;
   }
@@ -398,9 +432,17 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
   case WM_RBUTTONUP: {
     IMouseInfo info = pGraphics->GetMouseInfo(lParam, wParam);
     std::vector<IMouseInfo> list{info};
+#ifndef NDEBUG
+    DBGMSG("IGraphicsWin::WndProc WM_*BUTTONUP hwnd=%p osCapture=%p captured=%d count=%zu\n", hWnd, GetCapture(),
+           pGraphics->ControlIsCaptured(), pGraphics->GetCaptureCount());
+#endif
     pGraphics->OnMouseUp(list);
     if (GetCapture() == hWnd)
       ReleaseCapture();
+#ifndef NDEBUG
+    DBGMSG("IGraphicsWin::WndProc WM_*BUTTONUP done osCapture=%p captured=%d count=%zu\n", GetCapture(),
+           pGraphics->ControlIsCaptured(), pGraphics->GetCaptureCount());
+#endif
     return 0;
   }
   case WM_LBUTTONDBLCLK:
@@ -1015,7 +1057,33 @@ void IGraphicsWin::GetMouseLocation(float& x, float& y) const
 void IGraphicsWin::PlatformReleaseMouseCapture()
 {
   if (mPlugWnd && GetCapture() == mPlugWnd)
+  {
     ReleaseCapture();
+#ifndef NDEBUG
+    DBGMSG("IGraphicsWin::PlatformReleaseMouseCapture hwnd=%p\n", mPlugWnd);
+#endif
+  }
+}
+
+void IGraphicsWin::PlatformOnCaptureFinished(ITouchID touchID)
+{
+  auto itr = mDeltaCapture.find(touchID);
+
+  if (itr != mDeltaCapture.end())
+  {
+#ifndef NDEBUG
+    DBGMSG("IGraphicsWin::PlatformOnCaptureFinished touch=%" PRIuPTR " removing delta (size before=%zu)\n",
+           static_cast<uintptr_t>(touchID), mDeltaCapture.size());
+#endif
+    mDeltaCapture.erase(itr);
+  }
+#ifndef NDEBUG
+  else
+  {
+    DBGMSG("IGraphicsWin::PlatformOnCaptureFinished touch=%" PRIuPTR " delta missing (size=%zu)\n",
+           static_cast<uintptr_t>(touchID), mDeltaCapture.size());
+  }
+#endif
 }
 
 #ifdef IGRAPHICS_GL

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -380,6 +380,15 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
     pGraphics->OnMouseOut();
     return 0;
   }
+  case WM_CANCELMODE: {
+    if (pGraphics->ControlIsCaptured())
+      pGraphics->ReleaseMouseCapture();
+
+    if (GetCapture() == hWnd)
+      ReleaseCapture();
+
+    return 0;
+  }
   case WM_CAPTURECHANGED: {
     if (pGraphics->ControlIsCaptured())
     {
@@ -1746,6 +1755,9 @@ void IGraphicsWin::CloseWindow()
   {
     if (ControlIsCaptured())
       ReleaseMouseCapture();
+
+    if (GetCapture() == mPlugWnd)
+      ReleaseCapture();
 
     if (mVSYNCEnabled)
       StopVBlankThread();

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -381,19 +381,16 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
     return 0;
   }
   case WM_CANCELMODE: {
-    if (pGraphics->ControlIsCaptured())
+    if (pGraphics->ControlIsCaptured() || GetCapture() == hWnd)
       pGraphics->ReleaseMouseCapture();
 
     return 0;
   }
   case WM_CAPTURECHANGED: {
-    if (pGraphics->ControlIsCaptured())
-    {
-      const HWND newCapture = reinterpret_cast<HWND>(lParam);
+    const HWND newCapture = reinterpret_cast<HWND>(lParam);
 
-      if (newCapture != hWnd)
-        pGraphics->ReleaseMouseCapture();
-    }
+    if (newCapture != hWnd && (pGraphics->ControlIsCaptured() || GetCapture() == hWnd))
+      pGraphics->ReleaseMouseCapture();
 
     return 0;
   }
@@ -1756,7 +1753,7 @@ void IGraphicsWin::CloseWindow()
 {
   if (mPlugWnd)
   {
-    if (ControlIsCaptured())
+    if (ControlIsCaptured() || GetCapture() == mPlugWnd)
       ReleaseMouseCapture();
 
     if (mVSYNCEnabled)

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -308,14 +308,42 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
       return 0;
     }
     SetFocus(hWnd); // Added to get keyboard focus again when user clicks in window
-    SetCapture(hWnd);
-#ifndef NDEBUG
-    DBGMSG("IGraphicsWin::WndProc WM_*BUTTONDOWN hwnd=%p osCapture=%p count=%zu\n", hWnd, GetCapture(),
-           pGraphics->GetCaptureCount());
-#endif
+
     IMouseInfo info = pGraphics->GetMouseInfo(lParam, wParam);
     std::vector<IMouseInfo> list{info};
+
+#ifndef NDEBUG
+    const size_t captureCountBefore = pGraphics->GetCaptureCount();
+#endif
+
     pGraphics->OnMouseDown(list);
+
+    const bool hasCapture = pGraphics->ControlIsCaptured();
+    const bool osHasCapture = GetCapture() == hWnd;
+
+    if (hasCapture && !osHasCapture)
+    {
+      SetCapture(hWnd);
+#ifndef NDEBUG
+      DBGMSG("IGraphicsWin::WndProc WM_*BUTTONDOWN capture hwnd=%p osCapture=%p countBefore=%zu countAfter=%zu\n", hWnd,
+             GetCapture(), captureCountBefore, pGraphics->GetCaptureCount());
+#endif
+    }
+#ifndef NDEBUG
+    else
+    {
+      const char* reason = hasCapture ? "already-held" : "not-requested";
+      DBGMSG("IGraphicsWin::WndProc WM_*BUTTONDOWN no capture hwnd=%p osCapture=%p reason=%s countBefore=%zu countAfter=%zu\n",
+             hWnd, GetCapture(), reason, captureCountBefore, pGraphics->GetCaptureCount());
+    }
+#endif
+    if (!hasCapture && osHasCapture)
+    {
+      ReleaseCapture();
+#ifndef NDEBUG
+      DBGMSG("IGraphicsWin::WndProc WM_*BUTTONDOWN dropped stale capture hwnd=%p osCapture=%p\n", hWnd, GetCapture());
+#endif
+    }
     return 0;
   }
   case WM_SETCURSOR: {

--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -88,6 +88,8 @@ public:
 
   void GetMouseLocation(float& x, float& y) const override;
 
+  void PlatformReleaseMouseCapture() override;
+
   EMsgBoxResult ShowMessageBox(const char* str, const char* title, EMsgBoxType type, IMsgBoxCompletionHandlerFunc completionHandler) override;
 
   void* OpenWindow(void* pParent) override;

--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -89,6 +89,7 @@ public:
   void GetMouseLocation(float& x, float& y) const override;
 
   void PlatformReleaseMouseCapture() override;
+  void PlatformOnCaptureFinished(ITouchID touchID) override;
 
   EMsgBoxResult ShowMessageBox(const char* str, const char* title, EMsgBoxType type, IMsgBoxCompletionHandlerFunc completionHandler) override;
 


### PR DESCRIPTION
## Summary
- add a reusable helper that finishes captured drags so host notifications fire on every release path
- flush captured controls from forced release sites including ReleaseMouseCapture and Win32 capture loss
- handle WM_CAPTURECHANGED, defer ReleaseCapture until after UI handling, and finish captures during Win32 window teardown

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d096ce83608329b6b3bda597c00038