### PR TITLE
Throttle synchronous WM_PAINT dispatch on Windows

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -166,10 +166,7 @@ void IGraphicsWin::OnDisplayTimer(int vBlankCount)
     return; // TODO: check this!
   }
 
-  if (mDeferInvalidation)
-  {
-    return;
-  }
+  const bool deferInvalidation = mDeferInvalidation;
 
   // TODO: move this... listen to the right messages in windows for screen resolution changes, etc.
   if (!GetCapture()) // workaround Windows issues with window sizing during mouse move
@@ -187,6 +184,9 @@ void IGraphicsWin::OnDisplayTimer(int vBlankCount)
   {
     SetAllControlsClean();
 
+    const bool hadPendingPaint = mPaintPending;
+    bool postedInvalidation = false;
+
     for (int i = 0; i < rects.Size(); i++)
     {
       IRECT dirtyR = rects.Get(i);
@@ -194,7 +194,16 @@ void IGraphicsWin::OnDisplayTimer(int vBlankCount)
       dirtyR.PixelAlign();
       RECT r = {(LONG)dirtyR.L, (LONG)dirtyR.T, (LONG)dirtyR.R, (LONG)dirtyR.B};
       InvalidateRect(mPlugWnd, &r, FALSE);
+      postedInvalidation = true;
     }
+
+    if (!postedInvalidation)
+    {
+      return;
+    }
+
+    mPaintPending = true;
+    const bool shouldSynchronouslyUpdate = !deferInvalidation && !hadPendingPaint;
 
     if (mParamEditWnd)
     {
@@ -203,23 +212,29 @@ void IGraphicsWin::OnDisplayTimer(int vBlankCount)
       notDirtyR.PixelAlign();
       RECT r2 = {(LONG)notDirtyR.L, (LONG)notDirtyR.T, (LONG)notDirtyR.R, (LONG)notDirtyR.B};
       ValidateRect(mPlugWnd, &r2); // make sure we dont redraw the edit box area
-      UpdateWindow(mPlugWnd);
-      mParamEditMsg = kUpdate;
+      if (shouldSynchronouslyUpdate)
+      {
+        UpdateWindow(mPlugWnd);
+        mParamEditMsg = kUpdate;
+      }
     }
     else
     {
-      // Force a redraw right now
-      UpdateWindow(mPlugWnd);
-
-      if (mVSYNCEnabled)
+      if (shouldSynchronouslyUpdate)
       {
-        // Check and see if we are still in this frame.
-        curCount = mVBlankCount;
-        if (msgCount != curCount)
+        // Force a redraw right now
+        UpdateWindow(mPlugWnd);
+
+        if (mVSYNCEnabled)
         {
-          // we are late, skip the next vblank to give us a breather.
-          mVBlankSkipUntil = curCount + 1;
-          // DBGMSG("vblank painting was late by %i frames.", (mVBlankSkipUntil - msgCount));
+          // Check and see if we are still in this frame.
+          curCount = mVBlankCount;
+          if (msgCount != curCount)
+          {
+            // we are late, skip the next vblank to give us a breather.
+            mVBlankSkipUntil = curCount + 1;
+            // DBGMSG("vblank painting was late by %i frames.", (mVBlankSkipUntil - msgCount));
+          }
         }
       }
     }
@@ -706,6 +721,8 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
     // we are just going to get another WM_PAINT to handle.  Bad!  It also exibits the odd property
     // that windows will be popped under the window.
     ValidateRect(hWnd, 0);
+
+    pGraphics->mPaintPending = false;
 
     DeleteObject(region);
 

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -184,7 +184,6 @@ void IGraphicsWin::OnDisplayTimer(int vBlankCount)
   {
     SetAllControlsClean();
 
-    const bool hadPendingPaint = mPaintPending;
     bool postedInvalidation = false;
 
     for (int i = 0; i < rects.Size(); i++)
@@ -202,8 +201,11 @@ void IGraphicsWin::OnDisplayTimer(int vBlankCount)
       return;
     }
 
-    mPaintPending = true;
-    const bool shouldSynchronouslyUpdate = !deferInvalidation && !hadPendingPaint;
+    const bool hadQueuedPaint = mPaintPending;
+    const bool paintQueued = GetUpdateRect(mPlugWnd, nullptr, FALSE) != 0;
+    mPaintPending = paintQueued || hadQueuedPaint;
+    const bool hasPendingPaint = postedInvalidation || mPaintPending;
+    const bool shouldSynchronouslyUpdate = !deferInvalidation && !hasPendingPaint;
 
     if (mParamEditWnd)
     {

--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -227,6 +227,7 @@ private:
   int mVBlankSkipUntil = 0;                    // support for skipping vblank notification if the last callback took  too long.  This helps keep the message pump clear in the case of overload.
   bool mVSYNCEnabled = false;
   bool mDeferInvalidation = false;
+  bool mPaintPending = false;
 
   const IParam* mEditParam = nullptr;
   IText mEditText;


### PR DESCRIPTION
## Summary
- add a paint-pending flag so the Windows timer avoids forcing synchronous UpdateWindow calls when a redraw is already queued or deferral is active
- clear the pending flag after WM_PAINT completes so the next timer tick can request another frame

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0ee7c68d48329b09db5a58a9f560c