### PR TITLE
Fix Win32 paint flush when scheduling new invalidation

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -210,16 +210,25 @@ void IGraphicsWin::OnDisplayTimer(int vBlankCount)
       UpdateWindow(mPlugWnd);
       mParamEditMsg = kUpdate;
     }
-    else if (!hadPendingPaint && mVSYNCEnabled)
+    else if (mVSYNCEnabled)
     {
-      // Check and see if we are still in this frame.
-      curCount = mVBlankCount;
-      if (msgCount != curCount)
+      if (!hadPendingPaint)
       {
-        // we are late, skip the next vblank to give us a breather.
-        mVBlankSkipUntil = curCount + 1;
-        // DBGMSG("vblank painting was late by %i frames.", (mVBlankSkipUntil - msgCount));
+        // Check and see if we are still in this frame.
+        curCount = mVBlankCount;
+        if (msgCount != curCount)
+        {
+          // we are late, skip the next vblank to give us a breather.
+          mVBlankSkipUntil = curCount + 1;
+          // DBGMSG("vblank painting was late by %i frames.", (mVBlankSkipUntil - msgCount));
+        }
+
+        UpdateWindow(mPlugWnd);
       }
+    }
+    else if (!hadPendingPaint)
+    {
+      UpdateWindow(mPlugWnd);
     }
   }
   return;


### PR DESCRIPTION
## Summary
- immediately flush the first pending WM_PAINT on Win32 when no paint was already queued
- keep the existing vsync skip logic while ensuring the synchronous UpdateWindow runs once per new invalidation

## Testing
- not run (Windows-only behaviour)

------
https://chatgpt.com/codex/tasks/task_e_68d204fa3a6483299620482589c4786d