### PR TITLE
Fix Vulkan teardown order on Windows

### DIFF
--- a/IGraphics/Platforms/WinVulkanDeviceCoordinator.h
+++ b/IGraphics/Platforms/WinVulkanDeviceCoordinator.h
@@ -157,14 +157,14 @@ inline void WinVulkanDeviceCoordinator::Teardown()
   mInitialized = false;
   ResetSnapshot();
 
-  if (device != VK_NULL_HANDLE)
-  {
-    vkDestroyDevice(device, nullptr);
-  }
-
   if (surface != VK_NULL_HANDLE && instance != VK_NULL_HANDLE)
   {
     vkDestroySurfaceKHR(instance, surface, nullptr);
+  }
+
+  if (device != VK_NULL_HANDLE)
+  {
+    vkDestroyDevice(device, nullptr);
   }
 
   if (instance != VK_NULL_HANDLE)


### PR DESCRIPTION
## Summary
- destroy the Vulkan surface before the device in WinVulkanDeviceCoordinator::Teardown to avoid freeing resources out of order

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d22d1214ec83298095a09957906af7