### PR TITLE
Harden Win Vulkan teardown with generation tracking

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1253,14 +1253,15 @@ bool IGraphicsWin::CreateVulkanContext()
 #endif
 
   WinVulkanDeviceSnapshot snapshot{};
-  VkResult res = mVulkanDeviceCoordinator.Initialize(request, snapshot);
+  uint64_t generation = 0;
+  VkResult res = mVulkanDeviceCoordinator.Initialize(request, snapshot, generation);
   if (res != VK_SUCCESS)
   {
     IGRAPHICS_VK_LOG("CreateVulkanContext",
                         "deviceCoordinator",
                         vulkanlog::Severity::kError,
                         vulkanlog::MakeField("vkResult", static_cast<int>(res)));
-    mVulkanDeviceCoordinator.Teardown();
+    mVulkanDeviceCoordinator.Teardown(generation);
     return false;
   }
 
@@ -1270,6 +1271,7 @@ bool IGraphicsWin::CreateVulkanContext()
   mVkSurface = snapshot.surface;
   mPresentQueue = snapshot.presentQueue;
   mVkQueueFamily = snapshot.queueFamily;
+  mVulkanDeviceGeneration = generation;
 
   VkSurfaceCapabilitiesKHR caps{};
   res = vkGetPhysicalDeviceSurfaceCapabilitiesKHR(mVkPhysicalDevice, mVkSurface, &caps);
@@ -1353,7 +1355,7 @@ void IGraphicsWin::DestroyVulkanContext()
   mVkFormat = VK_FORMAT_B8G8R8A8_UNORM;
   mVkSwapchainUsageFlags = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
 
-  mVulkanDeviceCoordinator.Teardown();
+  mVulkanDeviceCoordinator.Teardown(mVulkanDeviceGeneration);
 
   mVkInstance = VK_NULL_HANDLE;
   mVkPhysicalDevice = VK_NULL_HANDLE;
@@ -1362,6 +1364,7 @@ void IGraphicsWin::DestroyVulkanContext()
   mPresentQueue = VK_NULL_HANDLE;
   mVkQueueFamily = 0;
   mVkSwapchain.device = VK_NULL_HANDLE;
+  mVulkanDeviceGeneration = 0;
 }
 
 bool IGraphicsWin::RecreateVulkanContext()

--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -22,6 +22,7 @@
 
 #include <string>
 #include <vector>
+#include <cstdint>
 
 #ifdef IGRAPHICS_VULKAN
   #define VK_USE_PLATFORM_WIN32_KHR
@@ -182,6 +183,7 @@ private:
   void ActivateVulkanContext();
   void DeactivateVulkanContext();
   WinVulkanDeviceCoordinator mVulkanDeviceCoordinator;
+  uint64_t mVulkanDeviceGeneration = 0;
   VkInstance mVkInstance = VK_NULL_HANDLE;
   VkPhysicalDevice mVkPhysicalDevice = VK_NULL_HANDLE;
   VkDevice mVkDevice = VK_NULL_HANDLE;

--- a/IGraphics/Platforms/WinVulkanDeviceCoordinator.h
+++ b/IGraphics/Platforms/WinVulkanDeviceCoordinator.h
@@ -45,6 +45,7 @@ struct WinVulkanDeviceSnapshot
   VkQueue presentQueue = VK_NULL_HANDLE;
   uint32_t queueFamily = 0;
   bool validationLayerEnabled = false;
+  uint64_t generation = 0;
 };
 
 class WinVulkanDeviceCoordinator
@@ -56,8 +57,8 @@ public:
   WinVulkanDeviceCoordinator(const WinVulkanDeviceCoordinator&) = delete;
   WinVulkanDeviceCoordinator& operator=(const WinVulkanDeviceCoordinator&) = delete;
 
-  VkResult Initialize(const WinVulkanDeviceRequest& request, WinVulkanDeviceSnapshot& outSnapshot);
-  void Teardown();
+  VkResult Initialize(const WinVulkanDeviceRequest& request, WinVulkanDeviceSnapshot& outSnapshot, uint64_t& outGeneration);
+  void Teardown(uint64_t generation = 0);
   bool IsInitialized() const { return mInitialized; }
   const WinVulkanDeviceSnapshot& Snapshot() const { return mSnapshot; }
 
@@ -70,6 +71,8 @@ private:
 
   bool mInitialized = false;
   WinVulkanDeviceSnapshot mSnapshot{};
+  uint64_t mGenerationCounter = 0;
+  uint64_t mSnapshotGeneration = 0;
 };
 
 namespace winvk
@@ -84,15 +87,20 @@ inline WinVulkanDeviceCoordinator::~WinVulkanDeviceCoordinator()
   Teardown();
 }
 
-inline VkResult WinVulkanDeviceCoordinator::Initialize(const WinVulkanDeviceRequest& request, WinVulkanDeviceSnapshot& outSnapshot)
+inline VkResult WinVulkanDeviceCoordinator::Initialize(const WinVulkanDeviceRequest& request,
+                                                       WinVulkanDeviceSnapshot& outSnapshot,
+                                                       uint64_t& outGeneration)
 {
   if (mInitialized)
   {
     outSnapshot = mSnapshot;
+    outGeneration = mSnapshotGeneration;
     return VK_SUCCESS;
   }
 
   ResetSnapshot();
+  mSnapshotGeneration = 0;
+  outGeneration = 0;
 
   VkResult res = CreateInstance(request);
   if (res != VK_SUCCESS)
@@ -139,12 +147,20 @@ inline VkResult WinVulkanDeviceCoordinator::Initialize(const WinVulkanDeviceRequ
   }
 
   mInitialized = true;
+  mSnapshotGeneration = ++mGenerationCounter;
+  mSnapshot.generation = mSnapshotGeneration;
   outSnapshot = mSnapshot;
+  outGeneration = mSnapshotGeneration;
   return VK_SUCCESS;
 }
 
-inline void WinVulkanDeviceCoordinator::Teardown()
+inline void WinVulkanDeviceCoordinator::Teardown(uint64_t generation)
 {
+  if (generation != 0 && generation != mSnapshotGeneration)
+  {
+    return;
+  }
+
   if (!mInitialized && mSnapshot.instance == VK_NULL_HANDLE && mSnapshot.device == VK_NULL_HANDLE)
   {
     return;
@@ -155,16 +171,17 @@ inline void WinVulkanDeviceCoordinator::Teardown()
   const VkDevice device = mSnapshot.device;
 
   mInitialized = false;
+  mSnapshotGeneration = 0;
   ResetSnapshot();
-
-  if (device != VK_NULL_HANDLE)
-  {
-    vkDestroyDevice(device, nullptr);
-  }
 
   if (surface != VK_NULL_HANDLE && instance != VK_NULL_HANDLE)
   {
     vkDestroySurfaceKHR(instance, surface, nullptr);
+  }
+
+  if (device != VK_NULL_HANDLE)
+  {
+    vkDestroyDevice(device, nullptr);
   }
 
   if (instance != VK_NULL_HANDLE)
@@ -394,6 +411,7 @@ inline void WinVulkanDeviceCoordinator::ResetSnapshot()
   mSnapshot.presentQueue = VK_NULL_HANDLE;
   mSnapshot.queueFamily = 0;
   mSnapshot.validationLayerEnabled = false;
+  mSnapshot.generation = 0;
 }
 
 END_IGRAPHICS_NAMESPACE


### PR DESCRIPTION
## Summary
- add generation tracking to WinVulkanDeviceCoordinator snapshots so stale teardowns are ignored
- store the returned generation in IGraphicsWin and only tear down when it still owns the live device handles

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d22d6fc21c8329b422a4d6c625a22c