### PR TITLE
Fix Win Vulkan device teardown ref counting

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1355,7 +1355,14 @@ void IGraphicsWin::DestroyVulkanContext()
   mVkFormat = VK_FORMAT_B8G8R8A8_UNORM;
   mVkSwapchainUsageFlags = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
 
-  mVulkanDeviceCoordinator.Teardown(mVulkanDeviceGeneration);
+  if (mVulkanDeviceGeneration != 0)
+  {
+    mVulkanDeviceCoordinator.Teardown(mVulkanDeviceGeneration);
+  }
+  else if (mVkInstance || mVkDevice)
+  {
+    mVulkanDeviceCoordinator.Teardown();
+  }
 
   mVkInstance = VK_NULL_HANDLE;
   mVkPhysicalDevice = VK_NULL_HANDLE;

--- a/IGraphics/Platforms/WinVulkanDeviceCoordinator.h
+++ b/IGraphics/Platforms/WinVulkanDeviceCoordinator.h
@@ -51,7 +51,7 @@ struct WinVulkanDeviceSnapshot
 class WinVulkanDeviceCoordinator
 {
 public:
-  WinVulkanDeviceCoordinator() = default;
+  WinVulkanDeviceCoordinator();
   ~WinVulkanDeviceCoordinator();
 
   WinVulkanDeviceCoordinator(const WinVulkanDeviceCoordinator&) = delete;
@@ -59,21 +59,30 @@ public:
 
   VkResult Initialize(const WinVulkanDeviceRequest& request, WinVulkanDeviceSnapshot& outSnapshot, uint64_t& outGeneration);
   void Teardown(uint64_t generation = 0);
-  bool IsInitialized() const { return mInitialized; }
-  const WinVulkanDeviceSnapshot& Snapshot() const { return mSnapshot; }
+  bool IsInitialized() const { return mState->initialized; }
+  const WinVulkanDeviceSnapshot& Snapshot() const { return mState->snapshot; }
 
 private:
+  struct SharedState
+  {
+    bool initialized = false;
+    WinVulkanDeviceSnapshot snapshot{};
+    uint64_t generationCounter = 0;
+    uint64_t snapshotGeneration = 0;
+    uint32_t activeClients = 0;
+  };
+
+  static SharedState& Shared();
+
   VkResult CreateInstance(const WinVulkanDeviceRequest& request);
   VkResult CreateSurface(const WinVulkanDeviceRequest& request);
   VkResult SelectPhysicalDevice(const WinVulkanDeviceRequest& request);
   VkResult CreateLogicalDevice();
   void ResetSnapshot();
 
-  bool mInitialized = false;
-  WinVulkanDeviceSnapshot mSnapshot{};
-  uint64_t mGenerationCounter = 0;
-  uint64_t mSnapshotGeneration = 0;
-  uint32_t mActiveClients = 0;
+  SharedState* mState = nullptr;
+  bool mClientRegistered = false;
+  uint64_t mClientGeneration = 0;
 };
 
 namespace winvk
@@ -83,27 +92,45 @@ static const std::array<const char*, 2> kRequiredInstanceExtensions{{"VK_KHR_sur
 static const std::array<const char*, 1> kRequiredDeviceExtensions{{VK_KHR_SWAPCHAIN_EXTENSION_NAME}};
 }
 
+inline WinVulkanDeviceCoordinator::SharedState& WinVulkanDeviceCoordinator::Shared()
+{
+  static SharedState state{};
+  return state;
+}
+
+inline WinVulkanDeviceCoordinator::WinVulkanDeviceCoordinator()
+  : mState(&Shared())
+{
+}
+
 inline WinVulkanDeviceCoordinator::~WinVulkanDeviceCoordinator()
 {
-  Teardown();
+  if (mClientRegistered)
+  {
+    Teardown(mClientGeneration);
+  }
 }
 
 inline VkResult WinVulkanDeviceCoordinator::Initialize(const WinVulkanDeviceRequest& request,
                                                        WinVulkanDeviceSnapshot& outSnapshot,
                                                        uint64_t& outGeneration)
 {
-  if (mInitialized)
+  SharedState& state = *mState;
+
+  if (state.initialized)
   {
-    ++mActiveClients;
-    outSnapshot = mSnapshot;
-    outGeneration = mSnapshotGeneration;
+    ++state.activeClients;
+    outSnapshot = state.snapshot;
+    outGeneration = state.snapshotGeneration;
+    mClientRegistered = true;
+    mClientGeneration = outGeneration;
     return VK_SUCCESS;
   }
 
   ResetSnapshot();
-  mSnapshotGeneration = 0;
+  state.snapshotGeneration = 0;
   outGeneration = 0;
-  mActiveClients = 0;
+  state.activeClients = 0;
 
   VkResult res = CreateInstance(request);
   if (res != VK_SUCCESS)
@@ -149,48 +176,66 @@ inline VkResult WinVulkanDeviceCoordinator::Initialize(const WinVulkanDeviceRequ
     return res;
   }
 
-  mInitialized = true;
-  mSnapshotGeneration = ++mGenerationCounter;
-  mSnapshot.generation = mSnapshotGeneration;
-  outSnapshot = mSnapshot;
-  outGeneration = mSnapshotGeneration;
-  mActiveClients = 1;
+  state.initialized = true;
+  state.snapshotGeneration = ++state.generationCounter;
+  state.snapshot.generation = state.snapshotGeneration;
+  outSnapshot = state.snapshot;
+  outGeneration = state.snapshotGeneration;
+  state.activeClients = 1;
+  mClientRegistered = true;
+  mClientGeneration = outGeneration;
   return VK_SUCCESS;
 }
 
 inline void WinVulkanDeviceCoordinator::Teardown(uint64_t generation)
 {
-  if (generation != 0 && generation != mSnapshotGeneration)
+  SharedState& state = *mState;
+
+  if (generation != 0 && generation != state.snapshotGeneration)
   {
     return;
   }
 
-  if (!mInitialized && mSnapshot.instance == VK_NULL_HANDLE && mSnapshot.device == VK_NULL_HANDLE)
+  if (!state.initialized && state.snapshot.instance == VK_NULL_HANDLE && state.snapshot.device == VK_NULL_HANDLE)
   {
     return;
   }
 
   if (generation == 0)
   {
-    mActiveClients = 0;
+    if (state.activeClients > 0)
+    {
+      return;
+    }
+    mClientRegistered = false;
+    mClientGeneration = 0;
   }
-  else if (mActiveClients > 0)
+  else
   {
-    --mActiveClients;
+    if (state.activeClients > 0)
+    {
+      --state.activeClients;
+    }
+
+    if (mClientRegistered && mClientGeneration == generation)
+    {
+      mClientRegistered = false;
+      mClientGeneration = 0;
+    }
   }
 
-  if (mActiveClients > 0)
+  if (state.activeClients > 0)
   {
     return;
   }
 
-  const VkInstance instance = mSnapshot.instance;
-  const VkSurfaceKHR surface = mSnapshot.surface;
-  const VkDevice device = mSnapshot.device;
+  const VkInstance instance = state.snapshot.instance;
+  const VkSurfaceKHR surface = state.snapshot.surface;
+  const VkDevice device = state.snapshot.device;
 
-  mInitialized = false;
-  mSnapshotGeneration = 0;
-  mActiveClients = 0;
+  state.initialized = false;
+  state.snapshotGeneration = 0;
+  state.activeClients = 0;
   ResetSnapshot();
 
   if (surface != VK_NULL_HANDLE && instance != VK_NULL_HANDLE)
@@ -211,6 +256,7 @@ inline void WinVulkanDeviceCoordinator::Teardown(uint64_t generation)
 
 inline VkResult WinVulkanDeviceCoordinator::CreateInstance(const WinVulkanDeviceRequest& request)
 {
+  SharedState& state = *mState;
   VkApplicationInfo appInfo{};
   appInfo.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
   appInfo.pApplicationName = "iPlug2";
@@ -247,16 +293,16 @@ inline VkResult WinVulkanDeviceCoordinator::CreateInstance(const WinVulkanDevice
   {
     instanceInfo.enabledLayerCount = 1;
     instanceInfo.ppEnabledLayerNames = &winvk::kValidationLayerName;
-    mSnapshot.validationLayerEnabled = true;
+    state.snapshot.validationLayerEnabled = true;
   }
   else
   {
     instanceInfo.enabledLayerCount = 0;
     instanceInfo.ppEnabledLayerNames = nullptr;
-    mSnapshot.validationLayerEnabled = false;
+    state.snapshot.validationLayerEnabled = false;
   }
 
-  return vkCreateInstance(&instanceInfo, nullptr, &mSnapshot.instance);
+  return vkCreateInstance(&instanceInfo, nullptr, &state.snapshot.instance);
 }
 
 inline VkResult WinVulkanDeviceCoordinator::CreateSurface(const WinVulkanDeviceRequest& request)
@@ -265,20 +311,21 @@ inline VkResult WinVulkanDeviceCoordinator::CreateSurface(const WinVulkanDeviceR
   surfaceInfo.sType = VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR;
   surfaceInfo.hinstance = request.instanceHandle;
   surfaceInfo.hwnd = request.windowHandle;
-  return vkCreateWin32SurfaceKHR(mSnapshot.instance, &surfaceInfo, nullptr, &mSnapshot.surface);
+  return vkCreateWin32SurfaceKHR(mState->snapshot.instance, &surfaceInfo, nullptr, &mState->snapshot.surface);
 }
 
 inline VkResult WinVulkanDeviceCoordinator::SelectPhysicalDevice(const WinVulkanDeviceRequest& request)
 {
+  SharedState& state = *mState;
   uint32_t gpuCount = 0;
-  VkResult res = vkEnumeratePhysicalDevices(mSnapshot.instance, &gpuCount, nullptr);
+  VkResult res = vkEnumeratePhysicalDevices(state.snapshot.instance, &gpuCount, nullptr);
   if (res != VK_SUCCESS || gpuCount == 0)
   {
     return (gpuCount == 0) ? VK_ERROR_INITIALIZATION_FAILED : res;
   }
 
   std::vector<VkPhysicalDevice> devices(gpuCount);
-  res = vkEnumeratePhysicalDevices(mSnapshot.instance, &gpuCount, devices.data());
+  res = vkEnumeratePhysicalDevices(state.snapshot.instance, &gpuCount, devices.data());
   if (res != VK_SUCCESS)
   {
     return res;
@@ -314,7 +361,7 @@ inline VkResult WinVulkanDeviceCoordinator::SelectPhysicalDevice(const WinVulkan
     for (uint32_t i = 0; i < queueCount; ++i)
     {
       VkBool32 presentSupport = VK_FALSE;
-      if (vkGetPhysicalDeviceSurfaceSupportKHR(device, i, mSnapshot.surface, &presentSupport) == VK_SUCCESS &&
+      if (vkGetPhysicalDeviceSurfaceSupportKHR(device, i, state.snapshot.surface, &presentSupport) == VK_SUCCESS &&
           (queues[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) && presentSupport)
       {
         queueIndex = i;
@@ -363,20 +410,22 @@ inline VkResult WinVulkanDeviceCoordinator::SelectPhysicalDevice(const WinVulkan
     return VK_ERROR_INITIALIZATION_FAILED;
   }
 
-  mSnapshot.physicalDevice = selectedDevice;
-  mSnapshot.queueFamily = selectedQueueFamily;
+  state.snapshot.physicalDevice = selectedDevice;
+  state.snapshot.queueFamily = selectedQueueFamily;
   return VK_SUCCESS;
 }
 
 inline VkResult WinVulkanDeviceCoordinator::CreateLogicalDevice()
 {
-  if (mSnapshot.physicalDevice == VK_NULL_HANDLE)
+  SharedState& state = *mState;
+
+  if (state.snapshot.physicalDevice == VK_NULL_HANDLE)
   {
     return VK_ERROR_INITIALIZATION_FAILED;
   }
 
   VkPhysicalDeviceFeatures supportedFeatures;
-  vkGetPhysicalDeviceFeatures(mSnapshot.physicalDevice, &supportedFeatures);
+  vkGetPhysicalDeviceFeatures(state.snapshot.physicalDevice, &supportedFeatures);
 
   VkPhysicalDeviceFeatures enabledFeatures{};
   enabledFeatures.samplerAnisotropy = supportedFeatures.samplerAnisotropy;
@@ -386,7 +435,7 @@ inline VkResult WinVulkanDeviceCoordinator::CreateLogicalDevice()
   float queuePriority = 1.f;
   VkDeviceQueueCreateInfo queueInfo{};
   queueInfo.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
-  queueInfo.queueFamilyIndex = mSnapshot.queueFamily;
+  queueInfo.queueFamilyIndex = state.snapshot.queueFamily;
   queueInfo.queueCount = 1;
   queueInfo.pQueuePriorities = &queuePriority;
 
@@ -399,7 +448,7 @@ inline VkResult WinVulkanDeviceCoordinator::CreateLogicalDevice()
   deviceInfo.pEnabledFeatures = &enabledFeatures;
 
 #if !defined(NDEBUG)
-  if (mSnapshot.validationLayerEnabled)
+  if (state.snapshot.validationLayerEnabled)
   {
     deviceInfo.enabledLayerCount = 1;
     deviceInfo.ppEnabledLayerNames = &winvk::kValidationLayerName;
@@ -411,26 +460,27 @@ inline VkResult WinVulkanDeviceCoordinator::CreateLogicalDevice()
     deviceInfo.ppEnabledLayerNames = nullptr;
   }
 
-  VkResult res = vkCreateDevice(mSnapshot.physicalDevice, &deviceInfo, nullptr, &mSnapshot.device);
+  VkResult res = vkCreateDevice(state.snapshot.physicalDevice, &deviceInfo, nullptr, &state.snapshot.device);
   if (res != VK_SUCCESS)
   {
     return res;
   }
 
-  vkGetDeviceQueue(mSnapshot.device, mSnapshot.queueFamily, 0, &mSnapshot.presentQueue);
+  vkGetDeviceQueue(state.snapshot.device, state.snapshot.queueFamily, 0, &state.snapshot.presentQueue);
   return VK_SUCCESS;
 }
 
 inline void WinVulkanDeviceCoordinator::ResetSnapshot()
 {
-  mSnapshot.instance = VK_NULL_HANDLE;
-  mSnapshot.physicalDevice = VK_NULL_HANDLE;
-  mSnapshot.device = VK_NULL_HANDLE;
-  mSnapshot.surface = VK_NULL_HANDLE;
-  mSnapshot.presentQueue = VK_NULL_HANDLE;
-  mSnapshot.queueFamily = 0;
-  mSnapshot.validationLayerEnabled = false;
-  mSnapshot.generation = 0;
+  WinVulkanDeviceSnapshot& snapshot = mState->snapshot;
+  snapshot.instance = VK_NULL_HANDLE;
+  snapshot.physicalDevice = VK_NULL_HANDLE;
+  snapshot.device = VK_NULL_HANDLE;
+  snapshot.surface = VK_NULL_HANDLE;
+  snapshot.presentQueue = VK_NULL_HANDLE;
+  snapshot.queueFamily = 0;
+  snapshot.validationLayerEnabled = false;
+  snapshot.generation = 0;
 }
 
 END_IGRAPHICS_NAMESPACE

--- a/IGraphics/Platforms/WinVulkanDeviceCoordinator.h
+++ b/IGraphics/Platforms/WinVulkanDeviceCoordinator.h
@@ -75,14 +75,15 @@ private:
   static SharedState& Shared();
 
   VkResult CreateInstance(const WinVulkanDeviceRequest& request);
-  VkResult CreateSurface(const WinVulkanDeviceRequest& request);
-  VkResult SelectPhysicalDevice(const WinVulkanDeviceRequest& request);
+  VkResult CreateSurface(const WinVulkanDeviceRequest& request, VkSurfaceKHR& outSurface);
+  VkResult SelectPhysicalDevice(const WinVulkanDeviceRequest& request, VkSurfaceKHR surface);
   VkResult CreateLogicalDevice();
   void ResetSnapshot();
 
   SharedState* mState = nullptr;
   bool mClientRegistered = false;
   uint64_t mClientGeneration = 0;
+  VkSurfaceKHR mClientSurface = VK_NULL_HANDLE;
 };
 
 namespace winvk
@@ -105,9 +106,9 @@ inline WinVulkanDeviceCoordinator::WinVulkanDeviceCoordinator()
 
 inline WinVulkanDeviceCoordinator::~WinVulkanDeviceCoordinator()
 {
-  if (mClientRegistered)
+  if (mClientRegistered || mClientSurface != VK_NULL_HANDLE)
   {
-    Teardown(mClientGeneration);
+    Teardown(mClientRegistered ? mClientGeneration : 0);
   }
 }
 
@@ -117,13 +118,44 @@ inline VkResult WinVulkanDeviceCoordinator::Initialize(const WinVulkanDeviceRequ
 {
   SharedState& state = *mState;
 
+  VkSurfaceKHR surface = VK_NULL_HANDLE;
+
   if (state.initialized)
   {
+    VkResult res = CreateSurface(request, surface);
+    if (res != VK_SUCCESS)
+    {
+      IGRAPHICS_VK_LOG("WinVulkanDeviceCoordinator.Initialize",
+                       "vkCreateWin32SurfaceKHR",
+                       vulkanlog::Severity::kError,
+                       vulkanlog::MakeField("vkResult", static_cast<int>(res)));
+      return res;
+    }
+
+    VkBool32 presentSupport = VK_FALSE;
+    res = vkGetPhysicalDeviceSurfaceSupportKHR(state.snapshot.physicalDevice,
+                                               state.snapshot.queueFamily,
+                                               surface,
+                                               &presentSupport);
+    if (res != VK_SUCCESS || presentSupport != VK_TRUE)
+    {
+      if (res == VK_SUCCESS)
+        res = VK_ERROR_INITIALIZATION_FAILED;
+      vkDestroySurfaceKHR(state.snapshot.instance, surface, nullptr);
+      IGRAPHICS_VK_LOG("WinVulkanDeviceCoordinator.Initialize",
+                       "vkGetPhysicalDeviceSurfaceSupportKHR",
+                       vulkanlog::Severity::kError,
+                       vulkanlog::MakeField("vkResult", static_cast<int>(res)));
+      return res;
+    }
+
     ++state.activeClients;
     outSnapshot = state.snapshot;
+    outSnapshot.surface = surface;
     outGeneration = state.snapshotGeneration;
     mClientRegistered = true;
     mClientGeneration = outGeneration;
+    mClientSurface = surface;
     return VK_SUCCESS;
   }
 
@@ -131,6 +163,7 @@ inline VkResult WinVulkanDeviceCoordinator::Initialize(const WinVulkanDeviceRequ
   state.snapshotGeneration = 0;
   outGeneration = 0;
   state.activeClients = 0;
+  mClientSurface = VK_NULL_HANDLE;
 
   VkResult res = CreateInstance(request);
   if (res != VK_SUCCESS)
@@ -143,7 +176,7 @@ inline VkResult WinVulkanDeviceCoordinator::Initialize(const WinVulkanDeviceRequ
     return res;
   }
 
-  res = CreateSurface(request);
+  res = CreateSurface(request, surface);
   if (res != VK_SUCCESS)
   {
     IGRAPHICS_VK_LOG("WinVulkanDeviceCoordinator.Initialize",
@@ -154,13 +187,14 @@ inline VkResult WinVulkanDeviceCoordinator::Initialize(const WinVulkanDeviceRequ
     return res;
   }
 
-  res = SelectPhysicalDevice(request);
+  res = SelectPhysicalDevice(request, surface);
   if (res != VK_SUCCESS)
   {
     IGRAPHICS_VK_LOG("WinVulkanDeviceCoordinator.Initialize",
                         "selectPhysicalDevice",
                         vulkanlog::Severity::kError,
                         vulkanlog::MakeField("vkResult", static_cast<int>(res)));
+    vkDestroySurfaceKHR(state.snapshot.instance, surface, nullptr);
     Teardown();
     return res;
   }
@@ -172,6 +206,7 @@ inline VkResult WinVulkanDeviceCoordinator::Initialize(const WinVulkanDeviceRequ
                         "vkCreateDevice",
                         vulkanlog::Severity::kError,
                         vulkanlog::MakeField("vkResult", static_cast<int>(res)));
+    vkDestroySurfaceKHR(state.snapshot.instance, surface, nullptr);
     Teardown();
     return res;
   }
@@ -180,10 +215,12 @@ inline VkResult WinVulkanDeviceCoordinator::Initialize(const WinVulkanDeviceRequ
   state.snapshotGeneration = ++state.generationCounter;
   state.snapshot.generation = state.snapshotGeneration;
   outSnapshot = state.snapshot;
+  outSnapshot.surface = surface;
   outGeneration = state.snapshotGeneration;
   state.activeClients = 1;
   mClientRegistered = true;
   mClientGeneration = outGeneration;
+  mClientSurface = surface;
   return VK_SUCCESS;
 }
 
@@ -191,38 +228,68 @@ inline void WinVulkanDeviceCoordinator::Teardown(uint64_t generation)
 {
   SharedState& state = *mState;
 
-  if (generation != 0 && generation != state.snapshotGeneration)
+  if (generation != 0 && mClientRegistered && generation != mClientGeneration)
   {
     return;
   }
 
-  if (!state.initialized && state.snapshot.instance == VK_NULL_HANDLE && state.snapshot.device == VK_NULL_HANDLE)
+  VkSurfaceKHR clientSurface = mClientSurface;
+  if (clientSurface != VK_NULL_HANDLE && state.snapshot.instance != VK_NULL_HANDLE)
   {
-    return;
+    vkDestroySurfaceKHR(state.snapshot.instance, clientSurface, nullptr);
   }
+  mClientSurface = VK_NULL_HANDLE;
 
   if (generation == 0)
   {
+    if (mClientRegistered)
+    {
+      if (state.activeClients > 0)
+      {
+        --state.activeClients;
+      }
+      mClientRegistered = false;
+      mClientGeneration = 0;
+    }
+
     if (state.activeClients > 0)
     {
       return;
     }
-    mClientRegistered = false;
-    mClientGeneration = 0;
-  }
-  else
-  {
-    if (state.activeClients > 0)
+
+    const VkInstance instance = state.snapshot.instance;
+    const VkDevice device = state.snapshot.device;
+
+    state.initialized = false;
+    state.snapshotGeneration = 0;
+    state.activeClients = 0;
+    ResetSnapshot();
+
+    if (device != VK_NULL_HANDLE)
     {
-      --state.activeClients;
+      vkDestroyDevice(device, nullptr);
     }
 
-    if (mClientRegistered && mClientGeneration == generation)
+    if (instance != VK_NULL_HANDLE)
     {
-      mClientRegistered = false;
-      mClientGeneration = 0;
+      vkDestroyInstance(instance, nullptr);
     }
+
+    return;
   }
+
+  if (!mClientRegistered || generation != mClientGeneration)
+  {
+    return;
+  }
+
+  if (state.activeClients > 0)
+  {
+    --state.activeClients;
+  }
+
+  mClientRegistered = false;
+  mClientGeneration = 0;
 
   if (state.activeClients > 0)
   {
@@ -230,18 +297,12 @@ inline void WinVulkanDeviceCoordinator::Teardown(uint64_t generation)
   }
 
   const VkInstance instance = state.snapshot.instance;
-  const VkSurfaceKHR surface = state.snapshot.surface;
   const VkDevice device = state.snapshot.device;
 
   state.initialized = false;
   state.snapshotGeneration = 0;
   state.activeClients = 0;
   ResetSnapshot();
-
-  if (surface != VK_NULL_HANDLE && instance != VK_NULL_HANDLE)
-  {
-    vkDestroySurfaceKHR(instance, surface, nullptr);
-  }
 
   if (device != VK_NULL_HANDLE)
   {
@@ -305,16 +366,16 @@ inline VkResult WinVulkanDeviceCoordinator::CreateInstance(const WinVulkanDevice
   return vkCreateInstance(&instanceInfo, nullptr, &state.snapshot.instance);
 }
 
-inline VkResult WinVulkanDeviceCoordinator::CreateSurface(const WinVulkanDeviceRequest& request)
+inline VkResult WinVulkanDeviceCoordinator::CreateSurface(const WinVulkanDeviceRequest& request, VkSurfaceKHR& outSurface)
 {
   VkWin32SurfaceCreateInfoKHR surfaceInfo{};
   surfaceInfo.sType = VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR;
   surfaceInfo.hinstance = request.instanceHandle;
   surfaceInfo.hwnd = request.windowHandle;
-  return vkCreateWin32SurfaceKHR(mState->snapshot.instance, &surfaceInfo, nullptr, &mState->snapshot.surface);
+  return vkCreateWin32SurfaceKHR(mState->snapshot.instance, &surfaceInfo, nullptr, &outSurface);
 }
 
-inline VkResult WinVulkanDeviceCoordinator::SelectPhysicalDevice(const WinVulkanDeviceRequest& request)
+inline VkResult WinVulkanDeviceCoordinator::SelectPhysicalDevice(const WinVulkanDeviceRequest& request, VkSurfaceKHR surface)
 {
   SharedState& state = *mState;
   uint32_t gpuCount = 0;
@@ -361,7 +422,7 @@ inline VkResult WinVulkanDeviceCoordinator::SelectPhysicalDevice(const WinVulkan
     for (uint32_t i = 0; i < queueCount; ++i)
     {
       VkBool32 presentSupport = VK_FALSE;
-      if (vkGetPhysicalDeviceSurfaceSupportKHR(device, i, state.snapshot.surface, &presentSupport) == VK_SUCCESS &&
+      if (vkGetPhysicalDeviceSurfaceSupportKHR(device, i, surface, &presentSupport) == VK_SUCCESS &&
           (queues[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) && presentSupport)
       {
         queueIndex = i;

--- a/IGraphics/Platforms/WinVulkanDeviceCoordinator.h
+++ b/IGraphics/Platforms/WinVulkanDeviceCoordinator.h
@@ -73,6 +73,7 @@ private:
   WinVulkanDeviceSnapshot mSnapshot{};
   uint64_t mGenerationCounter = 0;
   uint64_t mSnapshotGeneration = 0;
+  uint32_t mActiveClients = 0;
 };
 
 namespace winvk
@@ -93,6 +94,7 @@ inline VkResult WinVulkanDeviceCoordinator::Initialize(const WinVulkanDeviceRequ
 {
   if (mInitialized)
   {
+    ++mActiveClients;
     outSnapshot = mSnapshot;
     outGeneration = mSnapshotGeneration;
     return VK_SUCCESS;
@@ -101,6 +103,7 @@ inline VkResult WinVulkanDeviceCoordinator::Initialize(const WinVulkanDeviceRequ
   ResetSnapshot();
   mSnapshotGeneration = 0;
   outGeneration = 0;
+  mActiveClients = 0;
 
   VkResult res = CreateInstance(request);
   if (res != VK_SUCCESS)
@@ -151,6 +154,7 @@ inline VkResult WinVulkanDeviceCoordinator::Initialize(const WinVulkanDeviceRequ
   mSnapshot.generation = mSnapshotGeneration;
   outSnapshot = mSnapshot;
   outGeneration = mSnapshotGeneration;
+  mActiveClients = 1;
   return VK_SUCCESS;
 }
 
@@ -166,12 +170,27 @@ inline void WinVulkanDeviceCoordinator::Teardown(uint64_t generation)
     return;
   }
 
+  if (generation == 0)
+  {
+    mActiveClients = 0;
+  }
+  else if (mActiveClients > 0)
+  {
+    --mActiveClients;
+  }
+
+  if (mActiveClients > 0)
+  {
+    return;
+  }
+
   const VkInstance instance = mSnapshot.instance;
   const VkSurfaceKHR surface = mSnapshot.surface;
   const VkDevice device = mSnapshot.device;
 
   mInitialized = false;
   mSnapshotGeneration = 0;
+  mActiveClients = 0;
   ResetSnapshot();
 
   if (surface != VK_NULL_HANDLE && instance != VK_NULL_HANDLE)


### PR DESCRIPTION
## Summary
- track active clients in WinVulkanDeviceCoordinator so the shared Vulkan instance/device stay alive until the last editor releases them
- guard DestroyVulkanContext against forcing a teardown when no generation is recorded, preventing premature destruction of shared resources

## Testing
- not run (Windows-specific)


------
https://chatgpt.com/codex/tasks/task_e_68d23d3f92b88329a7d8ff2c328dcfdf