### PR TITLE
Fix Windows VBlank handler to catch up to newest frame

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -128,18 +128,32 @@ void IGraphicsWin::OnDisplayTimer(int vBlankCount)
 
   if (mVSYNCEnabled)
   {
+    const bool hasVBlankMessage = msgCount != 0;
+
+    if (hasVBlankMessage)
+    {
+      msgCount = std::max<DWORD>(msgCount, mQueuedVBlank.load(std::memory_order_relaxed));
+    }
+
     // skip until the actual vblank is at a certain number.
     if (mVBlankSkipUntil != 0 && mVBlankSkipUntil > curCount)
     {
+      if (hasVBlankMessage)
+      {
+        mLastProcessedVBlank = std::max<DWORD>(mLastProcessedVBlank, msgCount);
+        mVBlankMessagePending.store(false, std::memory_order_release);
+      }
       return;
     }
 
     mVBlankSkipUntil = 0;
 
-    if (msgCount != 0)
+    if (hasVBlankMessage)
     {
       if (msgCount <= mLastProcessedVBlank)
       {
+        mLastProcessedVBlank = std::max<DWORD>(mLastProcessedVBlank, msgCount);
+        mVBlankMessagePending.store(false, std::memory_order_release);
         return;
       }
 
@@ -160,7 +174,8 @@ void IGraphicsWin::OnDisplayTimer(int vBlankCount)
         msgCount = curCount;
       }
 
-      mLastProcessedVBlank = msgCount ? msgCount : curCount;
+      mLastProcessedVBlank = msgCount;
+      mVBlankMessagePending.store(false, std::memory_order_release);
     }
     else
     {
@@ -2874,6 +2889,8 @@ void IGraphicsWin::StartVBlankThread(HWND hWnd)
 {
   mVBlankWindow = hWnd;
   mVBlankShutdown = false;
+  mVBlankMessagePending.store(false, std::memory_order_relaxed);
+  mQueuedVBlank.store(0, std::memory_order_relaxed);
   mPendingSyncVBlank.store(0, std::memory_order_relaxed);
   mLastProcessedVBlank = 0;
   DWORD threadId = 0;
@@ -3059,35 +3076,45 @@ void IGraphicsWin::VBlankNotify()
   }
 
   const DWORD latestCount = ++mVBlankCount;
+  mQueuedVBlank.store(latestCount, std::memory_order_relaxed);
 
-  if (::PostMessageW(mVBlankWindow, WM_VBLANK, latestCount, 0))
+  if (mVBlankMessagePending.exchange(true, std::memory_order_acq_rel))
+  {
+    return;
+  }
+
+  DWORD dispatchCount = mQueuedVBlank.load(std::memory_order_relaxed);
+
+  if (::PostMessageW(mVBlankWindow, WM_VBLANK, dispatchCount, 0))
   {
     mPendingSyncVBlank.store(0, std::memory_order_relaxed);
     return;
   }
 
   const DWORD postError = GetLastError();
-  DWORD coalescedCount = latestCount;
+  DWORD coalescedCount = dispatchCount;
 
   if (postError == ERROR_NOT_ENOUGH_QUOTA)
   {
     // Windows drops WM_VBLANK posts when the message queue is saturated. Remember the freshest
     // tick so the synchronous path paints the newest frame once the UI thread catches up.
     DWORD observed = mPendingSyncVBlank.load(std::memory_order_relaxed);
-    while (observed < latestCount
-           && !mPendingSyncVBlank.compare_exchange_weak(observed, latestCount, std::memory_order_relaxed,
+    while (observed < dispatchCount
+           && !mPendingSyncVBlank.compare_exchange_weak(observed, dispatchCount, std::memory_order_relaxed,
                                                         std::memory_order_relaxed))
     {
     }
 
-    coalescedCount = mPendingSyncVBlank.load(std::memory_order_relaxed);
+    const DWORD pendingSyncCount = mPendingSyncVBlank.load(std::memory_order_relaxed);
+    coalescedCount = std::max<DWORD>(pendingSyncCount, mQueuedVBlank.load(std::memory_order_relaxed));
     DBGMSG("IGraphicsWin::VBlankNotify PostMessageW queue full, sending WM_VBLANK synchronously (count=%lu, coalesced=%lu)\n",
            static_cast<unsigned long>(latestCount), static_cast<unsigned long>(coalescedCount));
   }
   else
   {
+    coalescedCount = std::max<DWORD>(coalescedCount, mQueuedVBlank.load(std::memory_order_relaxed));
     DBGMSG("IGraphicsWin::VBlankNotify PostMessageW failed (error=%lu), sending WM_VBLANK synchronously (count=%lu)\n",
-           static_cast<unsigned long>(postError), static_cast<unsigned long>(latestCount));
+           static_cast<unsigned long>(postError), static_cast<unsigned long>(coalescedCount));
   }
 
   ::SendMessageW(mVBlankWindow, WM_VBLANK, coalescedCount, 0);

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -123,25 +123,53 @@ void IGraphicsWin::DestroyEditWindow()
 void IGraphicsWin::OnDisplayTimer(int vBlankCount)
 {
   // Check the message vblank with the current one to see if we are way behind. If so, then throw these away.
-  DWORD msgCount = vBlankCount;
+  DWORD msgCount = static_cast<DWORD>(vBlankCount);
   DWORD curCount = mVBlankCount;
 
   if (mVSYNCEnabled)
   {
     // skip until the actual vblank is at a certain number.
-    if (mVBlankSkipUntil != 0 && mVBlankSkipUntil > mVBlankCount)
+    if (mVBlankSkipUntil != 0 && mVBlankSkipUntil > curCount)
     {
       return;
     }
 
     mVBlankSkipUntil = 0;
 
-    if (msgCount != curCount)
+    if (msgCount != 0)
     {
-      // we are late, just skip it until we can get a message soon after the vblank event.
-      // DBGMSG("vblank is late by %i frames.  Skipping.", (mVBlankCount - msgCount));
-      return;
+      if (msgCount <= mLastProcessedVBlank)
+      {
+        return;
+      }
+
+      MSG msg;
+      while (PeekMessageW(&msg, mPlugWnd, WM_VBLANK, WM_VBLANK, PM_REMOVE))
+      {
+        const DWORD latest = static_cast<DWORD>(msg.wParam);
+        if (latest > msgCount)
+        {
+          msgCount = latest;
+        }
+      }
+
+      curCount = mVBlankCount;
+
+      if (msgCount > curCount)
+      {
+        msgCount = curCount;
+      }
+
+      mLastProcessedVBlank = msgCount ? msgCount : curCount;
     }
+    else
+    {
+      mLastProcessedVBlank = curCount;
+    }
+  }
+  else if (msgCount == 0)
+  {
+    mLastProcessedVBlank = curCount;
   }
 
   if (mParamEditWnd && mParamEditMsg != kNone)
@@ -2846,6 +2874,7 @@ void IGraphicsWin::StartVBlankThread(HWND hWnd)
 {
   mVBlankWindow = hWnd;
   mVBlankShutdown = false;
+  mLastProcessedVBlank = 0;
   DWORD threadId = 0;
   mVBlankThread = ::CreateThread(NULL, 0, VBlankRun, this, 0, &threadId);
 }

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -130,9 +130,31 @@ void IGraphicsWin::OnDisplayTimer(int vBlankCount)
   {
     const bool hasVBlankMessage = msgCount != 0;
 
+    auto drainVBlankMessages = [&](DWORD count) {
+      DWORD newest = std::max<DWORD>(count, mQueuedVBlank.load(std::memory_order_relaxed));
+      MSG msg;
+      while (PeekMessageW(&msg, mPlugWnd, WM_VBLANK, WM_VBLANK, PM_REMOVE))
+      {
+        const DWORD observed = static_cast<DWORD>(msg.wParam);
+        if (observed > newest)
+        {
+          newest = observed;
+        }
+      }
+
+      curCount = mVBlankCount;
+
+      if (newest > curCount)
+      {
+        newest = curCount;
+      }
+
+      return newest;
+    };
+
     if (hasVBlankMessage)
     {
-      msgCount = std::max<DWORD>(msgCount, mQueuedVBlank.load(std::memory_order_relaxed));
+      msgCount = drainVBlankMessages(msgCount);
     }
 
     // skip until the actual vblank is at a certain number.
@@ -155,23 +177,6 @@ void IGraphicsWin::OnDisplayTimer(int vBlankCount)
         mLastProcessedVBlank = std::max<DWORD>(mLastProcessedVBlank, msgCount);
         mVBlankMessagePending.store(false, std::memory_order_release);
         return;
-      }
-
-      MSG msg;
-      while (PeekMessageW(&msg, mPlugWnd, WM_VBLANK, WM_VBLANK, PM_REMOVE))
-      {
-        const DWORD latest = static_cast<DWORD>(msg.wParam);
-        if (latest > msgCount)
-        {
-          msgCount = latest;
-        }
-      }
-
-      curCount = mVBlankCount;
-
-      if (msgCount > curCount)
-      {
-        msgCount = curCount;
       }
 
       mLastProcessedVBlank = msgCount;

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -2874,6 +2874,7 @@ void IGraphicsWin::StartVBlankThread(HWND hWnd)
 {
   mVBlankWindow = hWnd;
   mVBlankShutdown = false;
+  mPendingSyncVBlank.store(0, std::memory_order_relaxed);
   mLastProcessedVBlank = 0;
   DWORD threadId = 0;
   mVBlankThread = ::CreateThread(NULL, 0, VBlankRun, this, 0, &threadId);
@@ -3052,8 +3053,46 @@ DWORD IGraphicsWin::OnVBlankRun()
 
 void IGraphicsWin::VBlankNotify()
 {
-  mVBlankCount++;
-  ::PostMessageW(mVBlankWindow, WM_VBLANK, mVBlankCount, 0);
+  if (!mVBlankWindow)
+  {
+    return;
+  }
+
+  const DWORD latestCount = ++mVBlankCount;
+
+  if (::PostMessageW(mVBlankWindow, WM_VBLANK, latestCount, 0))
+  {
+    mPendingSyncVBlank.store(0, std::memory_order_relaxed);
+    return;
+  }
+
+  const DWORD postError = GetLastError();
+  DWORD coalescedCount = latestCount;
+
+  if (postError == ERROR_NOT_ENOUGH_QUOTA)
+  {
+    // Windows drops WM_VBLANK posts when the message queue is saturated. Remember the freshest
+    // tick so the synchronous path paints the newest frame once the UI thread catches up.
+    DWORD observed = mPendingSyncVBlank.load(std::memory_order_relaxed);
+    while (observed < latestCount
+           && !mPendingSyncVBlank.compare_exchange_weak(observed, latestCount, std::memory_order_relaxed,
+                                                        std::memory_order_relaxed))
+    {
+    }
+
+    coalescedCount = mPendingSyncVBlank.load(std::memory_order_relaxed);
+    DBGMSG("IGraphicsWin::VBlankNotify PostMessageW queue full, sending WM_VBLANK synchronously (count=%lu, coalesced=%lu)\n",
+           static_cast<unsigned long>(latestCount), static_cast<unsigned long>(coalescedCount));
+  }
+  else
+  {
+    DBGMSG("IGraphicsWin::VBlankNotify PostMessageW failed (error=%lu), sending WM_VBLANK synchronously (count=%lu)\n",
+           static_cast<unsigned long>(postError), static_cast<unsigned long>(latestCount));
+  }
+
+  ::SendMessageW(mVBlankWindow, WM_VBLANK, coalescedCount, 0);
+
+  mPendingSyncVBlank.store(0, std::memory_order_relaxed);
 }
 
 #ifndef NO_IGRAPHICS

--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -227,6 +227,8 @@ private:
   volatile bool mVBlankShutdown = false;       // Flag to indiciate that the vsync thread should shutdown
   HANDLE mVBlankThread = INVALID_HANDLE_VALUE; // ID of thread.
   volatile DWORD mVBlankCount = 0;             // running count of vblank events since the start of the window.
+  std::atomic<bool> mVBlankMessagePending{false}; // true while a WM_VBLANK message is outstanding on the UI queue
+  std::atomic<DWORD> mQueuedVBlank{0};         // newest vblank counter queued for delivery to the UI thread
   std::atomic<DWORD> mPendingSyncVBlank{0};    // newest tick awaiting a synchronous WM_VBLANK send when PostMessageW fails
   DWORD mLastProcessedVBlank = 0;              // last WM_VBLANK tick serviced by the UI thread
   int mVBlankSkipUntil = 0;                    // support for skipping vblank notification if the last callback took  too long.  This helps keep the message pump clear in the case of overload.

--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -226,6 +226,7 @@ private:
   volatile bool mVBlankShutdown = false;       // Flag to indiciate that the vsync thread should shutdown
   HANDLE mVBlankThread = INVALID_HANDLE_VALUE; // ID of thread.
   volatile DWORD mVBlankCount = 0;             // running count of vblank events since the start of the window.
+  DWORD mLastProcessedVBlank = 0;              // last WM_VBLANK tick serviced by the UI thread
   int mVBlankSkipUntil = 0;                    // support for skipping vblank notification if the last callback took  too long.  This helps keep the message pump clear in the case of overload.
   bool mVSYNCEnabled = false;
   bool mDeferInvalidation = false;

--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -23,6 +23,7 @@
 #include <string>
 #include <vector>
 #include <cstdint>
+#include <atomic>
 
 #ifdef IGRAPHICS_VULKAN
   #define VK_USE_PLATFORM_WIN32_KHR
@@ -226,6 +227,7 @@ private:
   volatile bool mVBlankShutdown = false;       // Flag to indiciate that the vsync thread should shutdown
   HANDLE mVBlankThread = INVALID_HANDLE_VALUE; // ID of thread.
   volatile DWORD mVBlankCount = 0;             // running count of vblank events since the start of the window.
+  std::atomic<DWORD> mPendingSyncVBlank{0};    // newest tick awaiting a synchronous WM_VBLANK send when PostMessageW fails
   DWORD mLastProcessedVBlank = 0;              // last WM_VBLANK tick serviced by the UI thread
   int mVBlankSkipUntil = 0;                    // support for skipping vblank notification if the last callback took  too long.  This helps keep the message pump clear in the case of overload.
   bool mVSYNCEnabled = false;


### PR DESCRIPTION
## Summary
- teach OnDisplayTimer() to drain queued WM_VBLANK messages and remember the latest serviced tick
- add bookkeeping for the last processed VBlank counter and reset it when the VSYNC thread starts

## Testing
- not run (Windows-specific logic)


------
https://chatgpt.com/codex/tasks/task_e_68d25d26dc808329b4589678a7a42eb7