### PR TITLE
Handle NanoVG layer allocation failures

### DIFF
--- a/IGraphics/Drawing/IGraphicsNanoVG.cpp
+++ b/IGraphics/Drawing/IGraphicsNanoVG.cpp
@@ -66,6 +66,7 @@
 
 #include <string>
 #include <map>
+#include <memory>
 
 using namespace iplug;
 using namespace igraphics;
@@ -105,9 +106,12 @@ IGraphicsNanoVG::Bitmap::Bitmap(IGraphicsNanoVG* pGraphics, NVGcontext* pContext
   mGraphics = pGraphics;
   mVG = pContext;
   mFBO = nvgCreateFramebuffer(pContext, width, height, 0);
-  
+
+  if (!mFBO)
+    return;
+
   nvgBindFramebuffer(mFBO);
-  
+
 #ifdef IGRAPHICS_METAL
   mnvgClearWithColor(mVG, nvgRGBAf(0, 0, 0, 0));
 #else
@@ -134,7 +138,7 @@ IGraphicsNanoVG::Bitmap::~Bitmap()
   {
     if(mFBO)
       mGraphics->DeleteFBO(mFBO);
-    else
+    else if(GetBitmap())
       nvgDeleteImage(mVG, GetBitmap());
   }
 }
@@ -371,20 +375,25 @@ APIBitmap* IGraphicsNanoVG::LoadAPIBitmap(const char* name, const void* pData, i
 
 APIBitmap* IGraphicsNanoVG::CreateAPIBitmap(int width, int height, float scale, double drawScale, bool cacheable, int MSAASampleCount/*placeholder: only implemented for skia*/)
 {
-  if (mInDraw)
+  const bool wasDrawing = mInDraw;
+
+  if (wasDrawing)
   {
     nvgEndFrame(mVG);
   }
-  
-  APIBitmap* pAPIBitmap = new Bitmap(this, mVG, width, height, scale, drawScale);
 
-  if (mInDraw)
+  std::unique_ptr<Bitmap> bitmap(new Bitmap(this, mVG, width, height, scale, drawScale));
+
+  if (wasDrawing)
   {
     nvgBindFramebuffer(mMainFrameBuffer); // begin main frame buffer update
     nvgBeginFrame(mVG, WindowWidth(), WindowHeight(), GetScreenScale());
   }
-  
-  return pAPIBitmap;
+
+  if (!bitmap->GetBitmap())
+    return nullptr;
+
+  return bitmap.release();
 }
 
 void IGraphicsNanoVG::GetLayerBitmapData(const ILayerPtr& layer, RawBitmapData& data)
@@ -762,9 +771,14 @@ bool IGraphicsNanoVG::LoadAPIFont(const char* fontID, const PlatformFontPtr& fon
 
 void IGraphicsNanoVG::UpdateLayer()
 {
-  if (mLayers.empty())
+  nvgEndFrame(mVG);
+
+  const bool hasLayer = !mLayers.empty();
+  const ILayer* pLayer = hasLayer ? mLayers.top() : nullptr;
+  const APIBitmap* pBitmap = pLayer ? pLayer->GetAPIBitmap() : nullptr;
+
+  if (!hasLayer || !pBitmap)
   {
-    nvgEndFrame(mVG);
 #ifdef IGRAPHICS_GL
     glViewport(0, 0, WindowWidth() * GetScreenScale(), WindowHeight() * GetScreenScale());
 #endif
@@ -773,12 +787,11 @@ void IGraphicsNanoVG::UpdateLayer()
   }
   else
   {
-    nvgEndFrame(mVG);
 #ifdef IGRAPHICS_GL
     const double scale = GetBackingPixelScale();
     glViewport(0, 0, mLayers.top()->Bounds().W() * scale, mLayers.top()->Bounds().H() * scale);
 #endif
-    nvgBindFramebuffer(dynamic_cast<const Bitmap*>(mLayers.top()->GetAPIBitmap())->GetFBO());
+    nvgBindFramebuffer(dynamic_cast<const Bitmap*>(pBitmap)->GetFBO());
     nvgBeginFrame(mVG, mLayers.top()->Bounds().W() * GetDrawScale(), mLayers.top()->Bounds().H() * GetDrawScale(), GetScreenScale());
   }
 }

--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -2650,7 +2650,13 @@ APIBitmap* IGraphicsSkia::CreateAPIBitmap(int width, int height, float scale, do
   return new Bitmap(std::move(surface), width, height, scale, drawScale);
 }
 
-void IGraphicsSkia::UpdateLayer() { mCanvas = mLayers.empty() ? mSurface->getCanvas() : mLayers.top()->GetAPIBitmap()->GetBitmap()->mSurface->getCanvas(); }
+void IGraphicsSkia::UpdateLayer()
+{
+  if (mLayers.empty() || !mLayers.top()->GetAPIBitmap())
+    mCanvas = mSurface->getCanvas();
+  else
+    mCanvas = mLayers.top()->GetAPIBitmap()->GetBitmap()->mSurface->getCanvas();
+}
 
 static size_t CalcRowBytes(int width)
 {

--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -2089,7 +2089,8 @@ void IGraphics::StartLayer(IControl* pControl, const IRECT& r, bool cacheable, i
   const int w = static_cast<int>(std::ceil(pixelBackingScale * std::ceil(alignedBounds.W())));
   const int h = static_cast<int>(std::ceil(pixelBackingScale * std::ceil(alignedBounds.H())));
 
-  PushLayer(new ILayer(CreateAPIBitmap(w, h, GetScreenScale(), GetDrawScale(), cacheable, MSAASampleCount), alignedBounds, pControl, pControl ? pControl->GetRECT() : IRECT()));
+  APIBitmap* pBitmap = CreateAPIBitmap(w, h, GetScreenScale(), GetDrawScale(), cacheable, MSAASampleCount);
+  PushLayer(new ILayer(pBitmap, alignedBounds, pControl, pControl ? pControl->GetRECT() : IRECT()));
 }
 
 void IGraphics::ResumeLayer(ILayerPtr& layer)
@@ -2152,6 +2153,9 @@ bool IGraphics::CheckLayer(const ILayerPtr& layer)
 
 void IGraphics::DrawLayer(const ILayerPtr& layer, const IBlend* pBlend)
 {
+  if (!layer || !layer->GetAPIBitmap())
+    return;
+
   PathTransformSave();
   PathTransformReset();
   DrawBitmap(layer->GetBitmap(), layer->Bounds(), 0, 0, pBlend);
@@ -2160,6 +2164,9 @@ void IGraphics::DrawLayer(const ILayerPtr& layer, const IBlend* pBlend)
 
 void IGraphics::DrawFittedLayer(const ILayerPtr& layer, const IRECT& bounds, const IBlend* pBlend)
 {
+  if (!layer || !layer->GetAPIBitmap())
+    return;
+
   IBitmap bitmap = layer->GetBitmap();
   IRECT layerBounds = layer->Bounds();
   PathTransformSave();
@@ -2172,6 +2179,9 @@ void IGraphics::DrawFittedLayer(const ILayerPtr& layer, const IRECT& bounds, con
 
 void IGraphics::DrawRotatedLayer(const ILayerPtr& layer, double angle)
 {
+  if (!layer || !layer->GetAPIBitmap())
+    return;
+
   PathTransformSave();
   PathTransformReset();
   IBitmap bitmap = layer->GetBitmap();


### PR DESCRIPTION
## Summary
- handle NanoVG framebuffer allocation failures by avoiding invalid layer bitmaps and keeping the main framebuffer bound
- guard layer drawing helpers so controls skip rendering when no backing bitmap is available
- make the Skia and NanoVG layer update paths tolerate missing API bitmaps so the main canvas continues to render

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d3d7fe41148329a0e42944a5d3008b