### PR TITLE
Fix cached Skia font registration across instances

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -2245,7 +2245,15 @@ bool IGraphicsSkia::LoadAPIFont(const char* fontID, const PlatformFontPtr& font)
   Font* cached = storage.Find(fontID);
 
   if (cached)
+  {
+#if !defined IGRAPHICS_NO_SKIA_SKPARAGRAPH
+    if (mTypefaceProvider && cached->mTypeface)
+    {
+      mTypefaceProvider->registerTypeface(cached->mTypeface, cached->mFamily);
+    }
+#endif
     return true;
+  }
 
   IFontDataPtr data = font->GetFontData();
 


### PR DESCRIPTION
## Summary
- re-register cached Skia fonts with the instance TypefaceFontProvider when a cached font is reused

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6c299a87c832983b27caefbbcccdf