### PR TITLE
Fix Vulkan swapchain extent handling on Windows

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -2734,52 +2734,78 @@ void IGraphicsSkia::SetClipRegion(const IRECT& r)
 
 APIBitmap* IGraphicsSkia::CreateAPIBitmap(int width, int height, float scale, double drawScale, bool cacheable, int MSAASampleCount)
 {
+  const int clampedWidth = std::max(1, width);
+  const int clampedHeight = std::max(1, height);
+
   sk_sp<SkSurface> surface;
-  SkImageInfo info = SkImageInfo::MakeN32Premul(width, height);
+  SkImageInfo info = SkImageInfo::MakeN32Premul(clampedWidth, clampedHeight);
 
 #ifndef IGRAPHICS_CPU
-  if (cacheable)
+  if (!mGrContext)
+  {
+    surface = SkSurfaces::Raster(info);
+  }
+  else if (cacheable)
   {
     surface = SkSurfaces::Raster(info);
   }
   else
   {
-    bool supported = (MSAASampleCount != 0) && (mGrContext->maxSurfaceSampleCountForColorType(info.colorType()) >= MSAASampleCount);
+    const bool supportsMSAA = (MSAASampleCount > 0) &&
+                              (mGrContext->maxSurfaceSampleCountForColorType(info.colorType()) >= MSAASampleCount);
 
-    if (supported)
+    if (supportsMSAA)
     {
-      // SkDebugf("IGraphicsSkia: MSAA x4 reported as supported. Attempting new RenderTarget.\n");
       SkSurfaceProps surfaceProps(0, kUnknown_SkPixelGeometry);
       surface = SkSurfaces::RenderTarget(mGrContext.get(), skgpu::Budgeted::kNo, info, MSAASampleCount, kTopLeft_GrSurfaceOrigin, &surfaceProps);
 
-      if (!surface) // Budgeted MSAA
+      if (!surface)
       {
         surface = SkSurfaces::RenderTarget(mGrContext.get(), skgpu::Budgeted::kYes, info, MSAASampleCount, kTopLeft_GrSurfaceOrigin, &surfaceProps);
       }
 
-      if (!surface) // <-- DEFAULT ORIGINAL DRAWING, THIS DOES NOT FAIL
+      if (!surface)
       {
         surface = SkSurfaces::RenderTarget(mGrContext.get(), skgpu::Budgeted::kYes, info);
-      }
-
-      if (!surface) // If all GPU attempts (MSAA and non-MSAA) failed
-      {
-        surface = SkSurfaces::Raster(info);
       }
     }
     else
     {
-      // SkDebugf("IGraphicsSkia: MSAA x4 reported as NOT supported. Attempting original RenderTarget.\n");
       surface = SkSurfaces::RenderTarget(mGrContext.get(), skgpu::Budgeted::kYes, info);
+    }
+
+    if (!surface)
+    {
+#if defined IGRAPHICS_VULKAN
+      IGRAPHICS_VK_LOG("CreateAPIBitmap",
+                          "gpuSurfaceFallback",
+                          vulkanlog::Severity::kWarning,
+                          vulkanlog::MakeField("width", clampedWidth),
+                          vulkanlog::MakeField("height", clampedHeight),
+                          vulkanlog::MakeField("msaa", MSAASampleCount));
+#endif
+      surface = SkSurfaces::Raster(info);
     }
   }
 #else
   surface = SkSurfaces::Raster(info);
 #endif
 
+  if (!surface)
+  {
+#if defined IGRAPHICS_VULKAN
+    IGRAPHICS_VK_LOG("CreateAPIBitmap",
+                        "surfaceAllocationFailed",
+                        vulkanlog::Severity::kError,
+                        vulkanlog::MakeField("width", clampedWidth),
+                        vulkanlog::MakeField("height", clampedHeight));
+#endif
+    return nullptr;
+  }
+
   surface->getCanvas()->save();
 
-  return new Bitmap(std::move(surface), width, height, scale, drawScale);
+  return new Bitmap(std::move(surface), clampedWidth, clampedHeight, scale, drawScale);
 }
 
 void IGraphicsSkia::UpdateLayer() { mCanvas = mLayers.empty() ? mSurface->getCanvas() : mLayers.top()->GetAPIBitmap()->GetBitmap()->mSurface->getCanvas(); }

--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -1315,6 +1315,7 @@ void IGraphicsSkia::DrawResize()
         std::vector<VkImage> images;
         VkFormat format = mVKSwapchainFormat;
         VkExtent2D swapchainExtent = mVKSwapchainExtent;
+        bool swapchainSuboptimal = false;
         IGRAPHICS_VK_LOG("DrawResize",
                             "requestSwapchainResize",
                             vulkanlog::Severity::kInfo,
@@ -1322,9 +1323,23 @@ void IGraphicsSkia::DrawResize()
                              vulkanlog::MakeField("height", h),
                              vulkanlog::MakeField("frameVersion", static_cast<uint64_t>(mVKFrameVersion)),
                              vulkanlog::MakeField("swapchainVersion", static_cast<uint64_t>(mVKSwapchainVersion)));
-        VkResult res = pWin->CreateOrResizeVulkanSwapchain(w, h, swapchain, images, format, mVKSwapchainUsageFlags, mVKSubmissionPending, swapchainExtent);
+        VkResult res = pWin->CreateOrResizeVulkanSwapchain(w,
+                                                           h,
+                                                           swapchain,
+                                                           images,
+                                                           format,
+                                                           mVKSwapchainUsageFlags,
+                                                           mVKSubmissionPending,
+                                                           swapchainExtent,
+                                                           swapchainSuboptimal);
         if (res == VK_SUCCESS)
         {
+          if (swapchainSuboptimal)
+          {
+            IGRAPHICS_VK_LOG_SIMPLE("DrawResize",
+                                "swapchainSuboptimal",
+                                vulkanlog::Severity::kInfo);
+          }
           mVKSwapchain = swapchain;
           mVKSwapchainImages = images;
           mVKSwapchainSurfaces.assign(mVKSwapchainImages.size(), nullptr);

--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -1169,6 +1169,11 @@ void IGraphicsSkia::DrawResize()
   ScopedGraphicsContext scopedGLContext{this};
   auto w = static_cast<int>(std::ceil(static_cast<float>(WindowWidth()) * GetScreenScale()));
   auto h = static_cast<int>(std::ceil(static_cast<float>(WindowHeight()) * GetScreenScale()));
+  const int previousSurfaceWidth = mSurface ? mSurface->width() : 0;
+  const int previousSurfaceHeight = mSurface ? mSurface->height() : 0;
+#if defined IGRAPHICS_VULKAN
+  const VkExtent2D previousSwapchainExtent = mVKSwapchainExtent;
+#endif
 #if defined IGRAPHICS_VULKAN
   IGRAPHICS_VK_LOG("DrawResize",
                       "begin",
@@ -1331,6 +1336,7 @@ void IGraphicsSkia::DrawResize()
                              vulkanlog::MakeField("height", h),
                              vulkanlog::MakeField("frameVersion", static_cast<uint64_t>(mVKFrameVersion)),
                              vulkanlog::MakeField("swapchainVersion", static_cast<uint64_t>(mVKSwapchainVersion)));
+        bool swapchainCreated = false;
         VkResult res = pWin->CreateOrResizeVulkanSwapchain(w,
                                                            h,
                                                            swapchain,
@@ -1348,26 +1354,29 @@ void IGraphicsSkia::DrawResize()
                                 "swapchainSuboptimal",
                                 vulkanlog::Severity::kInfo);
           }
-          mVKSwapchain = swapchain;
-          mVKSwapchainImages = images;
-          mVKSwapchainSurfaces.assign(mVKSwapchainImages.size(), nullptr);
-          mVKImageLayouts.assign(mVKSwapchainImages.size(), VK_IMAGE_LAYOUT_UNDEFINED);
-          mVKSwapchainFormat = format;
-          mVKSwapchainExtent = swapchainExtent;
-          if (swapchainExtent.width > 0 && swapchainExtent.height > 0)
+          if (!images.empty())
           {
-            surfaceWidth = static_cast<int>(swapchainExtent.width);
-            surfaceHeight = static_cast<int>(swapchainExtent.height);
-          }
-          mVKCurrentImage = kInvalidImageIndex;
-          mVKSkipFrame = true;
+            swapchainCreated = true;
+            mVKSwapchain = swapchain;
+            mVKSwapchainImages = images;
+            mVKSwapchainSurfaces.assign(mVKSwapchainImages.size(), nullptr);
+            mVKImageLayouts.assign(mVKSwapchainImages.size(), VK_IMAGE_LAYOUT_UNDEFINED);
+            mVKSwapchainFormat = format;
+            mVKSwapchainExtent = swapchainExtent;
+            if (swapchainExtent.width > 0 && swapchainExtent.height > 0)
+            {
+              surfaceWidth = static_cast<int>(swapchainExtent.width);
+              surfaceHeight = static_cast<int>(swapchainExtent.height);
+            }
+            mVKCurrentImage = kInvalidImageIndex;
+            mVKSkipFrame = true;
       #ifndef NDEBUG
-          IGRAPHICS_VK_LOG("DrawResize",
-                              "swapchainCreated",
-                              vulkanlog::Severity::kDebug,
-                              vulkanlog::MakeField("swapchainVersion", static_cast<uint64_t>(mVKSwapchainVersion)),
-                               vulkanlog::MakeField("imageCount", static_cast<uint64_t>(mVKSwapchainImages.size())));
-          PFN_vkSetDebugUtilsObjectNameEXT setName = reinterpret_cast<PFN_vkSetDebugUtilsObjectNameEXT>(vkGetDeviceProcAddr(mVKDevice, "vkSetDebugUtilsObjectNameEXT"));
+            IGRAPHICS_VK_LOG("DrawResize",
+                                "swapchainCreated",
+                                vulkanlog::Severity::kDebug,
+                                vulkanlog::MakeField("swapchainVersion", static_cast<uint64_t>(mVKSwapchainVersion)),
+                                 vulkanlog::MakeField("imageCount", static_cast<uint64_t>(mVKSwapchainImages.size())));
+            PFN_vkSetDebugUtilsObjectNameEXT setName = reinterpret_cast<PFN_vkSetDebugUtilsObjectNameEXT>(vkGetDeviceProcAddr(mVKDevice, "vkSetDebugUtilsObjectNameEXT"));
       #endif
       for (size_t i = 0; i < mVKSwapchainImages.size(); ++i)
       {
@@ -1392,16 +1401,12 @@ void IGraphicsSkia::DrawResize()
         }
   #endif
       }
-          if (mVKSwapchainImages.empty())
+          }
+          else
           {
             IGRAPHICS_VK_LOG_SIMPLE("DrawResize",
                                 "createOrResizeEmpty",
                                 vulkanlog::Severity::kError);
-            mVKSwapchain = VK_NULL_HANDLE;
-            ResetVulkanSwapchainCaches();
-            mSurface.reset();
-            mCanvas = nullptr;
-            return;
           }
         }
         else
@@ -1413,24 +1418,56 @@ void IGraphicsSkia::DrawResize()
           vkWaitForFences(mVKDevice, 1, &mVKInFlightFence, VK_TRUE, UINT64_MAX);
           vkResetFences(mVKDevice, 1, &mVKInFlightFence);
           vkQueueSubmit(mVKQueue, 0, nullptr, mVKInFlightFence); // ensure fence signalled
+        }
+        if (!swapchainCreated)
+        {
           mVKSwapchain = VK_NULL_HANDLE;
           mVKSwapchainImages.clear();
           mVKCurrentImage = kInvalidImageIndex;
-          mSurface.reset();
           ResetVulkanSwapchainCaches();
-          mCanvas = nullptr;
+          mVKSwapchainExtent = {0, 0};
+          surfaceWidth = previousSurfaceWidth > 0 ? previousSurfaceWidth : surfaceWidth;
+          surfaceHeight = previousSurfaceHeight > 0 ? previousSurfaceHeight : surfaceHeight;
           mVKSkipFrame = true;
-          return;
         }
       }
     #endif
     }
   #endif
+    if (surfaceWidth <= 0 || surfaceHeight <= 0)
+    {
+#if defined IGRAPHICS_VULKAN
+      if (previousSwapchainExtent.width > 0 && previousSwapchainExtent.height > 0)
+      {
+        surfaceWidth = static_cast<int>(previousSwapchainExtent.width);
+        surfaceHeight = static_cast<int>(previousSwapchainExtent.height);
+      }
+#endif
+    }
+    if (surfaceWidth <= 0 || surfaceHeight <= 0)
+    {
+      surfaceWidth = std::max(1, previousSurfaceWidth > 0 ? previousSurfaceWidth : w);
+      surfaceHeight = std::max(1, previousSurfaceHeight > 0 ? previousSurfaceHeight : h);
+#if defined IGRAPHICS_VULKAN
+      mVKSkipFrame = true;
+#endif
+    }
     SkImageInfo info = SkImageInfo::MakeN32Premul(surfaceWidth, surfaceHeight);
     mSurface = SkSurfaces::RenderTarget(mGrContext.get(), skgpu::Budgeted::kYes, info);
+#if defined IGRAPHICS_VULKAN
+    if (!mSurface)
+    {
+      IGRAPHICS_VK_LOG("DrawResize",
+                          "createRenderTargetFallback",
+                          vulkanlog::Severity::kError,
+                          vulkanlog::MakeField("width", surfaceWidth),
+                           vulkanlog::MakeField("height", surfaceHeight));
+      mSurface = SkSurfaces::Raster(info);
+    }
+#endif
   }
 #else
-  #ifdef OS_WIN
+#ifdef OS_WIN
   mSurface.reset();
 
   const size_t bmpSize = sizeof(BITMAPINFOHEADER) + (w * h * sizeof(uint32_t));
@@ -1456,6 +1493,10 @@ void IGraphicsSkia::DrawResize()
   {
     mCanvas = mSurface->getCanvas();
     mCanvas->save();
+  }
+  else
+  {
+    mCanvas = nullptr;
   }
 }
 

--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -494,6 +494,7 @@ void IGraphicsSkia::ResetVulkanSwapchainCaches()
 {
   mVKSwapchainSurfaces.clear();
   mScreenSurface.reset();
+  mVKSwapchainExtent = {0, 0};
 }
 
 #endif // IGRAPHICS_VULKAN
@@ -984,6 +985,7 @@ void IGraphicsSkia::OnViewInitialized(void* pContext)
   mVKQueueFamily = ctx->queueFamily;
   mVKSwapchainFormat = ctx->format;
   mVKSwapchainUsageFlags = ctx->usageFlags;
+  mVKSwapchainExtent = ctx->swapchainExtent;
   mVKSwapchainImages.clear();
   if (ctx->swapchainImages)
   {
@@ -1079,6 +1081,7 @@ void IGraphicsSkia::OnViewDestroyed()
   mVKDebugImages.clear();
   mVKCurrentImage = kInvalidImageIndex;
   mVKSwapchainFormat = VK_FORMAT_B8G8R8A8_UNORM;
+  mVKSwapchainExtent = {0, 0};
   mVKSubmissionPending = false;
   mVKSkipFrame = true;
 
@@ -1295,9 +1298,14 @@ void IGraphicsSkia::DrawResize()
 #if defined IGRAPHICS_GL || defined IGRAPHICS_METAL || defined IGRAPHICS_VULKAN
   if (mGrContext.get())
   {
-    SkImageInfo info = SkImageInfo::MakeN32Premul(w, h);
-    mSurface = SkSurfaces::RenderTarget(mGrContext.get(), skgpu::Budgeted::kYes, info);
+    int surfaceWidth = w;
+    int surfaceHeight = h;
   #if defined IGRAPHICS_VULKAN
+    if (mVKSwapchainExtent.width > 0 && mVKSwapchainExtent.height > 0)
+    {
+      surfaceWidth = static_cast<int>(mVKSwapchainExtent.width);
+      surfaceHeight = static_cast<int>(mVKSwapchainExtent.height);
+    }
     if (mVKDevice && mVKSurface)
     {
     #if defined OS_WIN
@@ -1306,6 +1314,7 @@ void IGraphicsSkia::DrawResize()
         VkSwapchainKHR swapchain = VK_NULL_HANDLE;
         std::vector<VkImage> images;
         VkFormat format = mVKSwapchainFormat;
+        VkExtent2D swapchainExtent = mVKSwapchainExtent;
         IGRAPHICS_VK_LOG("DrawResize",
                             "requestSwapchainResize",
                             vulkanlog::Severity::kInfo,
@@ -1313,7 +1322,7 @@ void IGraphicsSkia::DrawResize()
                              vulkanlog::MakeField("height", h),
                              vulkanlog::MakeField("frameVersion", static_cast<uint64_t>(mVKFrameVersion)),
                              vulkanlog::MakeField("swapchainVersion", static_cast<uint64_t>(mVKSwapchainVersion)));
-        VkResult res = pWin->CreateOrResizeVulkanSwapchain(w, h, swapchain, images, format, mVKSwapchainUsageFlags, mVKSubmissionPending);
+        VkResult res = pWin->CreateOrResizeVulkanSwapchain(w, h, swapchain, images, format, mVKSwapchainUsageFlags, mVKSubmissionPending, swapchainExtent);
         if (res == VK_SUCCESS)
         {
           mVKSwapchain = swapchain;
@@ -1321,6 +1330,12 @@ void IGraphicsSkia::DrawResize()
           mVKSwapchainSurfaces.assign(mVKSwapchainImages.size(), nullptr);
           mVKImageLayouts.assign(mVKSwapchainImages.size(), VK_IMAGE_LAYOUT_UNDEFINED);
           mVKSwapchainFormat = format;
+          mVKSwapchainExtent = swapchainExtent;
+          if (swapchainExtent.width > 0 && swapchainExtent.height > 0)
+          {
+            surfaceWidth = static_cast<int>(swapchainExtent.width);
+            surfaceHeight = static_cast<int>(swapchainExtent.height);
+          }
           mVKCurrentImage = kInvalidImageIndex;
           mVKSkipFrame = true;
       #ifndef NDEBUG
@@ -1388,6 +1403,8 @@ void IGraphicsSkia::DrawResize()
     #endif
     }
   #endif
+    SkImageInfo info = SkImageInfo::MakeN32Premul(surfaceWidth, surfaceHeight);
+    mSurface = SkSurfaces::RenderTarget(mGrContext.get(), skgpu::Budgeted::kYes, info);
   }
 #else
   #ifdef OS_WIN
@@ -1492,8 +1509,8 @@ void IGraphicsSkia::BeginFrame()
       return;
     }
 
-    int width = WindowWidth() * GetScreenScale();
-    int height = WindowHeight() * GetScreenScale();
+    int width = (mVKSwapchainExtent.width > 0) ? static_cast<int>(mVKSwapchainExtent.width) : WindowWidth() * GetScreenScale();
+    int height = (mVKSwapchainExtent.height > 0) ? static_cast<int>(mVKSwapchainExtent.height) : WindowHeight() * GetScreenScale();
     if (mVKSubmissionPending)
     {
       IGRAPHICS_VK_LOG("BeginFrame",

--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -1602,8 +1602,16 @@ void IGraphicsSkia::BeginFrame()
     }
     else
     {
-      width = WindowWidth() * GetScreenScale();
-      height = WindowHeight() * GetScreenScale();
+      IGRAPHICS_VK_LOG("BeginFrame",
+                          "swapchainExtentUnavailable",
+                          vulkanlog::Severity::kInfo,
+                          vulkanlog::MakeHandleField("swapchain", vulkanlog::HandleToUint64(mVKSwapchain)),
+                          vulkanlog::MakeField("cachedWidth", static_cast<uint32_t>(mVKSwapchainExtent.width)),
+                          vulkanlog::MakeField("cachedHeight", static_cast<uint32_t>(mVKSwapchainExtent.height)));
+      mVKSkipFrame = true;
+      mVKCurrentImage = kInvalidImageIndex;
+      mScreenSurface.reset();
+      return;
     }
     if (width <= 0 || height <= 0)
     {

--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -1189,6 +1189,14 @@ void IGraphicsSkia::DrawResize()
                       vulkanlog::Severity::kDebug,
                       vulkanlog::MakeField("previous", static_cast<uint64_t>(previousSwapchainVersion)),
                        vulkanlog::MakeField("current", static_cast<uint64_t>(mVKSwapchainVersion)));
+#if defined OS_WIN
+  if (auto* pWinSync = static_cast<IGraphicsWin*>(this))
+  {
+    VkExtent2D winExtent = pWinSync->GetSwapchainExtent();
+    if (winExtent.width > 0 && winExtent.height > 0)
+      mVKSwapchainExtent = winExtent;
+  }
+#endif
   if (mVKDevice != VK_NULL_HANDLE)
   {
     bool fenceCompleted = !mVKSubmissionPending;
@@ -1524,8 +1532,50 @@ void IGraphicsSkia::BeginFrame()
       return;
     }
 
-    int width = (mVKSwapchainExtent.width > 0) ? static_cast<int>(mVKSwapchainExtent.width) : WindowWidth() * GetScreenScale();
-    int height = (mVKSwapchainExtent.height > 0) ? static_cast<int>(mVKSwapchainExtent.height) : WindowHeight() * GetScreenScale();
+    int width = 0;
+    int height = 0;
+#if defined OS_WIN
+    if (auto* pWin = static_cast<IGraphicsWin*>(this))
+    {
+      VkExtent2D winExtent = pWin->GetSwapchainExtent();
+      if (winExtent.width > 0 && winExtent.height > 0)
+      {
+        if (winExtent.width != mVKSwapchainExtent.width || winExtent.height != mVKSwapchainExtent.height)
+        {
+          IGRAPHICS_VK_LOG("BeginFrame",
+                               "syncSwapchainExtent",
+                               vulkanlog::Severity::kDebug,
+                               vulkanlog::MakeField("winWidth", static_cast<uint32_t>(winExtent.width)),
+                                vulkanlog::MakeField("winHeight", static_cast<uint32_t>(winExtent.height)),
+                                vulkanlog::MakeField("cachedWidth", static_cast<uint32_t>(mVKSwapchainExtent.width)),
+                                vulkanlog::MakeField("cachedHeight", static_cast<uint32_t>(mVKSwapchainExtent.height)));
+        }
+        mVKSwapchainExtent = winExtent;
+      }
+    }
+#endif
+    if (mVKSwapchainExtent.width > 0 && mVKSwapchainExtent.height > 0)
+    {
+      width = static_cast<int>(mVKSwapchainExtent.width);
+      height = static_cast<int>(mVKSwapchainExtent.height);
+    }
+    else
+    {
+      width = WindowWidth() * GetScreenScale();
+      height = WindowHeight() * GetScreenScale();
+    }
+    if (width <= 0 || height <= 0)
+    {
+      IGRAPHICS_VK_LOG("BeginFrame",
+                          "invalidSurfaceExtent",
+                          vulkanlog::Severity::kError,
+                          vulkanlog::MakeField("width", width),
+                           vulkanlog::MakeField("height", height));
+      mVKSkipFrame = true;
+      mVKCurrentImage = kInvalidImageIndex;
+      mScreenSurface.reset();
+      return;
+    }
     if (mVKSubmissionPending)
     {
       IGRAPHICS_VK_LOG("BeginFrame",

--- a/IGraphics/Drawing/IGraphicsSkia.h
+++ b/IGraphics/Drawing/IGraphicsSkia.h
@@ -263,6 +263,7 @@ private:
   VkFence mVKInFlightFence = VK_NULL_HANDLE;
   VkFormat mVKSwapchainFormat = VK_FORMAT_B8G8R8A8_UNORM;
   VkImageUsageFlags mVKSwapchainUsageFlags = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+  VkExtent2D mVKSwapchainExtent{0, 0};
   bool mVKSkipFrame = false;
   bool mVKSubmissionPending = false;
   uint64_t mVKSwapchainVersion = 0;

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1278,7 +1278,16 @@ bool IGraphicsWin::CreateVulkanContext()
 
   mVkSwapchain.device = mVkDevice;
   bool submissionPending = false;
-  res = CreateOrResizeVulkanSwapchain(caps.currentExtent.width, caps.currentExtent.height, mVkSwapchain.handle, mVkSwapchainImages, mVkFormat, mVkSwapchainUsageFlags, submissionPending, mVkSwapchainExtent);
+  bool swapchainSuboptimal = false;
+  res = CreateOrResizeVulkanSwapchain(caps.currentExtent.width,
+                                      caps.currentExtent.height,
+                                      mVkSwapchain.handle,
+                                      mVkSwapchainImages,
+                                      mVkFormat,
+                                      mVkSwapchainUsageFlags,
+                                      submissionPending,
+                                      mVkSwapchainExtent,
+                                      swapchainSuboptimal);
   if (res != VK_SUCCESS)
   {
     IGRAPHICS_VK_LOG("CreateVulkanContext",
@@ -1287,6 +1296,12 @@ bool IGraphicsWin::CreateVulkanContext()
                         vulkanlog::MakeField("vkResult", static_cast<int>(res)));
     DestroyVulkanContext();
     return false;
+  }
+  if (swapchainSuboptimal)
+  {
+    IGRAPHICS_VK_LOG_SIMPLE("CreateVulkanContext",
+                        "swapchainSuboptimal",
+                        vulkanlog::Severity::kInfo);
   }
 
   VkSemaphoreCreateInfo semInfo{VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO};
@@ -1392,8 +1407,15 @@ bool IGraphicsWin::RecreateVulkanContext()
   return true;
 }
 
-VkResult IGraphicsWin::CreateOrResizeVulkanSwapchain(
-  uint32_t width, uint32_t height, VkSwapchainKHR& swapchain, std::vector<VkImage>& images, VkFormat& format, VkImageUsageFlags& usage, bool& submissionPending, VkExtent2D& imageExtent)
+VkResult IGraphicsWin::CreateOrResizeVulkanSwapchain(uint32_t width,
+                                                     uint32_t height,
+                                                     VkSwapchainKHR& swapchain,
+                                                     std::vector<VkImage>& images,
+                                                     VkFormat& format,
+                                                     VkImageUsageFlags& usage,
+                                                     bool& submissionPending,
+                                                     VkExtent2D& imageExtent,
+                                                     bool& swapchainSuboptimal)
 {
   IGRAPHICS_VK_LOG("CreateOrResizeVulkanSwapchain",
                       "request",
@@ -1406,6 +1428,7 @@ VkResult IGraphicsWin::CreateOrResizeVulkanSwapchain(
 
   mVkSwapchainExtent = {0, 0};
   imageExtent = {0, 0};
+  swapchainSuboptimal = false;
 
   VkResult res = VK_SUCCESS;
   if (mInFlightFence.handle)
@@ -1580,6 +1603,16 @@ VkResult IGraphicsWin::CreateOrResizeVulkanSwapchain(
                        vulkanlog::MakeHandleField("oldSwapchain", vulkanlog::HandleToUint64(reinterpret_cast<uintptr_t>(mVkSwapchain.handle))));
 
   res = vkCreateSwapchainKHR(mVkDevice, &swapInfo, nullptr, &mVkSwapchain.handle);
+  if (res == VK_SUBOPTIMAL_KHR)
+  {
+    IGRAPHICS_VK_LOG("CreateOrResizeVulkanSwapchain",
+                        "vkCreateSwapchainKHR",
+                        vulkanlog::Severity::kInfo,
+                        vulkanlog::MakeField("vkResult", static_cast<int>(res)),
+                        vulkanlog::MakeField("suboptimal", true));
+    swapchainSuboptimal = true;
+    res = VK_SUCCESS;
+  }
   if (res != VK_SUCCESS)
   {
     IGRAPHICS_VK_LOG("CreateOrResizeVulkanSwapchain",

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -1278,7 +1278,7 @@ bool IGraphicsWin::CreateVulkanContext()
 
   mVkSwapchain.device = mVkDevice;
   bool submissionPending = false;
-  res = CreateOrResizeVulkanSwapchain(caps.currentExtent.width, caps.currentExtent.height, mVkSwapchain.handle, mVkSwapchainImages, mVkFormat, mVkSwapchainUsageFlags, submissionPending);
+  res = CreateOrResizeVulkanSwapchain(caps.currentExtent.width, caps.currentExtent.height, mVkSwapchain.handle, mVkSwapchainImages, mVkFormat, mVkSwapchainUsageFlags, submissionPending, mVkSwapchainExtent);
   if (res != VK_SUCCESS)
   {
     IGRAPHICS_VK_LOG("CreateVulkanContext",
@@ -1345,6 +1345,7 @@ void IGraphicsWin::DestroyVulkanContext()
   mVkSwapchainImages.clear();
   mVkFormat = VK_FORMAT_B8G8R8A8_UNORM;
   mVkSwapchainUsageFlags = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+  mVkSwapchainExtent = {0, 0};
 
   if (mVulkanDeviceGeneration != 0)
   {
@@ -1386,12 +1387,13 @@ bool IGraphicsWin::RecreateVulkanContext()
   ctx.swapchainImages = &mVkSwapchainImages;
   ctx.format = mVkFormat;
   ctx.usageFlags = mVkSwapchainUsageFlags;
+  ctx.swapchainExtent = mVkSwapchainExtent;
   OnViewInitialized(&ctx);
   return true;
 }
 
 VkResult IGraphicsWin::CreateOrResizeVulkanSwapchain(
-  uint32_t width, uint32_t height, VkSwapchainKHR& swapchain, std::vector<VkImage>& images, VkFormat& format, VkImageUsageFlags& usage, bool& submissionPending)
+  uint32_t width, uint32_t height, VkSwapchainKHR& swapchain, std::vector<VkImage>& images, VkFormat& format, VkImageUsageFlags& usage, bool& submissionPending, VkExtent2D& imageExtent)
 {
   IGRAPHICS_VK_LOG("CreateOrResizeVulkanSwapchain",
                       "request",
@@ -1401,6 +1403,9 @@ VkResult IGraphicsWin::CreateOrResizeVulkanSwapchain(
                        vulkanlog::MakeHandleField("previousSwapchain", vulkanlog::HandleToUint64(reinterpret_cast<uintptr_t>(mVkSwapchain.handle))));
   if (!mVkDevice || !mVkPhysicalDevice || !mVkSurface)
     return VK_ERROR_INITIALIZATION_FAILED;
+
+  mVkSwapchainExtent = {0, 0};
+  imageExtent = {0, 0};
 
   VkResult res = VK_SUCCESS;
   if (mInFlightFence.handle)
@@ -1631,6 +1636,8 @@ VkResult IGraphicsWin::CreateOrResizeVulkanSwapchain(
   format = mVkFormat;
   usage = usageFlags;
   mVkSwapchainUsageFlags = usageFlags;
+  mVkSwapchainExtent = swapInfo.imageExtent;
+  imageExtent = mVkSwapchainExtent;
   swapchain = mVkSwapchain.handle;
   images = mVkSwapchainImages;
   return VK_SUCCESS;
@@ -1733,6 +1740,7 @@ void* IGraphicsWin::OpenWindow(void* pParent)
   ctx.swapchainImages = &mVkSwapchainImages;
   ctx.format = mVkFormat;
   ctx.usageFlags = mVkSwapchainUsageFlags;
+  ctx.swapchainExtent = mVkSwapchainExtent;
   OnViewInitialized(&ctx);
 #else
   HDC dc = GetDC(mPlugWnd);

--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -144,6 +144,8 @@ public:
                                          bool& submissionPending,
                                          VkExtent2D& imageExtent,
                                          bool& swapchainSuboptimal);
+
+  VkExtent2D GetSwapchainExtent() const { return mVkSwapchainExtent; }
   bool RecreateVulkanContext();
 #endif
 

--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -135,7 +135,15 @@ public:
   DWORD OnVBlankRun();
 
 #ifdef IGRAPHICS_VULKAN
-  VkResult CreateOrResizeVulkanSwapchain(uint32_t width, uint32_t height, VkSwapchainKHR& swapchain, std::vector<VkImage>& images, VkFormat& format, VkImageUsageFlags& usage, bool& submissionPending, VkExtent2D& imageExtent);
+  VkResult CreateOrResizeVulkanSwapchain(uint32_t width,
+                                         uint32_t height,
+                                         VkSwapchainKHR& swapchain,
+                                         std::vector<VkImage>& images,
+                                         VkFormat& format,
+                                         VkImageUsageFlags& usage,
+                                         bool& submissionPending,
+                                         VkExtent2D& imageExtent,
+                                         bool& swapchainSuboptimal);
   bool RecreateVulkanContext();
 #endif
 

--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -52,6 +52,7 @@ struct VulkanContext
   std::vector<VkImage>* swapchainImages = nullptr;
   VkFormat format = VK_FORMAT_B8G8R8A8_UNORM;
   VkImageUsageFlags usageFlags = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+  VkExtent2D swapchainExtent{0, 0};
 };
 #endif
 
@@ -134,7 +135,7 @@ public:
   DWORD OnVBlankRun();
 
 #ifdef IGRAPHICS_VULKAN
-  VkResult CreateOrResizeVulkanSwapchain(uint32_t width, uint32_t height, VkSwapchainKHR& swapchain, std::vector<VkImage>& images, VkFormat& format, VkImageUsageFlags& usage, bool& submissionPending);
+  VkResult CreateOrResizeVulkanSwapchain(uint32_t width, uint32_t height, VkSwapchainKHR& swapchain, std::vector<VkImage>& images, VkFormat& format, VkImageUsageFlags& usage, bool& submissionPending, VkExtent2D& imageExtent);
   bool RecreateVulkanContext();
 #endif
 
@@ -199,6 +200,7 @@ private:
   std::vector<VkImage> mVkSwapchainImages;
   VkFormat mVkFormat = VK_FORMAT_B8G8R8A8_UNORM;
   VkImageUsageFlags mVkSwapchainUsageFlags = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+  VkExtent2D mVkSwapchainExtent{0, 0};
 #endif
 
 #ifdef IGRAPHICS_GL


### PR DESCRIPTION
## Summary
- track the swapchain's pixel extent in the Windows Vulkan context and expose it through VulkanContext
- propagate the actual extent to the Skia renderer and size Skia surfaces based on the swapchain images
- use the stored extent in BeginFrame to wrap swapchain images without triggering validation errors

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d99e2243e883298fd2510413bcc4f9