### PR TITLE
Fix Windows telemetry helper access and namespace scope

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -468,6 +468,8 @@ StaticStorage<HFontHolder> IGraphicsWin::sHFontCache;
 
 extern float GetScaleForHWND(HWND hWnd);
 
+namespace iplug::igraphics
+{
 namespace
 {
 constexpr ULONGLONG kBurstCoolingWindowMs = 32ULL; // ~2 VSYNC intervals at 60Hz
@@ -892,7 +894,7 @@ void UpdatePaintBudgetCounters(const IGraphicsWin::InstancePaintBudget::Snapshot
 }
 } // namespace
 
-} // anonymous namespace
+} // namespace iplug::igraphics
 
 #if IGRAPHICS_SCHED_IDLE_EXPERIMENTAL
 void IGraphicsWin::SchedulerState::Reset(EIdlePacingMode mode, ULONGLONG nowTick)

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -568,9 +568,6 @@ bool ParseIdlePacingModeStringInternal(const std::string& value, EIdlePacingMode
   return false;
 }
 
-namespace
-{
-
 struct PaintBudgetTelemetryAccumulator
 {
   std::atomic<int> maxInflight{0};
@@ -893,8 +890,6 @@ void UpdatePaintBudgetCounters(const IGraphicsWin::InstancePaintBudget::Snapshot
   AtomicMax(telemetry.maxInflight, snapshot.pendingPaints);
   AtomicMax(telemetry.maxQueued, snapshot.queuedInvalidates);
 }
-} // namespace
-
 } // namespace
 
 } // namespace iplug::igraphics

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -459,14 +459,18 @@ typedef BOOL(WINAPI* PFNWGLSWAPINTERVALEXTPROC)(int interval);
 
 #pragma mark - Static storage
 
-StaticStorage<iplug::igraphics::IGraphicsWin::InstalledFont> iplug::igraphics::IGraphicsWin::sPlatformFontCache;
-StaticStorage<iplug::igraphics::HFontHolder> iplug::igraphics::IGraphicsWin::sHFontCache;
-#pragma mark - Mouse and tablet helpers
+namespace iplug::igraphics
+{
+StaticStorage<IGraphicsWin::InstalledFont> IGraphicsWin::sPlatformFontCache;
+StaticStorage<HFontHolder> IGraphicsWin::sHFontCache;
+} // namespace iplug::igraphics
 
 extern float GetScaleForHWND(HWND hWnd);
 
 namespace iplug::igraphics
 {
+#pragma mark - Mouse and tablet helpers
+
 namespace
 {
 constexpr ULONGLONG kBurstCoolingWindowMs = 32ULL; // ~2 VSYNC intervals at 60Hz
@@ -889,6 +893,8 @@ void UpdatePaintBudgetCounters(const IGraphicsWin::InstancePaintBudget::Snapshot
   AtomicMax(telemetry.maxInflight, snapshot.pendingPaints);
   AtomicMax(telemetry.maxQueued, snapshot.queuedInvalidates);
 }
+} // namespace
+
 } // namespace
 
 } // namespace iplug::igraphics

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -892,6 +892,8 @@ void UpdatePaintBudgetCounters(const IGraphicsWin::InstancePaintBudget::Snapshot
 }
 } // namespace
 
+} // anonymous namespace
+
 #if IGRAPHICS_SCHED_IDLE_EXPERIMENTAL
 void IGraphicsWin::SchedulerState::Reset(EIdlePacingMode mode, ULONGLONG nowTick)
 {

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -445,9 +445,6 @@ private:
 
 } // namespace iplug::igraphics
 
-using namespace iplug;
-using namespace igraphics;
-
 #ifdef IGRAPHICS_GL3
 typedef HGLRC(WINAPI* PFNWGLCREATECONTEXTATTRIBSARBPROC)(HDC hDC, HGLRC hShareContext, const int* attribList);
   #define WGL_CONTEXT_MAJOR_VERSION_ARB 0x2091
@@ -462,8 +459,8 @@ typedef BOOL(WINAPI* PFNWGLSWAPINTERVALEXTPROC)(int interval);
 
 #pragma mark - Static storage
 
-StaticStorage<IGraphicsWin::InstalledFont> IGraphicsWin::sPlatformFontCache;
-StaticStorage<HFontHolder> IGraphicsWin::sHFontCache;
+StaticStorage<iplug::igraphics::IGraphicsWin::InstalledFont> iplug::igraphics::IGraphicsWin::sPlatformFontCache;
+StaticStorage<iplug::igraphics::HFontHolder> iplug::igraphics::IGraphicsWin::sHFontCache;
 #pragma mark - Mouse and tablet helpers
 
 extern float GetScaleForHWND(HWND hWnd);
@@ -896,6 +893,8 @@ void UpdatePaintBudgetCounters(const IGraphicsWin::InstancePaintBudget::Snapshot
 
 } // namespace iplug::igraphics
 
+namespace iplug::igraphics
+{
 #if IGRAPHICS_SCHED_IDLE_EXPERIMENTAL
 void IGraphicsWin::SchedulerState::Reset(EIdlePacingMode mode, ULONGLONG nowTick)
 {
@@ -5626,6 +5625,8 @@ void IGraphicsWin::VBlankNotify()
                             schedulerlog::MakeField("count", latestCount)});
   }
 }
+
+} // namespace iplug::igraphics
 
 #ifndef NO_IGRAPHICS
   #if defined IGRAPHICS_SKIA

--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -258,8 +258,6 @@ private:
   void StopVBlankThread();
   void VBlankNotify();
 
-  static constexpr size_t kVBlankLatencySampleCount = 32;
-  static constexpr size_t kSchedulerSampleWindow = 120;
 #if IGRAPHICS_SCHED_IDLE_EXPERIMENTAL
   static constexpr int kParamQueueWarnThreshold = 12;
   static constexpr int kParamQueueErrorThreshold = 16;
@@ -275,31 +273,10 @@ private:
   void PerformVBlankHealthCheck();
   void RequestSwapchainSoftReset(ULONGLONG sincePauseMs);
 
-  friend class VBlankDispatchWorker;
+public:
+  static constexpr size_t kVBlankLatencySampleCount = 32;
+  static constexpr size_t kSchedulerSampleWindow = 120;
 
-  HWND mVBlankWindow = 0;                      // Window to post messages to for every vsync
-  volatile bool mVBlankShutdown = false;       // Flag to indiciate that the vsync thread should shutdown
-  HANDLE mVBlankThread = INVALID_HANDLE_VALUE; // ID of thread.
-  std::atomic<DWORD> mVBlankCount{0};          // running count of vblank events since the start of the window.
-  std::atomic<bool> mVBlankMessagePending{false}; // true while a WM_VBLANK message is outstanding on the UI queue
-  std::atomic<DWORD> mQueuedVBlank{0};         // newest vblank counter queued for delivery to the UI thread
-  std::atomic<DWORD> mPendingSyncVBlank{0};    // newest tick awaiting a fallback WM_VBLANK send when PostMessageW fails
-  DWORD mLastProcessedVBlank = 0;              // last WM_VBLANK tick serviced by the UI thread
-  int mVBlankSkipUntil = 0;                    // support for skipping vblank notification if the last callback took too long.
-                                              // This helps keep the message pump clear in the case of overload.
-  std::shared_ptr<VBlankSubscription> mVBlankSubscription; // worker registration for bounded WM_VBLANK dispatch
-  mutable std::mutex mVBlankSubscriptionMutex;             // guards subscription access across threads
-  std::atomic<uint32_t> mDroppedVBlank{0};     // number of ticks abandoned after exhausting retries
-  std::atomic<bool> mVBlankPaused{false};
-  std::atomic<bool> mVBlankHealthTimerActive{false};
-  std::atomic<uint32_t> mVBlankConsecutiveDrops{0};
-  std::atomic<uint32_t> mVBlankHealthCheckAttempts{0};
-  ULONGLONG mVBlankPausedSinceTick = 0;
-  bool mVBlankSoftResetIssued = false;
-  std::array<std::atomic<DWORD>, kVBlankLatencySampleCount> mVBlankLatencyCounts{};
-  std::array<std::atomic<uint64_t>, kVBlankLatencySampleCount> mVBlankLatencyMicros{};
-  bool mVSYNCEnabled = false;
-  bool mDeferInvalidation = false;
   struct InstancePaintBudget
   {
     enum class DecisionKind
@@ -434,6 +411,32 @@ private:
     uint32_t idleTimerBehindWindow[kSchedulerSampleWindow] = {};
   };
 
+private:
+  friend class VBlankDispatchWorker;
+
+  HWND mVBlankWindow = 0;                      // Window to post messages to for every vsync
+  volatile bool mVBlankShutdown = false;       // Flag to indiciate that the vsync thread should shutdown
+  HANDLE mVBlankThread = INVALID_HANDLE_VALUE; // ID of thread.
+  std::atomic<DWORD> mVBlankCount{0};          // running count of vblank events since the start of the window.
+  std::atomic<bool> mVBlankMessagePending{false}; // true while a WM_VBLANK message is outstanding on the UI queue
+  std::atomic<DWORD> mQueuedVBlank{0};         // newest vblank counter queued for delivery to the UI thread
+  std::atomic<DWORD> mPendingSyncVBlank{0};    // newest tick awaiting a fallback WM_VBLANK send when PostMessageW fails
+  DWORD mLastProcessedVBlank = 0;              // last WM_VBLANK tick serviced by the UI thread
+  int mVBlankSkipUntil = 0;                    // support for skipping vblank notification if the last callback took too long.
+                                              // This helps keep the message pump clear in the case of overload.
+  std::shared_ptr<VBlankSubscription> mVBlankSubscription; // worker registration for bounded WM_VBLANK dispatch
+  mutable std::mutex mVBlankSubscriptionMutex;             // guards subscription access across threads
+  std::atomic<uint32_t> mDroppedVBlank{0};     // number of ticks abandoned after exhausting retries
+  std::atomic<bool> mVBlankPaused{false};
+  std::atomic<bool> mVBlankHealthTimerActive{false};
+  std::atomic<uint32_t> mVBlankConsecutiveDrops{0};
+  std::atomic<uint32_t> mVBlankHealthCheckAttempts{0};
+  ULONGLONG mVBlankPausedSinceTick = 0;
+  bool mVBlankSoftResetIssued = false;
+  std::array<std::atomic<DWORD>, kVBlankLatencySampleCount> mVBlankLatencyCounts{};
+  std::array<std::atomic<uint64_t>, kVBlankLatencySampleCount> mVBlankLatencyMicros{};
+  bool mVSYNCEnabled = false;
+  bool mDeferInvalidation = false;
   static SchedulerTelemetrySnapshot GetSchedulerTelemetrySnapshot();
   static void ResetSchedulerTelemetrySnapshot();
 

--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -274,6 +274,7 @@ private:
   void RequestSwapchainSoftReset(ULONGLONG sincePauseMs);
 
 public:
+  // Telemetry helpers in IGraphicsWin.cpp require direct access to these types/constants.
   static constexpr size_t kVBlankLatencySampleCount = 32;
   static constexpr size_t kSchedulerSampleWindow = 120;
 


### PR DESCRIPTION
## Summary
- expose scheduler telemetry constants and InstancePaintBudget so the anonymous helper utilities in IGraphicsWin.cpp can access them when building with MSVC
- close the outer anonymous namespace in IGraphicsWin.cpp so subsequent IGraphicsWin member definitions reside in the correct scope

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da41f28d348329868db49c9d40e417