### PR TITLE
Fix Windows idle tick recursion

### DIFF
--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -1162,7 +1162,7 @@ public:
 
   virtual void OnHostIdleTick(const HostIdleTickInfo& info)
   {
-    OnHostIdleTick();
+    DispatchLegacyHostIdleTick();
     (void) info;
   }
 
@@ -1922,8 +1922,22 @@ private:
   IKeyHandlerFunc mKeyHandlerFunc = nullptr;
   IDisplayTickFunc mDisplayTickFunc = nullptr;
   IUIAppearanceChangedFunc mAppearanceChangedFunc = nullptr;
-  
+
+  bool mDispatchingLegacyHostIdleTick = false;
+
 protected:
+  void DispatchLegacyHostIdleTick()
+  {
+    if (mDispatchingLegacyHostIdleTick)
+      return;
+
+    mDispatchingLegacyHostIdleTick = true;
+    this->IGraphics::OnHostIdleTick();
+    mDispatchingLegacyHostIdleTick = false;
+  }
+
+  bool IsDispatchingLegacyHostIdleTick() const { return mDispatchingLegacyHostIdleTick; }
+
   virtual void OnIdlePacingModeChanged(EIdlePacingMode mode) {}
 
   IGEditorDelegate* mDelegate;

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -3106,6 +3106,9 @@ void IGraphicsWin::OnIdlePacingModeChanged(EIdlePacingMode mode)
 
 void IGraphicsWin::OnHostIdleTick()
 {
+  if (IsDispatchingLegacyHostIdleTick())
+    return;
+
   HostIdleTickInfo info{};
   OnHostIdleTick(info);
 }
@@ -3236,7 +3239,7 @@ void IGraphicsWin::OnHostIdleTick(const HostIdleTickInfo& info)
   (void) info;
 #endif
 
-  IGRAPHICS_DRAW_CLASS::OnHostIdleTick(info);
+  DispatchLegacyHostIdleTick();
 }
 
 void IGraphicsWin::InitializeIdlePacingConfiguration()


### PR DESCRIPTION
## Summary
- add a reentrancy guard for the legacy host idle handler in `IGraphics`
- stop the Windows host idle path from re-entering via the host idle info overload

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da6520f4c0832982011c1d2ad7063e