### PR TITLE
Improve Vulkan present sync and D3DKMT fallback

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -992,6 +992,26 @@ void IGraphicsSkia::OnViewInitialized(void* pContext)
   }
   mVKCurrentImage = kInvalidImageIndex;
   mVKImageAvailableSemaphore = ctx->imageAvailableSemaphore;
+  if (mVKDevice != VK_NULL_HANDLE)
+  {
+    VkSemaphoreCreateInfo submitSemInfo{VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO};
+    VkResult submitSemRes = vkCreateSemaphore(mVKDevice, &submitSemInfo, nullptr, &mVKSkiaSubmitSemaphore);
+    if (submitSemRes != VK_SUCCESS)
+    {
+      IGRAPHICS_VK_LOG("OnViewInitialized",
+                          "vkCreateSemaphore",
+                          vulkanlog::Severity::kError,
+                          vulkanlog::MakeField("vkResult", static_cast<int>(submitSemRes)),
+                           vulkanlog::MakeField("semaphore", "skiaSubmit"));
+      mVKSkiaSubmitSemaphore = VK_NULL_HANDLE;
+    }
+    else
+    {
+      IGRAPHICS_VK_LOG_SIMPLE("OnViewInitialized",
+                          "createdSkiaSubmitSemaphore",
+                          vulkanlog::Severity::kDebug);
+    }
+  }
   mVKRenderFinishedSemaphore = ctx->renderFinishedSemaphore;
   mVKInFlightFence = ctx->inFlightFence;
 
@@ -1050,6 +1070,12 @@ void IGraphicsSkia::OnViewDestroyed()
   {
     vkDeviceWaitIdle(mVKDevice);
 
+    if (mVKSkiaSubmitSemaphore != VK_NULL_HANDLE)
+    {
+      vkDestroySemaphore(mVKDevice, mVKSkiaSubmitSemaphore, nullptr);
+      mVKSkiaSubmitSemaphore = VK_NULL_HANDLE;
+    }
+
     if (mVKCommandBuffer != VK_NULL_HANDLE && mVKCommandPool != VK_NULL_HANDLE)
     {
       vkFreeCommandBuffers(mVKDevice, mVKCommandPool, 1, &mVKCommandBuffer);
@@ -1065,6 +1091,7 @@ void IGraphicsSkia::OnViewDestroyed()
   mVKCommandPool = VK_NULL_HANDLE;
 
   mVKImageAvailableSemaphore = VK_NULL_HANDLE;
+  mVKSkiaSubmitSemaphore = VK_NULL_HANDLE;
   mVKRenderFinishedSemaphore = VK_NULL_HANDLE;
   mVKInFlightFence = VK_NULL_HANDLE;
   mVKSwapchain = VK_NULL_HANDLE;
@@ -1932,7 +1959,27 @@ void IGraphicsSkia::EndFrame()
   #if defined IGRAPHICS_VULKAN
   if (auto dContext = GrAsDirectContext(mScreenSurface->getCanvas()->recordingContext()))
   {
-    GrBackendSemaphore signalSemaphore = GrBackendSemaphores::MakeVk(mVKRenderFinishedSemaphore);
+    if (mVKSkiaSubmitSemaphore == VK_NULL_HANDLE)
+    {
+      IGRAPHICS_VK_LOG_SIMPLE("EndFrame",
+                          "missingSkiaSubmitSemaphore",
+                          vulkanlog::Severity::kError);
+      vkQueueSubmit(mVKQueue, 0, nullptr, mVKInFlightFence); // signal fence
+      mVKSubmissionPending = true;
+      return;
+    }
+
+    if (mVKRenderFinishedSemaphore == VK_NULL_HANDLE)
+    {
+      IGRAPHICS_VK_LOG_SIMPLE("EndFrame",
+                          "missingRenderFinishedSemaphore",
+                          vulkanlog::Severity::kError);
+      vkQueueSubmit(mVKQueue, 0, nullptr, mVKInFlightFence); // signal fence
+      mVKSubmissionPending = true;
+      return;
+    }
+
+    GrBackendSemaphore signalSemaphore = GrBackendSemaphores::MakeVk(mVKSkiaSubmitSemaphore);
     GrFlushInfo flushInfo{};
     flushInfo.fNumSemaphores = 1;
     flushInfo.fSignalSemaphores = &signalSemaphore;
@@ -2075,12 +2122,13 @@ void IGraphicsSkia::EndFrame()
   VkPipelineStageFlags waitStage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
   VkSubmitInfo submitInfo{};
   submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
-  submitInfo.waitSemaphoreCount = 1;
-  submitInfo.pWaitSemaphores = &mVKRenderFinishedSemaphore;
-  submitInfo.pWaitDstStageMask = &waitStage;
+  submitInfo.waitSemaphoreCount = (mVKSkiaSubmitSemaphore != VK_NULL_HANDLE) ? 1 : 0;
+  submitInfo.pWaitSemaphores = (submitInfo.waitSemaphoreCount == 1) ? &mVKSkiaSubmitSemaphore : nullptr;
+  submitInfo.pWaitDstStageMask = (submitInfo.waitSemaphoreCount == 1) ? &waitStage : nullptr;
   submitInfo.commandBufferCount = 1;
   submitInfo.pCommandBuffers = &mVKCommandBuffer;
-  submitInfo.signalSemaphoreCount = 0;
+  submitInfo.signalSemaphoreCount = 1;
+  submitInfo.pSignalSemaphores = &mVKRenderFinishedSemaphore;
 
   VkResult submitRes = vkQueueSubmit(mVKQueue, 1, &submitInfo, mVKInFlightFence);
   bool previousPending = mVKSubmissionPending;
@@ -2109,8 +2157,8 @@ void IGraphicsSkia::EndFrame()
 
   VkPresentInfoKHR presentInfo{};
   presentInfo.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
-  presentInfo.waitSemaphoreCount = 0;
-  presentInfo.pWaitSemaphores = nullptr;
+  presentInfo.waitSemaphoreCount = 1;
+  presentInfo.pWaitSemaphores = &mVKRenderFinishedSemaphore;
   presentInfo.swapchainCount = 1;
   presentInfo.pSwapchains = &mVKSwapchain;
   presentInfo.pImageIndices = &mVKCurrentImage;

--- a/IGraphics/Drawing/IGraphicsSkia.h
+++ b/IGraphics/Drawing/IGraphicsSkia.h
@@ -259,6 +259,7 @@ private:
   std::vector<sk_sp<SkSurface>> mVKSwapchainSurfaces;
   uint32_t mVKCurrentImage = kInvalidImageIndex;
   VkSemaphore mVKImageAvailableSemaphore = VK_NULL_HANDLE;
+  VkSemaphore mVKSkiaSubmitSemaphore = VK_NULL_HANDLE;
   VkSemaphore mVKRenderFinishedSemaphore = VK_NULL_HANDLE;
   VkFence mVKInFlightFence = VK_NULL_HANDLE;
   VkFormat mVKSwapchainFormat = VK_FORMAT_B8G8R8A8_UNORM;

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -3738,6 +3738,49 @@ void IGraphicsWin::DestroyGLContext()
 #endif
 
 #ifdef IGRAPHICS_VULKAN
+
+void IGraphicsWin::UpdateVulkanAdapterIdentity(const VkPhysicalDeviceIDProperties& idProps)
+{
+  if (idProps.deviceLUIDValid)
+  {
+    uint64_t encodedLuid = 0;
+    static_assert(sizeof(idProps.deviceLUID) >= sizeof(encodedLuid), "Unexpected LUID size");
+    std::memcpy(&encodedLuid, idProps.deviceLUID, sizeof(encodedLuid));
+    mVulkanAdapterLuidValue.store(encodedLuid, std::memory_order_release);
+    mVulkanAdapterLuidValid.store(true, std::memory_order_release);
+    mVulkanAdapterNodeMask.store(idProps.deviceNodeMask, std::memory_order_release);
+  }
+  else
+  {
+    mVulkanAdapterLuidValue.store(0, std::memory_order_release);
+    mVulkanAdapterLuidValid.store(false, std::memory_order_release);
+    mVulkanAdapterNodeMask.store(0, std::memory_order_release);
+  }
+}
+
+void IGraphicsWin::ClearVulkanAdapterIdentity()
+{
+  mVulkanAdapterLuidValue.store(0, std::memory_order_release);
+  mVulkanAdapterLuidValid.store(false, std::memory_order_release);
+  mVulkanAdapterNodeMask.store(0, std::memory_order_release);
+}
+
+bool IGraphicsWin::GetVulkanAdapterLuid(LUID& luidOut) const
+{
+  if (!mVulkanAdapterLuidValid.load(std::memory_order_acquire))
+    return false;
+
+  const uint64_t encoded = mVulkanAdapterLuidValue.load(std::memory_order_acquire);
+  luidOut.LowPart = static_cast<DWORD>(encoded & 0xFFFFFFFFULL);
+  luidOut.HighPart = static_cast<LONG>((encoded >> 32) & 0xFFFFFFFFULL);
+  return true;
+}
+
+uint32_t IGraphicsWin::GetVulkanAdapterNodeMask() const
+{
+  return mVulkanAdapterNodeMask.load(std::memory_order_acquire);
+}
+
 bool IGraphicsWin::CreateVulkanContext()
 {
   if (mVkInstance)
@@ -3782,6 +3825,14 @@ bool IGraphicsWin::CreateVulkanContext()
   mPresentQueue = snapshot.presentQueue;
   mVkQueueFamily = snapshot.queueFamily;
   mVulkanDeviceGeneration = generation;
+
+  VkPhysicalDeviceProperties2 props2{};
+  props2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
+  VkPhysicalDeviceIDProperties idProps{};
+  idProps.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES;
+  props2.pNext = &idProps;
+  vkGetPhysicalDeviceProperties2(mVkPhysicalDevice, &props2);
+  UpdateVulkanAdapterIdentity(idProps);
 
   VkSurfaceCapabilitiesKHR caps{};
   res = vkGetPhysicalDeviceSurfaceCapabilitiesKHR(mVkPhysicalDevice, mVkSurface, &caps);
@@ -3855,6 +3906,8 @@ void IGraphicsWin::DestroyVulkanContext()
 {
   if (mVkDevice)
     vkDeviceWaitIdle(mVkDevice);
+
+  ClearVulkanAdapterIdentity();
 
   mImageAvailableSemaphore.Reset();
   mRenderFinishedSemaphore.Reset();
@@ -5540,10 +5593,17 @@ DWORD IGraphicsWin::OnVBlankRun()
     bool hasAdapterLuid = false;
     D3DDDI_VIDEO_PRESENT_SOURCE_ID vidPnSourceId = static_cast<D3DDDI_VIDEO_PRESENT_SOURCE_ID>(-1);
     bool hasVidPnSourceId = false;
+    bool hasPreferredLuid = false;
+    LUID preferredLuid{};
 
     ~DxgiVBlankHelper()
     {
       Cleanup();
+    }
+
+    static bool EqualLuid(const LUID& a, const LUID& b)
+    {
+      return a.HighPart == b.HighPart && a.LowPart == b.LowPart;
     }
 
     void Cleanup()
@@ -5596,20 +5656,57 @@ DWORD IGraphicsWin::OnVBlankRun()
       return true;
     }
 
+    bool SetPreferredAdapterLuid(const LUID* luid)
+    {
+      if (!luid)
+      {
+        if (!hasPreferredLuid)
+          return false;
+        hasPreferredLuid = false;
+        preferredLuid = {};
+        return true;
+      }
+
+      if (hasPreferredLuid && EqualLuid(preferredLuid, *luid))
+        return false;
+
+      preferredLuid = *luid;
+      hasPreferredLuid = true;
+      if (output && (!hasAdapterLuid || !EqualLuid(adapterLuid, preferredLuid)))
+      {
+        ResetOutput();
+      }
+      return true;
+    }
+
+    bool PreferredAdapterLuid(LUID& luidOut) const
+    {
+      if (!hasPreferredLuid)
+        return false;
+      luidOut = preferredLuid;
+      return true;
+    }
+
     bool EnsureOutput(HWND window)
     {
       if (!EnsureInitialized())
         return false;
 
       HMONITOR targetMonitor = MonitorFromWindow(window, MONITOR_DEFAULTTONEAREST);
-      if (!targetMonitor)
+      if (!targetMonitor && !hasPreferredLuid)
       {
         ResetOutput();
         return false;
       }
 
-      if (output && monitor == targetMonitor)
-        return true;
+      if (output)
+      {
+        if ((targetMonitor && monitor == targetMonitor)
+            || (!targetMonitor && hasAdapterLuid && hasPreferredLuid && EqualLuid(adapterLuid, preferredLuid)))
+        {
+          return true;
+        }
+      }
 
       ResetOutput();
 
@@ -5621,6 +5718,9 @@ DWORD IGraphicsWin::OnVBlankRun()
       }
 
       factory = newFactory;
+
+      IDXGIOutput* preferredOutput = nullptr;
+      DXGI_OUTPUT_DESC preferredDesc{};
 
       UINT adapterIndex = 0;
       while (true)
@@ -5650,12 +5750,13 @@ DWORD IGraphicsWin::OnVBlankRun()
             continue;
           }
 
-          DXGI_OUTPUT_DESC desc;
+          DXGI_OUTPUT_DESC desc{};
           hr = candidate->GetDesc(&desc);
-          if (SUCCEEDED(hr) && desc.Monitor == targetMonitor)
+          bool keepCandidate = false;
+          if (SUCCEEDED(hr) && targetMonitor && desc.Monitor == targetMonitor)
           {
             output = candidate;
-            monitor = targetMonitor;
+            monitor = desc.Monitor;
             lstrcpynW(deviceName,
                       desc.DeviceName,
                       static_cast<int>(sizeof(deviceName) / sizeof(deviceName[0])));
@@ -5663,15 +5764,44 @@ DWORD IGraphicsWin::OnVBlankRun()
             hasAdapterLuid = true;
             hasVidPnSourceId = false;
             EnsureVidPnSourceId();
+            if (preferredOutput)
+              preferredOutput->Release();
             adapter->Release();
             return true;
           }
 
-          candidate->Release();
+          if (SUCCEEDED(hr) && hasPreferredLuid && EqualLuid(desc.AdapterLuid, preferredLuid) && !preferredOutput)
+          {
+            preferredOutput = candidate;
+            preferredDesc = desc;
+            keepCandidate = true;
+          }
+
+          if (!keepCandidate)
+          {
+            candidate->Release();
+          }
         }
 
         adapter->Release();
       }
+
+      if (preferredOutput)
+      {
+        output = preferredOutput;
+        monitor = preferredDesc.Monitor;
+        lstrcpynW(deviceName,
+                  preferredDesc.DeviceName,
+                  static_cast<int>(sizeof(deviceName) / sizeof(deviceName[0])));
+        adapterLuid = preferredDesc.AdapterLuid;
+        hasAdapterLuid = true;
+        hasVidPnSourceId = false;
+        EnsureVidPnSourceId();
+        return true;
+      }
+
+      if (preferredOutput)
+        preferredOutput->Release();
 
       ResetOutput();
       return false;
@@ -5682,8 +5812,18 @@ DWORD IGraphicsWin::OnVBlankRun()
       if (hasVidPnSourceId)
         return true;
 
-      if (!hasAdapterLuid || deviceName[0] == L'\0')
-        return false;
+      if (!hasAdapterLuid)
+      {
+        if (hasPreferredLuid)
+        {
+          adapterLuid = preferredLuid;
+          hasAdapterLuid = true;
+        }
+        else
+        {
+          return false;
+        }
+      }
 
       UINT32 pathCount = 0;
       UINT32 modeCount = 0;
@@ -5701,8 +5841,7 @@ DWORD IGraphicsWin::OnVBlankRun()
       for (UINT32 i = 0; i < pathCount; ++i)
       {
         const auto& path = paths[i];
-        if (path.sourceInfo.adapterId.HighPart != adapterLuid.HighPart
-            || path.sourceInfo.adapterId.LowPart != adapterLuid.LowPart)
+        if (!EqualLuid(path.sourceInfo.adapterId, adapterLuid))
         {
           continue;
         }
@@ -5712,15 +5851,39 @@ DWORD IGraphicsWin::OnVBlankRun()
         sourceName.header.size = sizeof(sourceName);
         sourceName.header.adapterId = path.sourceInfo.adapterId;
         sourceName.header.id = path.sourceInfo.id;
-        if (DisplayConfigGetDeviceInfo(&sourceName.header) != ERROR_SUCCESS)
+
+        bool nameMatches = false;
+        if (DisplayConfigGetDeviceInfo(&sourceName.header) == ERROR_SUCCESS)
+        {
+          if (deviceName[0] == L'\0')
+          {
+            lstrcpynW(deviceName,
+                      sourceName.viewGdiDeviceName,
+                      static_cast<int>(sizeof(deviceName) / sizeof(deviceName[0])));
+            nameMatches = true;
+          }
+          else if (lstrcmpiW(sourceName.viewGdiDeviceName, deviceName) == 0)
+          {
+            nameMatches = true;
+          }
+        }
+        else if (deviceName[0] == L'\0' && hasPreferredLuid)
+        {
+          nameMatches = true;
+        }
+
+        if (!nameMatches && deviceName[0] != L'\0' && !hasPreferredLuid)
           continue;
 
-        if (lstrcmpiW(sourceName.viewGdiDeviceName, deviceName) == 0)
+        vidPnSourceId = static_cast<D3DDDI_VIDEO_PRESENT_SOURCE_ID>(path.sourceInfo.id);
+        hasVidPnSourceId = true;
+        if (!nameMatches && hasPreferredLuid && sourceName.viewGdiDeviceName[0] != L'\0')
         {
-          vidPnSourceId = static_cast<D3DDDI_VIDEO_PRESENT_SOURCE_ID>(path.sourceInfo.id);
-          hasVidPnSourceId = true;
-          return true;
+          lstrcpynW(deviceName,
+                    sourceName.viewGdiDeviceName,
+                    static_cast<int>(sizeof(deviceName) / sizeof(deviceName[0])));
         }
+        return true;
       }
 
       return false;
@@ -5758,10 +5921,17 @@ DWORD IGraphicsWin::OnVBlankRun()
 
     bool AdapterLuid(LUID& luidOut) const
     {
-      if (!hasAdapterLuid)
-        return false;
-      luidOut = adapterLuid;
-      return true;
+      if (hasAdapterLuid)
+      {
+        luidOut = adapterLuid;
+        return true;
+      }
+      if (hasPreferredLuid)
+      {
+        luidOut = preferredLuid;
+        return true;
+      }
+      return false;
     }
 
     bool VidPnSourceId(D3DDDI_VIDEO_PRESENT_SOURCE_ID& sourceIdOut)
@@ -5863,6 +6033,36 @@ DWORD IGraphicsWin::OnVBlankRun()
   };
 
   DxgiVBlankHelper dxgiHelper;
+  auto refreshPreferredAdapter = [&]() {
+    bool changed = false;
+    LUID preferred{};
+    if (GetVulkanAdapterLuid(preferred))
+    {
+      changed = dxgiHelper.SetPreferredAdapterLuid(&preferred);
+      if (changed)
+      {
+        schedulerlog::LogEvent(schedulerlog::kCategoryVBlankDispatch,
+                               "vblank",
+                               schedulerlog::Severity::kInfo,
+                               {schedulerlog::MakeField("event", "preferred_luid_updated"),
+                                schedulerlog::MakeField("luid_high", static_cast<int>(preferred.HighPart)),
+                                schedulerlog::MakeField("luid_low", static_cast<uint32_t>(preferred.LowPart))});
+      }
+    }
+    else
+    {
+      changed = dxgiHelper.SetPreferredAdapterLuid(nullptr);
+      if (changed)
+      {
+        schedulerlog::LogEvent(schedulerlog::kCategoryVBlankDispatch,
+                               "vblank",
+                               schedulerlog::Severity::kInfo,
+                               {schedulerlog::MakeField("event", "preferred_luid_cleared")});
+      }
+    }
+    return changed;
+  };
+  refreshPreferredAdapter();
   DwmVBlankHelper dwmHelper;
   bool dxgiActive = false;
   bool dwmActive = false;
@@ -6015,6 +6215,7 @@ DWORD IGraphicsWin::OnVBlankRun()
                             schedulerlog::MakeField("fallback", "dxgi_dwm")});
     while (mVBlankShutdown == false)
     {
+      refreshPreferredAdapter();
       waitWithFallback("d3dkmt_missing");
       VBlankNotify();
     }
@@ -6222,6 +6423,7 @@ DWORD IGraphicsWin::OnVBlankRun()
 
     while (mVBlankShutdown == false)
     {
+      refreshPreferredAdapter();
       if (!adapterIsOpen)
       {
         // reacquire the adapter (at most once a second).

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -5483,6 +5483,14 @@ typedef struct _D3DKMT_OPENADAPTERFROMHDC
   D3DDDI_VIDEO_PRESENT_SOURCE_ID VidPnSourceId;
 } D3DKMT_OPENADAPTERFROMHDC;
 
+typedef struct _D3DKMT_OPENADAPTERFROMGDIDISPLAYNAME
+{
+  WCHAR DeviceName[32];
+  D3DKMT_HANDLE hAdapter;
+  LUID AdapterLuid;
+  D3DDDI_VIDEO_PRESENT_SOURCE_ID VidPnSourceId;
+} D3DKMT_OPENADAPTERFROMGDIDISPLAYNAME;
+
 typedef struct _D3DKMT_CLOSEADAPTER
 {
   D3DKMT_HANDLE hAdapter;
@@ -5497,6 +5505,7 @@ typedef struct _D3DKMT_WAITFORVERTICALBLANKEVENT
 
 // entry points
 typedef NTSTATUS(WINAPI* D3DKMTOpenAdapterFromHdc)(D3DKMT_OPENADAPTERFROMHDC* Arg1);
+typedef NTSTATUS(WINAPI* D3DKMTOpenAdapterFromGdiDisplayName)(D3DKMT_OPENADAPTERFROMGDIDISPLAYNAME* Arg1);
 typedef NTSTATUS(WINAPI* D3DKMTCloseAdapter)(const D3DKMT_CLOSEADAPTER* Arg1);
 typedef NTSTATUS(WINAPI* D3DKMTWaitForVerticalBlankEvent)(const D3DKMT_WAITFORVERTICALBLANKEVENT* Arg1);
 
@@ -5782,6 +5791,7 @@ DWORD IGraphicsWin::OnVBlankRun()
   // TODO: handle low power modes
 
   D3DKMTOpenAdapterFromHdc pOpen = nullptr;
+  D3DKMTOpenAdapterFromGdiDisplayName pOpenFromDisplay = nullptr;
   D3DKMTCloseAdapter pClose = nullptr;
   D3DKMTWaitForVerticalBlankEvent pWait = nullptr;
   HINSTANCE hInst = LoadLibraryW(L"gdi32.dll");
@@ -5789,6 +5799,8 @@ DWORD IGraphicsWin::OnVBlankRun()
   if (hInst != nullptr)
   {
     pOpen = (D3DKMTOpenAdapterFromHdc)GetProcAddress((HMODULE)hInst, "D3DKMTOpenAdapterFromHdc");
+    pOpenFromDisplay =
+      (D3DKMTOpenAdapterFromGdiDisplayName)GetProcAddress((HMODULE)hInst, "D3DKMTOpenAdapterFromGdiDisplayName");
     pClose = (D3DKMTCloseAdapter)GetProcAddress((HMODULE)hInst, "D3DKMTCloseAdapter");
     pWait = (D3DKMTWaitForVerticalBlankEvent)GetProcAddress((HMODULE)hInst, "D3DKMTWaitForVerticalBlankEvent");
   }
@@ -5907,7 +5919,7 @@ DWORD IGraphicsWin::OnVBlankRun()
   // to a DXGI wait, otherwise to sleeping. This is really just a last
   // resort and not expected on modern hardware and Windows OS
   // installs.
-  if (!pOpen || !pClose || !pWait)
+  if ((!pOpen && !pOpenFromDisplay) || !pClose || !pWait)
   {
     schedulerlog::LogEvent(schedulerlog::kCategoryVBlankDispatch,
                            "vblank",
@@ -5932,7 +5944,7 @@ DWORD IGraphicsWin::OnVBlankRun()
     };
 
     auto tryOpenAdapterForWindow = [&](HWND window, D3DKMT_OPENADAPTERFROMHDC& openAdapterData) -> NTSTATUS {
-      if (window == nullptr)
+      if (window == nullptr || !pOpen)
         return static_cast<NTSTATUS>(E_HANDLE);
 
       HDC hDC = GetDC(window);
@@ -5964,6 +5976,39 @@ DWORD IGraphicsWin::OnVBlankRun()
     auto tryOpenAdapterForDisplay = [&](const WCHAR* deviceName,
                                         D3DKMT_OPENADAPTERFROMHDC& openAdapterData) -> NTSTATUS {
       if (!deviceName || deviceName[0] == L'\0')
+        return static_cast<NTSTATUS>(E_HANDLE);
+
+      if (pOpenFromDisplay)
+      {
+        D3DKMT_OPENADAPTERFROMGDIDISPLAYNAME byName = {};
+        lstrcpynW(byName.DeviceName,
+                  deviceName,
+                  static_cast<int>(sizeof(byName.DeviceName) / sizeof(byName.DeviceName[0])));
+        NTSTATUS status = (*pOpenFromDisplay)(&byName);
+        if (status == S_OK)
+        {
+          openAdapterData = {};
+          openAdapterData.hDc = nullptr;
+          openAdapterData.hAdapter = byName.hAdapter;
+          openAdapterData.AdapterLuid = byName.AdapterLuid;
+          openAdapterData.VidPnSourceId = byName.VidPnSourceId;
+          schedulerlog::LogEvent(schedulerlog::kCategoryVBlankDispatch,
+                                 "vblank",
+                                 schedulerlog::Severity::kDebug,
+                                 {schedulerlog::MakeField("event", "d3dkmt_open_gdi_success"),
+                                  schedulerlog::MakeField("fallback", "dxgi_dwm")});
+          return status;
+        }
+
+        schedulerlog::LogEvent(schedulerlog::kCategoryVBlankDispatch,
+                               "vblank",
+                               schedulerlog::Severity::kWarn,
+                               {schedulerlog::MakeField("event", "d3dkmt_open_gdi_failed"),
+                                schedulerlog::MakeField("status", static_cast<int>(status)),
+                                schedulerlog::MakeField("fallback", "dxgi_dwm")});
+      }
+
+      if (!pOpen)
         return static_cast<NTSTATUS>(E_HANDLE);
 
       HDC displayDC = CreateDCW(L"DISPLAY", deviceName, nullptr, nullptr);

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -82,6 +82,7 @@ struct VBlankSubscription
 namespace
 {
 constexpr uint32_t kVBlankQueueDepthWarningMultiplier = 2;
+constexpr HRESULT kDwmCompositionDisabled = static_cast<HRESULT>(0x80263001L);
 
 void RecordVBlankQueueDepthSample(uint32_t depth);
 void IncrementVBlankQueueWarnCount();
@@ -5517,6 +5518,7 @@ DWORD IGraphicsWin::OnVBlankRun()
     IDXGIFactory1* factory = nullptr;
     IDXGIOutput* output = nullptr;
     HMONITOR monitor = nullptr;
+    WCHAR deviceName[32] = {0};
 
     ~DxgiVBlankHelper()
     {
@@ -5547,6 +5549,7 @@ DWORD IGraphicsWin::OnVBlankRun()
         factory = nullptr;
       }
       monitor = nullptr;
+      deviceName[0] = L'\0';
     }
 
     bool EnsureInitialized()
@@ -5628,6 +5631,9 @@ DWORD IGraphicsWin::OnVBlankRun()
           {
             output = candidate;
             monitor = targetMonitor;
+            lstrcpynW(deviceName,
+                      desc.DeviceName,
+                      static_cast<int>(sizeof(deviceName) / sizeof(deviceName[0])));
             adapter->Release();
             return true;
           }
@@ -5666,14 +5672,17 @@ DWORD IGraphicsWin::OnVBlankRun()
 
       return true;
     }
+
+    const WCHAR* DeviceName() const
+    {
+      return deviceName[0] != L'\0' ? deviceName : nullptr;
+    }
   };
 
   struct DwmVBlankHelper
   {
     using DwmIsCompositionEnabledFn = HRESULT(WINAPI*)(BOOL*);
     using DwmFlushFn = HRESULT(WINAPI*)();
-
-    static constexpr HRESULT kCompositionDisabled = static_cast<HRESULT>(0x80263001L);
 
     HMODULE module = nullptr;
     DwmIsCompositionEnabledFn isCompositionEnabled = nullptr;
@@ -5745,7 +5754,7 @@ DWORD IGraphicsWin::OnVBlankRun()
 
       if (FAILED(hr))
       {
-        if (hr == kCompositionDisabled)
+        if (hr == kDwmCompositionDisabled)
         {
           compositionEnabled = FALSE;
         }
@@ -5952,7 +5961,48 @@ DWORD IGraphicsWin::OnVBlankRun()
       return status;
     };
 
+    auto tryOpenAdapterForDisplay = [&](const WCHAR* deviceName,
+                                        D3DKMT_OPENADAPTERFROMHDC& openAdapterData) -> NTSTATUS {
+      if (!deviceName || deviceName[0] == L'\0')
+        return static_cast<NTSTATUS>(E_HANDLE);
+
+      HDC displayDC = CreateDCW(L"DISPLAY", deviceName, nullptr, nullptr);
+      if (!displayDC)
+      {
+        schedulerlog::LogEvent(schedulerlog::kCategoryVBlankDispatch,
+                               "vblank",
+                               schedulerlog::Severity::kWarn,
+                               {schedulerlog::MakeField("event", "d3dkmt_createdc_failed"),
+                                schedulerlog::MakeField("fallback", "dxgi_dwm")});
+        return static_cast<NTSTATUS>(E_HANDLE);
+      }
+
+      openAdapterData = {};
+      openAdapterData.hDc = displayDC;
+      NTSTATUS status = (*pOpen)(&openAdapterData);
+      DeleteDC(displayDC);
+      if (status != S_OK)
+      {
+        schedulerlog::LogEvent(schedulerlog::kCategoryVBlankDispatch,
+                               "vblank",
+                               schedulerlog::Severity::kWarn,
+                               {schedulerlog::MakeField("event", "d3dkmt_open_display_failed"),
+                                schedulerlog::MakeField("status", static_cast<int>(status)),
+                                schedulerlog::MakeField("fallback", "dxgi_dwm")});
+      }
+      else
+      {
+        schedulerlog::LogEvent(schedulerlog::kCategoryVBlankDispatch,
+                               "vblank",
+                               schedulerlog::Severity::kDebug,
+                               {schedulerlog::MakeField("event", "d3dkmt_open_display_success"),
+                                schedulerlog::MakeField("fallback", "dxgi_dwm")});
+      }
+      return status;
+    };
+
     auto tryOpenAdapter = [&](D3DKMT_OPENADAPTERFROMHDC& openAdapterData) -> bool {
+      dxgiHelper.EnsureOutput(mVBlankWindow);
       std::array<HWND, 5> searchWindows = {mVBlankWindow,
                                            GetAncestor(mVBlankWindow, GA_PARENT),
                                            GetAncestor(mVBlankWindow, GA_ROOT),
@@ -5978,6 +6028,13 @@ DWORD IGraphicsWin::OnVBlankRun()
           continue;
 
         NTSTATUS status = tryOpenAdapterForWindow(window, openAdapterData);
+        if (status == S_OK)
+          return true;
+      }
+      const WCHAR* deviceName = dxgiHelper.DeviceName();
+      if (deviceName)
+      {
+        NTSTATUS status = tryOpenAdapterForDisplay(deviceName, openAdapterData);
         if (status == S_OK)
           return true;
       }

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -46,7 +46,7 @@
 #include <utility>
 #include <vector>
 #include <wininet.h>
-#include <windisplayconfig.h>
+#include <wingdi.h>
 
 #if defined __clang__
   #undef CCSIZEOF_STRUCT
@@ -5721,6 +5721,8 @@ DWORD IGraphicsWin::OnVBlankRun()
 
       IDXGIOutput* preferredOutput = nullptr;
       DXGI_OUTPUT_DESC preferredDesc{};
+      LUID preferredAdapterLuid{};
+      bool preferredHasAdapterLuid = false;
 
       UINT adapterIndex = 0;
       while (true)
@@ -5752,6 +5754,23 @@ DWORD IGraphicsWin::OnVBlankRun()
 
           DXGI_OUTPUT_DESC desc{};
           hr = candidate->GetDesc(&desc);
+          LUID candidateAdapterLuid{};
+          bool candidateHasAdapterLuid = false;
+          if (SUCCEEDED(hr))
+          {
+            IDXGIAdapter* parent = nullptr;
+            if (SUCCEEDED(candidate->GetParent(__uuidof(IDXGIAdapter), reinterpret_cast<void**>(&parent))) && parent)
+            {
+              DXGI_ADAPTER_DESC adapterDesc{};
+              if (SUCCEEDED(parent->GetDesc(&adapterDesc)))
+              {
+                candidateAdapterLuid = adapterDesc.AdapterLuid;
+                candidateHasAdapterLuid = true;
+              }
+              parent->Release();
+            }
+          }
+
           bool keepCandidate = false;
           if (SUCCEEDED(hr) && targetMonitor && desc.Monitor == targetMonitor)
           {
@@ -5760,8 +5779,16 @@ DWORD IGraphicsWin::OnVBlankRun()
             lstrcpynW(deviceName,
                       desc.DeviceName,
                       static_cast<int>(sizeof(deviceName) / sizeof(deviceName[0])));
-            adapterLuid = desc.AdapterLuid;
-            hasAdapterLuid = true;
+            if (candidateHasAdapterLuid)
+            {
+              adapterLuid = candidateAdapterLuid;
+              hasAdapterLuid = true;
+            }
+            else
+            {
+              adapterLuid = {};
+              hasAdapterLuid = false;
+            }
             hasVidPnSourceId = false;
             EnsureVidPnSourceId();
             if (preferredOutput)
@@ -5770,10 +5797,13 @@ DWORD IGraphicsWin::OnVBlankRun()
             return true;
           }
 
-          if (SUCCEEDED(hr) && hasPreferredLuid && EqualLuid(desc.AdapterLuid, preferredLuid) && !preferredOutput)
+          if (SUCCEEDED(hr) && candidateHasAdapterLuid && hasPreferredLuid
+              && EqualLuid(candidateAdapterLuid, preferredLuid) && !preferredOutput)
           {
             preferredOutput = candidate;
             preferredDesc = desc;
+            preferredAdapterLuid = candidateAdapterLuid;
+            preferredHasAdapterLuid = true;
             keepCandidate = true;
           }
 
@@ -5793,8 +5823,16 @@ DWORD IGraphicsWin::OnVBlankRun()
         lstrcpynW(deviceName,
                   preferredDesc.DeviceName,
                   static_cast<int>(sizeof(deviceName) / sizeof(deviceName[0])));
-        adapterLuid = preferredDesc.AdapterLuid;
-        hasAdapterLuid = true;
+        if (preferredHasAdapterLuid)
+        {
+          adapterLuid = preferredAdapterLuid;
+          hasAdapterLuid = true;
+        }
+        else
+        {
+          adapterLuid = {};
+          hasAdapterLuid = false;
+        }
         hasVidPnSourceId = false;
         EnsureVidPnSourceId();
         return true;

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -38,6 +38,7 @@
 #include <deque>
 #include <fstream>
 #include <mutex>
+#include <dxgi.h>
 #include <random>
 #include <sstream>
 #include <limits>
@@ -5507,6 +5508,170 @@ DWORD IGraphicsWin::OnVBlankRun()
   float rateFallback = 60.0f;
   int rateMS = (int)(1000.0f / rateFallback);
 
+  struct DxgiVBlankHelper
+  {
+    using CreateFactoryFn = HRESULT(WINAPI*)(REFIID, void**);
+
+    HMODULE module = nullptr;
+    CreateFactoryFn createFactory = nullptr;
+    IDXGIFactory1* factory = nullptr;
+    IDXGIOutput* output = nullptr;
+    HMONITOR monitor = nullptr;
+
+    ~DxgiVBlankHelper()
+    {
+      Cleanup();
+    }
+
+    void Cleanup()
+    {
+      ResetOutput();
+      if (module)
+      {
+        FreeLibrary(module);
+        module = nullptr;
+      }
+      createFactory = nullptr;
+    }
+
+    void ResetOutput()
+    {
+      if (output)
+      {
+        output->Release();
+        output = nullptr;
+      }
+      if (factory)
+      {
+        factory->Release();
+        factory = nullptr;
+      }
+      monitor = nullptr;
+    }
+
+    bool EnsureInitialized()
+    {
+      if (createFactory)
+        return true;
+
+      module = LoadLibraryW(L"dxgi.dll");
+      if (!module)
+        return false;
+
+      createFactory = reinterpret_cast<CreateFactoryFn>(GetProcAddress(module, "CreateDXGIFactory1"));
+      if (!createFactory)
+      {
+        Cleanup();
+        return false;
+      }
+
+      return true;
+    }
+
+    bool EnsureOutput(HWND window)
+    {
+      if (!EnsureInitialized())
+        return false;
+
+      HMONITOR targetMonitor = MonitorFromWindow(window, MONITOR_DEFAULTTONEAREST);
+      if (!targetMonitor)
+      {
+        ResetOutput();
+        return false;
+      }
+
+      if (output && monitor == targetMonitor)
+        return true;
+
+      ResetOutput();
+
+      IDXGIFactory1* newFactory = nullptr;
+      HRESULT hr = createFactory(__uuidof(IDXGIFactory1), reinterpret_cast<void**>(&newFactory));
+      if (FAILED(hr) || !newFactory)
+      {
+        return false;
+      }
+
+      factory = newFactory;
+
+      UINT adapterIndex = 0;
+      while (true)
+      {
+        IDXGIAdapter1* adapter = nullptr;
+        hr = factory->EnumAdapters1(adapterIndex++, &adapter);
+        if (hr == DXGI_ERROR_NOT_FOUND)
+          break;
+        if (FAILED(hr) || adapter == nullptr)
+        {
+          if (adapter)
+            adapter->Release();
+          continue;
+        }
+
+        UINT outputIndex = 0;
+        while (true)
+        {
+          IDXGIOutput* candidate = nullptr;
+          hr = adapter->EnumOutputs(outputIndex++, &candidate);
+          if (hr == DXGI_ERROR_NOT_FOUND)
+            break;
+          if (FAILED(hr) || candidate == nullptr)
+          {
+            if (candidate)
+              candidate->Release();
+            continue;
+          }
+
+          DXGI_OUTPUT_DESC desc;
+          hr = candidate->GetDesc(&desc);
+          if (SUCCEEDED(hr) && desc.Monitor == targetMonitor)
+          {
+            output = candidate;
+            monitor = targetMonitor;
+            adapter->Release();
+            return true;
+          }
+
+          candidate->Release();
+        }
+
+        adapter->Release();
+      }
+
+      ResetOutput();
+      return false;
+    }
+
+    bool Wait(HWND window, HRESULT* outHr)
+    {
+      if (outHr)
+        *outHr = S_OK;
+
+      if (!EnsureOutput(window) || !output)
+      {
+        if (outHr)
+          *outHr = E_FAIL;
+        return false;
+      }
+
+      HRESULT hr = output->WaitForVBlank();
+      if (outHr)
+        *outHr = hr;
+
+      if (FAILED(hr))
+      {
+        ResetOutput();
+        return false;
+      }
+
+      return true;
+    }
+  };
+
+  DxgiVBlankHelper dxgiHelper;
+  bool dxgiActive = false;
+  bool reportedDxgiFailure = false;
+
   // We need to try to load the module and entry points to wait on v blank.
   // if anything fails, we try to gracefully fallback to sleeping for some
   // number of milliseconds.
@@ -5525,8 +5690,65 @@ DWORD IGraphicsWin::OnVBlankRun()
     pWait = (D3DKMTWaitForVerticalBlankEvent)GetProcAddress((HMODULE)hInst, "D3DKMTWaitForVerticalBlankEvent");
   }
 
+  bool reportedSleepFallback = false;
+
+  auto waitWithDxgiFallback = [&](const char* stage) {
+    HRESULT waitHr = S_OK;
+    bool waited = dxgiHelper.Wait(mVBlankWindow, &waitHr);
+    if (waited)
+    {
+      if (!dxgiActive)
+      {
+        dxgiActive = true;
+        schedulerlog::LogEvent(schedulerlog::kCategoryVBlankDispatch,
+                               "vblank",
+                               schedulerlog::Severity::kInfo,
+                               {schedulerlog::MakeField("event", "dxgi_wait_active"),
+                                schedulerlog::MakeField("stage", stage)});
+      }
+      reportedDxgiFailure = false;
+      reportedSleepFallback = false;
+      return;
+    }
+
+    if (dxgiActive)
+    {
+      dxgiActive = false;
+      schedulerlog::LogEvent(schedulerlog::kCategoryVBlankDispatch,
+                             "vblank",
+                             schedulerlog::Severity::kWarn,
+                             {schedulerlog::MakeField("event", "dxgi_wait_lost"),
+                              schedulerlog::MakeField("stage", stage),
+                              schedulerlog::MakeField("hr", static_cast<int>(waitHr))});
+    }
+
+    if (!reportedDxgiFailure)
+    {
+      reportedDxgiFailure = true;
+      schedulerlog::LogEvent(schedulerlog::kCategoryVBlankDispatch,
+                             "vblank",
+                             schedulerlog::Severity::kWarn,
+                             {schedulerlog::MakeField("event", "dxgi_wait_failed"),
+                              schedulerlog::MakeField("stage", stage),
+                              schedulerlog::MakeField("hr", static_cast<int>(waitHr)),
+                              schedulerlog::MakeField("fallback", "sleep")});
+    }
+
+    if (!reportedSleepFallback)
+    {
+      schedulerlog::LogEvent(schedulerlog::kCategoryVBlankDispatch,
+                             "vblank",
+                             schedulerlog::Severity::kWarn,
+                             {schedulerlog::MakeField("event", "sleep_fallback"),
+                              schedulerlog::MakeField("stage", stage)});
+      reportedSleepFallback = true;
+    }
+
+    ::Sleep(rateMS);
+  };
+
   // if we don't get bindings to the methods we will fallback
-  // to a crummy sleep loop for now.  This is really just a last
+  // to a DXGI wait, otherwise to sleeping. This is really just a last
   // resort and not expected on modern hardware and Windows OS
   // installs.
   if (!pOpen || !pClose || !pWait)
@@ -5535,10 +5757,10 @@ DWORD IGraphicsWin::OnVBlankRun()
                            "vblank",
                            schedulerlog::Severity::kInfo,
                            {schedulerlog::MakeField("event", "d3dkmt_missing"),
-                            schedulerlog::MakeField("fallback", "sleep")});
+                            schedulerlog::MakeField("fallback", "dxgi")});
     while (mVBlankShutdown == false)
     {
-      ::Sleep(rateMS);
+      waitWithDxgiFallback("d3dkmt_missing");
       VBlankNotify();
     }
   }
@@ -5619,7 +5841,6 @@ DWORD IGraphicsWin::OnVBlankRun()
     // track of the adapter and reask for it if the device is lost.
     bool adapterIsOpen = false;
     DWORD adapterLastFailTime = 0;
-    bool reportedSleepFallback = false;
     _D3DKMT_WAITFORVERTICALBLANKEVENT we = {0};
 
     while (mVBlankShutdown == false)
@@ -5639,25 +5860,32 @@ DWORD IGraphicsWin::OnVBlankRun()
             we.hAdapter = openAdapterData.hAdapter;
             we.hDevice = 0;
             we.VidPnSourceId = openAdapterData.VidPnSourceId;
+            if (dxgiActive)
+            {
+              dxgiActive = false;
+              schedulerlog::LogEvent(schedulerlog::kCategoryVBlankDispatch,
+                                     "vblank",
+                                     schedulerlog::Severity::kInfo,
+                                     {schedulerlog::MakeField("event", "dxgi_wait_inactive"),
+                                      schedulerlog::MakeField("stage", "d3dkmt_open")});
+            }
+            reportedDxgiFailure = false;
             reportedSleepFallback = false;
           }
           else
           {
             // failed
             adapterLastFailTime = ::GetTickCount();
-            if (!reportedSleepFallback)
-            {
-              schedulerlog::LogEvent(schedulerlog::kCategoryVBlankDispatch,
-                                     "vblank",
-                                     schedulerlog::Severity::kWarn,
-                                     {schedulerlog::MakeField("event", "d3dkmt_open_retry"),
-                                      schedulerlog::MakeField("fallback", "sleep")});
-              reportedSleepFallback = true;
-            }
+            schedulerlog::LogEvent(schedulerlog::kCategoryVBlankDispatch,
+                                   "vblank",
+                                   schedulerlog::Severity::kWarn,
+                                   {schedulerlog::MakeField("event", "d3dkmt_open_retry"),
+                                    schedulerlog::MakeField("fallback", "dxgi")});
           }
         }
       }
 
+      bool waitFailed = false;
       if (adapterIsOpen)
       {
         // Finally we can wait on VBlank
@@ -5674,14 +5902,29 @@ DWORD IGraphicsWin::OnVBlankRun()
           ca.hAdapter = we.hAdapter;
           (*pClose)(&ca);
           adapterIsOpen = false;
+          waitFailed = true;
+        }
+        else
+        {
+          reportedDxgiFailure = false;
+          reportedSleepFallback = false;
+          if (dxgiActive)
+          {
+            dxgiActive = false;
+            schedulerlog::LogEvent(schedulerlog::kCategoryVBlankDispatch,
+                                   "vblank",
+                                   schedulerlog::Severity::kInfo,
+                                   {schedulerlog::MakeField("event", "dxgi_wait_inactive"),
+                                    schedulerlog::MakeField("stage", "d3dkmt_wait")});
+          }
+          VBlankNotify();
+          continue;
         }
       }
 
       // Temporary fallback for lost adapter or failed call.
-      if (!adapterIsOpen)
-      {
-        ::Sleep(rateMS);
-      }
+      const char* fallbackStage = waitFailed ? "d3dkmt_wait_failed" : "d3dkmt_retry";
+      waitWithDxgiFallback(fallbackStage);
 
       // notify logic
       VBlankNotify();

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -46,6 +46,7 @@
 #include <utility>
 #include <vector>
 #include <wininet.h>
+#include <windisplayconfig.h>
 
 #if defined __clang__
   #undef CCSIZEOF_STRUCT
@@ -5491,6 +5492,12 @@ typedef struct _D3DKMT_OPENADAPTERFROMGDIDISPLAYNAME
   D3DDDI_VIDEO_PRESENT_SOURCE_ID VidPnSourceId;
 } D3DKMT_OPENADAPTERFROMGDIDISPLAYNAME;
 
+typedef struct _D3DKMT_OPENADAPTERFROMLUID
+{
+  LUID AdapterLuid;
+  D3DKMT_HANDLE hAdapter;
+} D3DKMT_OPENADAPTERFROMLUID;
+
 typedef struct _D3DKMT_CLOSEADAPTER
 {
   D3DKMT_HANDLE hAdapter;
@@ -5506,6 +5513,7 @@ typedef struct _D3DKMT_WAITFORVERTICALBLANKEVENT
 // entry points
 typedef NTSTATUS(WINAPI* D3DKMTOpenAdapterFromHdc)(D3DKMT_OPENADAPTERFROMHDC* Arg1);
 typedef NTSTATUS(WINAPI* D3DKMTOpenAdapterFromGdiDisplayName)(D3DKMT_OPENADAPTERFROMGDIDISPLAYNAME* Arg1);
+typedef NTSTATUS(WINAPI* D3DKMTOpenAdapterFromLuid)(D3DKMT_OPENADAPTERFROMLUID* Arg1);
 typedef NTSTATUS(WINAPI* D3DKMTCloseAdapter)(const D3DKMT_CLOSEADAPTER* Arg1);
 typedef NTSTATUS(WINAPI* D3DKMTWaitForVerticalBlankEvent)(const D3DKMT_WAITFORVERTICALBLANKEVENT* Arg1);
 
@@ -5528,6 +5536,10 @@ DWORD IGraphicsWin::OnVBlankRun()
     IDXGIOutput* output = nullptr;
     HMONITOR monitor = nullptr;
     WCHAR deviceName[32] = {0};
+    LUID adapterLuid{};
+    bool hasAdapterLuid = false;
+    D3DDDI_VIDEO_PRESENT_SOURCE_ID vidPnSourceId = static_cast<D3DDDI_VIDEO_PRESENT_SOURCE_ID>(-1);
+    bool hasVidPnSourceId = false;
 
     ~DxgiVBlankHelper()
     {
@@ -5559,6 +5571,10 @@ DWORD IGraphicsWin::OnVBlankRun()
       }
       monitor = nullptr;
       deviceName[0] = L'\0';
+      hasAdapterLuid = false;
+      adapterLuid = {};
+      vidPnSourceId = static_cast<D3DDDI_VIDEO_PRESENT_SOURCE_ID>(-1);
+      hasVidPnSourceId = false;
     }
 
     bool EnsureInitialized()
@@ -5643,6 +5659,10 @@ DWORD IGraphicsWin::OnVBlankRun()
             lstrcpynW(deviceName,
                       desc.DeviceName,
                       static_cast<int>(sizeof(deviceName) / sizeof(deviceName[0])));
+            adapterLuid = desc.AdapterLuid;
+            hasAdapterLuid = true;
+            hasVidPnSourceId = false;
+            EnsureVidPnSourceId();
             adapter->Release();
             return true;
           }
@@ -5654,6 +5674,55 @@ DWORD IGraphicsWin::OnVBlankRun()
       }
 
       ResetOutput();
+      return false;
+    }
+
+    bool EnsureVidPnSourceId()
+    {
+      if (hasVidPnSourceId)
+        return true;
+
+      if (!hasAdapterLuid || deviceName[0] == L'\0')
+        return false;
+
+      UINT32 pathCount = 0;
+      UINT32 modeCount = 0;
+      if (GetDisplayConfigBufferSizes(QDC_ONLY_ACTIVE_PATHS, &pathCount, &modeCount) != ERROR_SUCCESS)
+        return false;
+
+      if (pathCount == 0 || modeCount == 0)
+        return false;
+
+      std::vector<DISPLAYCONFIG_PATH_INFO> paths(pathCount);
+      std::vector<DISPLAYCONFIG_MODE_INFO> modes(modeCount);
+      if (QueryDisplayConfig(QDC_ONLY_ACTIVE_PATHS, &pathCount, paths.data(), &modeCount, modes.data(), nullptr) != ERROR_SUCCESS)
+        return false;
+
+      for (UINT32 i = 0; i < pathCount; ++i)
+      {
+        const auto& path = paths[i];
+        if (path.sourceInfo.adapterId.HighPart != adapterLuid.HighPart
+            || path.sourceInfo.adapterId.LowPart != adapterLuid.LowPart)
+        {
+          continue;
+        }
+
+        DISPLAYCONFIG_SOURCE_DEVICE_NAME sourceName{};
+        sourceName.header.type = DISPLAYCONFIG_DEVICE_INFO_GET_SOURCE_NAME;
+        sourceName.header.size = sizeof(sourceName);
+        sourceName.header.adapterId = path.sourceInfo.adapterId;
+        sourceName.header.id = path.sourceInfo.id;
+        if (DisplayConfigGetDeviceInfo(&sourceName.header) != ERROR_SUCCESS)
+          continue;
+
+        if (lstrcmpiW(sourceName.viewGdiDeviceName, deviceName) == 0)
+        {
+          vidPnSourceId = static_cast<D3DDDI_VIDEO_PRESENT_SOURCE_ID>(path.sourceInfo.id);
+          hasVidPnSourceId = true;
+          return true;
+        }
+      }
+
       return false;
     }
 
@@ -5685,6 +5754,22 @@ DWORD IGraphicsWin::OnVBlankRun()
     const WCHAR* DeviceName() const
     {
       return deviceName[0] != L'\0' ? deviceName : nullptr;
+    }
+
+    bool AdapterLuid(LUID& luidOut) const
+    {
+      if (!hasAdapterLuid)
+        return false;
+      luidOut = adapterLuid;
+      return true;
+    }
+
+    bool VidPnSourceId(D3DDDI_VIDEO_PRESENT_SOURCE_ID& sourceIdOut)
+    {
+      if (!hasVidPnSourceId && !EnsureVidPnSourceId())
+        return false;
+      sourceIdOut = vidPnSourceId;
+      return hasVidPnSourceId;
     }
   };
 
@@ -5792,6 +5877,7 @@ DWORD IGraphicsWin::OnVBlankRun()
 
   D3DKMTOpenAdapterFromHdc pOpen = nullptr;
   D3DKMTOpenAdapterFromGdiDisplayName pOpenFromDisplay = nullptr;
+  D3DKMTOpenAdapterFromLuid pOpenFromLuid = nullptr;
   D3DKMTCloseAdapter pClose = nullptr;
   D3DKMTWaitForVerticalBlankEvent pWait = nullptr;
   HINSTANCE hInst = LoadLibraryW(L"gdi32.dll");
@@ -5801,6 +5887,7 @@ DWORD IGraphicsWin::OnVBlankRun()
     pOpen = (D3DKMTOpenAdapterFromHdc)GetProcAddress((HMODULE)hInst, "D3DKMTOpenAdapterFromHdc");
     pOpenFromDisplay =
       (D3DKMTOpenAdapterFromGdiDisplayName)GetProcAddress((HMODULE)hInst, "D3DKMTOpenAdapterFromGdiDisplayName");
+    pOpenFromLuid = (D3DKMTOpenAdapterFromLuid)GetProcAddress((HMODULE)hInst, "D3DKMTOpenAdapterFromLuid");
     pClose = (D3DKMTCloseAdapter)GetProcAddress((HMODULE)hInst, "D3DKMTCloseAdapter");
     pWait = (D3DKMTWaitForVerticalBlankEvent)GetProcAddress((HMODULE)hInst, "D3DKMTWaitForVerticalBlankEvent");
   }
@@ -6046,8 +6133,41 @@ DWORD IGraphicsWin::OnVBlankRun()
       return status;
     };
 
+    auto tryOpenAdapterForLuid = [&](const LUID* luid,
+                                     D3DKMT_OPENADAPTERFROMHDC& openAdapterData,
+                                     D3DDDI_VIDEO_PRESENT_SOURCE_ID sourceId) -> NTSTATUS {
+      if (!luid || !pOpenFromLuid)
+        return static_cast<NTSTATUS>(E_HANDLE);
+
+      D3DKMT_OPENADAPTERFROMLUID byLuid = {};
+      byLuid.AdapterLuid = *luid;
+      NTSTATUS status = (*pOpenFromLuid)(&byLuid);
+      if (status == S_OK)
+      {
+        openAdapterData = {};
+        openAdapterData.hAdapter = byLuid.hAdapter;
+        openAdapterData.AdapterLuid = byLuid.AdapterLuid;
+        openAdapterData.VidPnSourceId = sourceId;
+        schedulerlog::LogEvent(schedulerlog::kCategoryVBlankDispatch,
+                               "vblank",
+                               schedulerlog::Severity::kDebug,
+                               {schedulerlog::MakeField("event", "d3dkmt_open_luid_success"),
+                                schedulerlog::MakeField("fallback", "dxgi_dwm")});
+        return status;
+      }
+
+      schedulerlog::LogEvent(schedulerlog::kCategoryVBlankDispatch,
+                             "vblank",
+                             schedulerlog::Severity::kWarn,
+                             {schedulerlog::MakeField("event", "d3dkmt_open_luid_failed"),
+                              schedulerlog::MakeField("status", static_cast<int>(status)),
+                              schedulerlog::MakeField("fallback", "dxgi_dwm")});
+      return status;
+    };
+
     auto tryOpenAdapter = [&](D3DKMT_OPENADAPTERFROMHDC& openAdapterData) -> bool {
       dxgiHelper.EnsureOutput(mVBlankWindow);
+      dxgiHelper.EnsureVidPnSourceId();
       std::array<HWND, 5> searchWindows = {mVBlankWindow,
                                            GetAncestor(mVBlankWindow, GA_PARENT),
                                            GetAncestor(mVBlankWindow, GA_ROOT),
@@ -6080,6 +6200,14 @@ DWORD IGraphicsWin::OnVBlankRun()
       if (deviceName)
       {
         NTSTATUS status = tryOpenAdapterForDisplay(deviceName, openAdapterData);
+        if (status == S_OK)
+          return true;
+      }
+      LUID luid;
+      D3DDDI_VIDEO_PRESENT_SOURCE_ID sourceId = 0;
+      if (dxgiHelper.AdapterLuid(luid) && dxgiHelper.VidPnSourceId(sourceId))
+      {
+        NTSTATUS status = tryOpenAdapterForLuid(&luid, openAdapterData, sourceId);
         if (status == S_OK)
           return true;
       }

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -5668,9 +5668,103 @@ DWORD IGraphicsWin::OnVBlankRun()
     }
   };
 
+  struct DwmVBlankHelper
+  {
+    using DwmIsCompositionEnabledFn = HRESULT(WINAPI*)(BOOL*);
+    using DwmFlushFn = HRESULT(WINAPI*)();
+
+    static constexpr HRESULT kCompositionDisabled = static_cast<HRESULT>(0x80263001L);
+
+    HMODULE module = nullptr;
+    DwmIsCompositionEnabledFn isCompositionEnabled = nullptr;
+    DwmFlushFn flush = nullptr;
+
+    ~DwmVBlankHelper()
+    {
+      Cleanup();
+    }
+
+    void Cleanup()
+    {
+      if (module)
+      {
+        FreeLibrary(module);
+        module = nullptr;
+      }
+      isCompositionEnabled = nullptr;
+      flush = nullptr;
+    }
+
+    bool EnsureInitialized()
+    {
+      if (flush)
+        return true;
+
+      module = LoadLibraryW(L"dwmapi.dll");
+      if (!module)
+        return false;
+
+      isCompositionEnabled = reinterpret_cast<DwmIsCompositionEnabledFn>(GetProcAddress(module, "DwmIsCompositionEnabled"));
+      flush = reinterpret_cast<DwmFlushFn>(GetProcAddress(module, "DwmFlush"));
+      if (!flush)
+      {
+        Cleanup();
+        return false;
+      }
+
+      return true;
+    }
+
+    bool Wait(bool* compositionEnabledOut, HRESULT* outHr)
+    {
+      if (compositionEnabledOut)
+        *compositionEnabledOut = false;
+      if (outHr)
+        *outHr = S_OK;
+
+      if (!EnsureInitialized())
+      {
+        if (outHr)
+          *outHr = E_FAIL;
+        return false;
+      }
+
+      BOOL compositionEnabled = TRUE;
+      if (isCompositionEnabled)
+      {
+        HRESULT compHr = isCompositionEnabled(&compositionEnabled);
+        if (FAILED(compHr))
+        {
+          compositionEnabled = TRUE;
+        }
+      }
+
+      HRESULT hr = flush();
+      if (outHr)
+        *outHr = hr;
+
+      if (FAILED(hr))
+      {
+        if (hr == kCompositionDisabled)
+        {
+          compositionEnabled = FALSE;
+        }
+        return false;
+      }
+
+      if (compositionEnabledOut)
+        *compositionEnabledOut = compositionEnabled != FALSE;
+
+      return true;
+    }
+  };
+
   DxgiVBlankHelper dxgiHelper;
+  DwmVBlankHelper dwmHelper;
   bool dxgiActive = false;
+  bool dwmActive = false;
   bool reportedDxgiFailure = false;
+  bool reportedDwmFailure = false;
 
   // We need to try to load the module and entry points to wait on v blank.
   // if anything fails, we try to gracefully fallback to sleeping for some
@@ -5692,7 +5786,7 @@ DWORD IGraphicsWin::OnVBlankRun()
 
   bool reportedSleepFallback = false;
 
-  auto waitWithDxgiFallback = [&](const char* stage) {
+  auto waitWithFallback = [&](const char* stage) {
     HRESULT waitHr = S_OK;
     bool waited = dxgiHelper.Wait(mVBlankWindow, &waitHr);
     if (waited)
@@ -5707,7 +5801,17 @@ DWORD IGraphicsWin::OnVBlankRun()
                                 schedulerlog::MakeField("stage", stage)});
       }
       reportedDxgiFailure = false;
+      reportedDwmFailure = false;
       reportedSleepFallback = false;
+      if (dwmActive)
+      {
+        dwmActive = false;
+        schedulerlog::LogEvent(schedulerlog::kCategoryVBlankDispatch,
+                               "vblank",
+                               schedulerlog::Severity::kInfo,
+                               {schedulerlog::MakeField("event", "dwm_wait_inactive"),
+                                schedulerlog::MakeField("stage", stage)});
+      }
       return;
     }
 
@@ -5734,6 +5838,49 @@ DWORD IGraphicsWin::OnVBlankRun()
                               schedulerlog::MakeField("fallback", "sleep")});
     }
 
+    bool compositionEnabled = false;
+    HRESULT dwmHr = S_OK;
+    bool dwmWaited = dwmHelper.Wait(&compositionEnabled, &dwmHr);
+    if (dwmWaited)
+    {
+      if (!dwmActive)
+      {
+        dwmActive = true;
+        schedulerlog::LogEvent(schedulerlog::kCategoryVBlankDispatch,
+                               "vblank",
+                               schedulerlog::Severity::kInfo,
+                               {schedulerlog::MakeField("event", "dwm_wait_active"),
+                                schedulerlog::MakeField("stage", stage),
+                                schedulerlog::MakeField("composition", compositionEnabled)});
+      }
+      reportedDwmFailure = false;
+      reportedSleepFallback = false;
+      return;
+    }
+
+    if (dwmActive)
+    {
+      dwmActive = false;
+      schedulerlog::LogEvent(schedulerlog::kCategoryVBlankDispatch,
+                             "vblank",
+                             schedulerlog::Severity::kWarn,
+                             {schedulerlog::MakeField("event", "dwm_wait_lost"),
+                              schedulerlog::MakeField("stage", stage),
+                              schedulerlog::MakeField("hr", static_cast<int>(dwmHr))});
+    }
+
+    if (!reportedDwmFailure)
+    {
+      reportedDwmFailure = true;
+      schedulerlog::LogEvent(schedulerlog::kCategoryVBlankDispatch,
+                             "vblank",
+                             schedulerlog::Severity::kWarn,
+                             {schedulerlog::MakeField("event", "dwm_wait_failed"),
+                              schedulerlog::MakeField("stage", stage),
+                              schedulerlog::MakeField("hr", static_cast<int>(dwmHr)),
+                              schedulerlog::MakeField("fallback", "sleep")});
+    }
+
     if (!reportedSleepFallback)
     {
       schedulerlog::LogEvent(schedulerlog::kCategoryVBlankDispatch,
@@ -5757,10 +5904,10 @@ DWORD IGraphicsWin::OnVBlankRun()
                            "vblank",
                            schedulerlog::Severity::kInfo,
                            {schedulerlog::MakeField("event", "d3dkmt_missing"),
-                            schedulerlog::MakeField("fallback", "dxgi")});
+                            schedulerlog::MakeField("fallback", "dxgi_dwm")});
     while (mVBlankShutdown == false)
     {
-      waitWithDxgiFallback("d3dkmt_missing");
+      waitWithFallback("d3dkmt_missing");
       VBlankNotify();
     }
   }
@@ -5869,7 +6016,17 @@ DWORD IGraphicsWin::OnVBlankRun()
                                      {schedulerlog::MakeField("event", "dxgi_wait_inactive"),
                                       schedulerlog::MakeField("stage", "d3dkmt_open")});
             }
+            if (dwmActive)
+            {
+              dwmActive = false;
+              schedulerlog::LogEvent(schedulerlog::kCategoryVBlankDispatch,
+                                     "vblank",
+                                     schedulerlog::Severity::kInfo,
+                                     {schedulerlog::MakeField("event", "dwm_wait_inactive"),
+                                      schedulerlog::MakeField("stage", "d3dkmt_open")});
+            }
             reportedDxgiFailure = false;
+            reportedDwmFailure = false;
             reportedSleepFallback = false;
           }
           else
@@ -5880,7 +6037,7 @@ DWORD IGraphicsWin::OnVBlankRun()
                                    "vblank",
                                    schedulerlog::Severity::kWarn,
                                    {schedulerlog::MakeField("event", "d3dkmt_open_retry"),
-                                    schedulerlog::MakeField("fallback", "dxgi")});
+                                    schedulerlog::MakeField("fallback", "dxgi_dwm")});
           }
         }
       }
@@ -5917,6 +6074,15 @@ DWORD IGraphicsWin::OnVBlankRun()
                                    {schedulerlog::MakeField("event", "dxgi_wait_inactive"),
                                     schedulerlog::MakeField("stage", "d3dkmt_wait")});
           }
+          if (dwmActive)
+          {
+            dwmActive = false;
+            schedulerlog::LogEvent(schedulerlog::kCategoryVBlankDispatch,
+                                   "vblank",
+                                   schedulerlog::Severity::kInfo,
+                                   {schedulerlog::MakeField("event", "dwm_wait_inactive"),
+                                    schedulerlog::MakeField("stage", "d3dkmt_wait")});
+          }
           VBlankNotify();
           continue;
         }
@@ -5924,7 +6090,7 @@ DWORD IGraphicsWin::OnVBlankRun()
 
       // Temporary fallback for lost adapter or failed call.
       const char* fallbackStage = waitFailed ? "d3dkmt_wait_failed" : "d3dkmt_retry";
-      waitWithDxgiFallback(fallbackStage);
+      waitWithFallback(fallbackStage);
 
       // notify logic
       VBlankNotify();

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -6599,7 +6599,21 @@ void IGraphicsWin::VBlankNotify()
   const int pendingPaints = mInstancePaintBudget.PendingPaints();
   if (pendingPaints > 0)
   {
-    return;
+    // Keep track of the latest VBlank index so the UI thread can drain to the freshest tick,
+    // but continue on to queue a dispatch instead of suppressing updates while a paint is in
+    // flight. This avoids multi-frame gaps when WM_PAINT latency is high.
+    DWORD observed = mPendingSyncVBlank.load(std::memory_order_acquire);
+    while (observed < latestCount
+           && !mPendingSyncVBlank.compare_exchange_weak(observed,
+                                                        latestCount,
+                                                        std::memory_order_acq_rel,
+                                                        std::memory_order_acquire))
+    {
+    }
+  }
+  else
+  {
+    mPendingSyncVBlank.store(0, std::memory_order_release);
   }
 
   if (mVBlankPaused.load(std::memory_order_acquire))
@@ -6628,8 +6642,6 @@ void IGraphicsWin::VBlankNotify()
     }
     return;
   }
-
-  mPendingSyncVBlank.store(0, std::memory_order_release);
 
   if (!VBlankDispatchWorker::Instance().QueueDispatch(subscription, latestCount))
   {

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -5531,18 +5531,95 @@ DWORD IGraphicsWin::OnVBlankRun()
   // installs.
   if (!pOpen || !pClose || !pWait)
   {
+    schedulerlog::LogEvent(schedulerlog::kCategoryVBlankDispatch,
+                           "vblank",
+                           schedulerlog::Severity::kInfo,
+                           {schedulerlog::MakeField("event", "d3dkmt_missing"),
+                            schedulerlog::MakeField("fallback", "sleep")});
     while (mVBlankShutdown == false)
     {
-      Sleep(rateMS);
+      ::Sleep(rateMS);
       VBlankNotify();
     }
   }
   else
   {
+    auto logAdapterOpenFailure = [&](const char* stage, NTSTATUS status, HWND window) {
+      schedulerlog::LogEvent(schedulerlog::kCategoryVBlankDispatch,
+                             "vblank",
+                             schedulerlog::Severity::kWarn,
+                             {schedulerlog::MakeField("event", stage),
+                              schedulerlog::MakeField("status", static_cast<int>(status)),
+                              schedulerlog::MakeField("window", static_cast<uint64_t>(reinterpret_cast<uintptr_t>(window)))});
+    };
+
+    auto tryOpenAdapterForWindow = [&](HWND window, D3DKMT_OPENADAPTERFROMHDC& openAdapterData) -> NTSTATUS {
+      if (window == nullptr)
+        return static_cast<NTSTATUS>(E_HANDLE);
+
+      HDC hDC = GetDC(window);
+      if (hDC == nullptr)
+      {
+        logAdapterOpenFailure("d3dkmt_getdc_failed", static_cast<NTSTATUS>(E_HANDLE), window);
+        return static_cast<NTSTATUS>(E_HANDLE);
+      }
+
+      openAdapterData = {};
+      openAdapterData.hDc = hDC;
+      NTSTATUS status = (*pOpen)(&openAdapterData);
+      ReleaseDC(window, hDC);
+      if (status != S_OK)
+      {
+        logAdapterOpenFailure("d3dkmt_open_failed", status, window);
+      }
+      else
+      {
+        schedulerlog::LogEvent(schedulerlog::kCategoryVBlankDispatch,
+                               "vblank",
+                               schedulerlog::Severity::kDebug,
+                               {schedulerlog::MakeField("event", "d3dkmt_open_success"),
+                                schedulerlog::MakeField("window", static_cast<uint64_t>(reinterpret_cast<uintptr_t>(window)))});
+      }
+      return status;
+    };
+
+    auto tryOpenAdapter = [&](D3DKMT_OPENADAPTERFROMHDC& openAdapterData) -> bool {
+      std::array<HWND, 5> searchWindows = {mVBlankWindow,
+                                           GetAncestor(mVBlankWindow, GA_PARENT),
+                                           GetAncestor(mVBlankWindow, GA_ROOT),
+                                           GetAncestor(mVBlankWindow, GA_ROOTOWNER),
+                                           GetDesktopWindow()};
+
+      for (size_t i = 0; i < searchWindows.size(); ++i)
+      {
+        HWND window = searchWindows[i];
+        if (!window)
+          continue;
+
+        bool alreadyTried = false;
+        for (size_t j = 0; j < i; ++j)
+        {
+          if (searchWindows[j] == window)
+          {
+            alreadyTried = true;
+            break;
+          }
+        }
+        if (alreadyTried)
+          continue;
+
+        NTSTATUS status = tryOpenAdapterForWindow(window, openAdapterData);
+        if (status == S_OK)
+          return true;
+      }
+      return false;
+    };
+
     // we have a good set of functions to call.  We need to keep
     // track of the adapter and reask for it if the device is lost.
     bool adapterIsOpen = false;
     DWORD adapterLastFailTime = 0;
+    bool reportedSleepFallback = false;
     _D3DKMT_WAITFORVERTICALBLANKEVENT we = {0};
 
     while (mVBlankShutdown == false)
@@ -5554,10 +5631,7 @@ DWORD IGraphicsWin::OnVBlankRun()
         {
           // try to get adapter
           D3DKMT_OPENADAPTERFROMHDC openAdapterData = {0};
-          HDC hDC = GetDC(mVBlankWindow);
-          openAdapterData.hDc = hDC;
-          NTSTATUS status = (*pOpen)(&openAdapterData);
-          if (status == S_OK)
+          if (tryOpenAdapter(openAdapterData))
           {
             // success, setup wait request parameters.
             adapterLastFailTime = 0;
@@ -5565,13 +5639,22 @@ DWORD IGraphicsWin::OnVBlankRun()
             we.hAdapter = openAdapterData.hAdapter;
             we.hDevice = 0;
             we.VidPnSourceId = openAdapterData.VidPnSourceId;
+            reportedSleepFallback = false;
           }
           else
           {
             // failed
             adapterLastFailTime = ::GetTickCount();
+            if (!reportedSleepFallback)
+            {
+              schedulerlog::LogEvent(schedulerlog::kCategoryVBlankDispatch,
+                                     "vblank",
+                                     schedulerlog::Severity::kWarn,
+                                     {schedulerlog::MakeField("event", "d3dkmt_open_retry"),
+                                      schedulerlog::MakeField("fallback", "sleep")});
+              reportedSleepFallback = true;
+            }
           }
-          DeleteDC(hDC);
         }
       }
 
@@ -5582,6 +5665,11 @@ DWORD IGraphicsWin::OnVBlankRun()
         if (status != S_OK)
         {
           // failed, close now and try again on the next pass.
+          schedulerlog::LogEvent(schedulerlog::kCategoryVBlankDispatch,
+                                 "vblank",
+                                 schedulerlog::Severity::kWarn,
+                                 {schedulerlog::MakeField("event", "d3dkmt_wait_failed"),
+                                  schedulerlog::MakeField("status", static_cast<int>(status))});
           _D3DKMT_CLOSEADAPTER ca;
           ca.hAdapter = we.hAdapter;
           (*pClose)(&ca);

--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -218,6 +218,10 @@ private:
   void DestroyVulkanContext();
   void ActivateVulkanContext();
   void DeactivateVulkanContext();
+  void UpdateVulkanAdapterIdentity(const VkPhysicalDeviceIDProperties& idProps);
+  void ClearVulkanAdapterIdentity();
+  bool GetVulkanAdapterLuid(LUID& luidOut) const;
+  uint32_t GetVulkanAdapterNodeMask() const;
   WinVulkanDeviceCoordinator mVulkanDeviceCoordinator;
   uint64_t mVulkanDeviceGeneration = 0;
   VkInstance mVkInstance = VK_NULL_HANDLE;
@@ -233,6 +237,9 @@ private:
   std::vector<VkImage> mVkSwapchainImages;
   VkFormat mVkFormat = VK_FORMAT_B8G8R8A8_UNORM;
   VkImageUsageFlags mVkSwapchainUsageFlags = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+  std::atomic<uint64_t> mVulkanAdapterLuidValue{0};
+  std::atomic<bool> mVulkanAdapterLuidValid{false};
+  std::atomic<uint32_t> mVulkanAdapterNodeMask{0};
 #endif
 
 #ifdef IGRAPHICS_GL

--- a/IGraphics/Platforms/SchedulerLogging.h
+++ b/IGraphics/Platforms/SchedulerLogging.h
@@ -24,7 +24,11 @@ enum class Verbosity
 };
 
 #ifndef IGRAPHICS_SCHED_LOG_VERBOSITY
-  #define IGRAPHICS_SCHED_LOG_VERBOSITY 2
+  #if defined(NDEBUG)
+    #define IGRAPHICS_SCHED_LOG_VERBOSITY 2
+  #else
+    #define IGRAPHICS_SCHED_LOG_VERBOSITY 3
+  #endif
 #endif
 
 constexpr Verbosity kConfiguredVerbosity =


### PR DESCRIPTION
## Summary
- create a dedicated Vulkan semaphore so Skia submits signal completion before presentation waits on the render-finished semaphore
- cleanly create and destroy the Skia submit semaphore during view lifecycle and gate EndFrame on both semaphores being available
- harden the Windows VBlank thread by fixing DC cleanup, probing parent/root windows when opening the adapter, and logging when falling back to the sleep-based path

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e2d352f5688320b93b75db933d53e7