### PR TITLE
Track last drawn control bounds when invalidating dirty regions

### DIFF
--- a/IGraphics/IControl.cpp
+++ b/IGraphics/IControl.cpp
@@ -82,6 +82,7 @@ using namespace igraphics;
 
 IControl::IControl(const IRECT& bounds, int paramIdx, IActionFunction aF)
 : mRECT(bounds)
+, mLastDrawRECT(bounds)
 , mTargetRECT(bounds)
 , mActionFunc(aF)
 {
@@ -90,6 +91,7 @@ IControl::IControl(const IRECT& bounds, int paramIdx, IActionFunction aF)
 
 IControl::IControl(const IRECT& bounds, const std::initializer_list<int>& params, IActionFunction aF)
 : mRECT(bounds)
+, mLastDrawRECT(bounds)
 , mTargetRECT(bounds)
 , mActionFunc(aF)
 {
@@ -101,9 +103,29 @@ IControl::IControl(const IRECT& bounds, const std::initializer_list<int>& params
 
 IControl::IControl(const IRECT& bounds, IActionFunction aF)
 : mRECT(bounds)
+, mLastDrawRECT(bounds)
 , mTargetRECT(bounds)
 , mActionFunc(aF)
 {
+}
+
+void IControl::AddDirtyArea(const IRECT& rect)
+{
+  if (rect.Empty())
+    return;
+
+  mDirtyBounds = mDirtyBounds.Empty() ? rect : mDirtyBounds.Union(rect);
+}
+
+void IControl::UpdateDirtyAreaForRectChange(const IRECT& previousBounds)
+{
+  if (previousBounds != mRECT)
+  {
+    mDirty = true;
+    AddDirtyArea(mLastDrawRECT);
+    AddDirtyArea(previousBounds);
+    AddDirtyArea(mRECT);
+  }
 }
 
 int IControl::GetParamIdx(int valIdx) const
@@ -201,9 +223,11 @@ void IControl::SetDirty(bool triggerAction, int valIdx)
 
   auto setValue = [this](int v) { SetValue(Clip(GetValue(v), 0.0, 1.0), v); };
   ForValIdx(valIdx, setValue);
-  
+
   mDirty = true;
-  
+  AddDirtyArea(mLastDrawRECT);
+  AddDirtyArea(mRECT);
+
   if (triggerAction)
   {
     auto paramUpdate = [this](int v)

--- a/IGraphics/IControl.h
+++ b/IGraphics/IControl.h
@@ -317,7 +317,14 @@ public:
 
   /** Set the rectangular draw area for this control, within the graphics context
    * @param bounds The control's bounds */
-  void SetRECT(const IRECT& bounds) { mRECT = bounds; mMouseIsOver = false; OnResize(); }
+  void SetRECT(const IRECT& bounds)
+  {
+    const IRECT previous = mRECT;
+    mRECT = bounds;
+    mMouseIsOver = false;
+    OnResize();
+    UpdateDirtyAreaForRectChange(previous);
+  }
   
   /** Get the rectangular mouse tracking target area, within the graphics context for this control
    * @return The control's target bounds within the graphics context */
@@ -329,7 +336,14 @@ public:
   
   /** Set BOTH the draw rect and the target area, within the graphics context for this control
    * @param bounds The control's new draw and target bounds within the graphics context */
-  void SetTargetAndDrawRECTs(const IRECT& bounds) { mRECT = mTargetRECT = bounds; mMouseIsOver = false; OnResize(); }
+  void SetTargetAndDrawRECTs(const IRECT& bounds)
+  {
+    const IRECT previous = mRECT;
+    mRECT = mTargetRECT = bounds;
+    mMouseIsOver = false;
+    OnResize();
+    UpdateDirtyAreaForRectChange(previous);
+  }
 
   /** Set the position of the control, preserving the width and height. This may need to be overriden if you maintain custom positioning data in your control
    * @param x the new x coordinate of the top left corner of the control
@@ -406,7 +420,12 @@ public:
   virtual void SetDirty(bool triggerAction = true, int valIdx = kNoValIdx);
 
   /* Set the control clean, i.e. Called by IGraphics draw loop after control has been drawn */
-  virtual void SetClean() { mDirty = false; }
+  virtual void SetClean()
+  {
+    mDirty = false;
+    mLastDrawRECT = mRECT;
+    mDirtyBounds.Clear();
+  }
 
   /* Called at each display refresh by the IGraphics draw loop, triggers the control's AnimationFunc if it is set */
   void Animate();
@@ -414,6 +433,8 @@ public:
   /** Called at each display refresh by the IGraphics draw loop, after IControl::Animate(), to determine if the control is marked as dirty. 
    * @return \c true if the control is marked dirty. */
   virtual bool IsDirty();
+
+  IRECT GetDirtyBounds() const { return mDirtyBounds.Empty() ? mRECT : mDirtyBounds; }
 
   /** Disable/enable default prompt for user input
    * @param disable Set true to disable prompt */
@@ -542,6 +563,7 @@ protected:
   }
   
   IRECT mRECT;
+  IRECT mLastDrawRECT;
   IRECT mTargetRECT;
   
   /** Controls can be grouped for hiding and showing panels */
@@ -583,6 +605,9 @@ protected:
 #endif
   
 private:
+  void AddDirtyArea(const IRECT& rect);
+  void UpdateDirtyAreaForRectChange(const IRECT& previousBounds);
+
   IContainerBase* mParent = nullptr;
   IGEditorDelegate* mDelegate = nullptr;
   IGraphics* mGraphics = nullptr;
@@ -594,6 +619,7 @@ private:
   std::vector<ParamTuple> mVals { {kNoParameter, 0.} };
   std::unordered_map<EGestureType, IGestureFunc> mGestureFuncs;
   EGestureType mLastGesture = EGestureType::Unknown;
+  IRECT mDirtyBounds;
 };
 
 #pragma mark - Base Controls

--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -920,7 +920,7 @@ bool IGraphics::IsDirty(IRECTList& rects)
     if (pControl->IsDirty())
     {
       // N.B padding outlines for single line outlines
-      auto rectToAdd = pControl->GetRECT().GetPadded(0.75);
+      auto rectToAdd = pControl->GetDirtyBounds().GetPadded(0.75);
       
       if (pControl->GetParent())
       {


### PR DESCRIPTION
## Summary
- record each control's last drawn bounds so dirty regions always include the previous location
- mark rectangle changes as dirty and union the last draw rect when accumulating dirty areas to repaint vacated pixels

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e35c8542388320a3d487623c39e9bd