### PR TITLE
Fix Vulkan swapchain image views for Skia surfaces

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -209,7 +209,7 @@ struct HasImageViewField : std::false_type
 };
 
 template <typename T>
-struct HasImageViewField<T, VoidT<decltype(std::declval<T&>().fImageView)>> : std::true_type
+struct HasImageViewField<T, VoidT<decltype(&T::fImageView)>> : std::true_type
 {
 };
 
@@ -310,20 +310,20 @@ VkImageView IGraphicsSkia::EnsureSwapchainImageView(uint32_t imageIndex, VkImage
   return cachedView;
 }
 
-sk_sp<SkSurface> IGraphicsSkia::EnsureSwapchainSurface(uint32_t imageIndex, int width, int height, const GrVkImageInfo& baseImageInfo)
+sk_sp<SkSurface> IGraphicsSkia::EnsureSwapchainSurface(uint32_t imageIndex, int width, int height, const GrVkImageInfo& imageInfo)
 {
-  GrVkImageInfo imageInfo = baseImageInfo;
+  GrVkImageInfo localInfo = imageInfo;
   if (imageIndex >= mVKSwapchainSurfaces.size())
   {
     mVKSwapchainSurfaces.resize(mVKSwapchainImages.size());
   }
 
-  VkImageView imageView = EnsureSwapchainImageView(imageIndex, imageInfo.fImage);
+  VkImageView imageView = EnsureSwapchainImageView(imageIndex, localInfo.fImage);
   if (imageView == VK_NULL_HANDLE)
     return nullptr;
 
-  SetImageView(imageInfo, imageView);
-  const VkImageView loggedImageView = GetImageView(imageInfo);
+  SetImageView(localInfo, imageView);
+  const VkImageView loggedImageView = GetImageView(localInfo);
 
   SkColorType colorType = kUnknown_SkColorType;
   switch (mVKSwapchainFormat)
@@ -345,7 +345,7 @@ sk_sp<SkSurface> IGraphicsSkia::EnsureSwapchainSurface(uint32_t imageIndex, int 
   {
     if (cachedSurface->width() == width && cachedSurface->height() == height)
     {
-      auto backendRT = GrBackendRenderTargets::MakeVk(width, height, imageInfo);
+      auto backendRT = GrBackendRenderTargets::MakeVk(width, height, localInfo);
       if (backendRT.isValid())
       {
         auto colorState = skgpu::MutableTextureStates::MakeVulkan(VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, mVKQueueFamily);
@@ -357,12 +357,12 @@ sk_sp<SkSurface> IGraphicsSkia::EnsureSwapchainSurface(uint32_t imageIndex, int 
     cachedSurface.reset();
   }
 
-  auto backendRT = GrBackendRenderTargets::MakeVk(width, height, imageInfo);
+  auto backendRT = GrBackendRenderTargets::MakeVk(width, height, localInfo);
   if (!backendRT.isValid() || colorType == kUnknown_SkColorType || !mGrContext->colorTypeSupportedAsSurface(colorType))
   {
     IGRAPHICS_VK_LOG("EnsureSwapchainSurface", "validation", vulkanlog::Severity::kError,
                          vulkanlog::MakeField("imageIndex", imageIndex),
-                          vulkanlog::MakeHandleField("image", vulkanlog::HandleToUint64(imageInfo.fImage)),
+                          vulkanlog::MakeHandleField("image", vulkanlog::HandleToUint64(localInfo.fImage)),
                           vulkanlog::MakeHandleField("imageView", vulkanlog::HandleToUint64(loggedImageView)),
                           vulkanlog::MakeField("width", width),
                           vulkanlog::MakeField("height", height));
@@ -378,14 +378,14 @@ sk_sp<SkSurface> IGraphicsSkia::EnsureSwapchainSurface(uint32_t imageIndex, int 
   {
     IGRAPHICS_VK_LOG("EnsureSwapchainSurface", "WrapBackendRenderTarget", vulkanlog::Severity::kError,
                          vulkanlog::MakeField("imageIndex", imageIndex),
-                          vulkanlog::MakeHandleField("image", vulkanlog::HandleToUint64(imageInfo.fImage)),
+                          vulkanlog::MakeHandleField("image", vulkanlog::HandleToUint64(localInfo.fImage)),
                           vulkanlog::MakeHandleField("imageView", vulkanlog::HandleToUint64(loggedImageView)));
     return nullptr;
   }
 
   IGRAPHICS_VK_LOG("EnsureSwapchainSurface", "created", vulkanlog::Severity::kDebug,
                        vulkanlog::MakeField("imageIndex", imageIndex),
-                        vulkanlog::MakeHandleField("image", vulkanlog::HandleToUint64(imageInfo.fImage)),
+                        vulkanlog::MakeHandleField("image", vulkanlog::HandleToUint64(localInfo.fImage)),
                         vulkanlog::MakeHandleField("imageView", vulkanlog::HandleToUint64(loggedImageView)),
                         vulkanlog::MakeField("width", width),
                         vulkanlog::MakeField("height", height));

--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -1080,17 +1080,20 @@ void IGraphicsSkia::OnViewInitialized(void* pContext)
   mVKQueueFamily = ctx->queueFamily;
   mVKSwapchainFormat = ctx->format;
   mVKSwapchainUsageFlags = ctx->usageFlags;
-  mVKSwapchainImages.clear();
-  if (ctx->swapchainImages)
   {
-    for (auto img : *ctx->swapchainImages)
-      mVKSwapchainImages.push_back(img);
+    std::lock_guard<std::mutex> lock(mVKSwapchainMutex);
+    mVKSwapchainImages.clear();
+    if (ctx->swapchainImages)
+    {
+      for (auto img : *ctx->swapchainImages)
+        mVKSwapchainImages.push_back(img);
+    }
+    mVKSwapchainImageViews.assign(mVKSwapchainImages.size(), VK_NULL_HANDLE);
+    mVKCurrentImage = kInvalidImageIndex;
+    mVKImageAvailableSemaphore = ctx->imageAvailableSemaphore;
+    mVKRenderFinishedSemaphore = ctx->renderFinishedSemaphore;
+    mVKInFlightFence = ctx->inFlightFence;
   }
-  mVKSwapchainImageViews.assign(mVKSwapchainImages.size(), VK_NULL_HANDLE);
-  mVKCurrentImage = kInvalidImageIndex;
-  mVKImageAvailableSemaphore = ctx->imageAvailableSemaphore;
-  mVKRenderFinishedSemaphore = ctx->renderFinishedSemaphore;
-  mVKInFlightFence = ctx->inFlightFence;
 
   skgpu::VulkanBackendContext backendContext = {};
   backendContext.fGetProc = [](const char* name, VkInstance instance, VkDevice device) {
@@ -1124,6 +1127,7 @@ void IGraphicsSkia::OnViewDestroyed()
   mMTLLayer = nullptr;
   mMTLDevice = nullptr;
 #elif defined IGRAPHICS_VULKAN
+  std::unique_lock<std::mutex> lock(mVKSwapchainMutex);
   if (mGrContext)
   {
     bool preparedForFlush = PrepareCurrentSwapchainImageForFlush();

--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -210,12 +210,81 @@ void ReleaseSkiaGpuResources(Context* context)
 // Wrap and cache a Skia surface for the given swap-chain image if the existing cache entry
 // is invalid. The cache is keyed by the image index so the frame loop can reuse immutable
 // SkSurfaces across frames without paying the wrap cost on every BeginFrame.
-sk_sp<SkSurface> IGraphicsSkia::EnsureSwapchainSurface(uint32_t imageIndex, int width, int height, const GrVkImageInfo& imageInfo)
+VkImageView IGraphicsSkia::EnsureSwapchainImageView(uint32_t imageIndex, VkImage image)
+{
+  if (imageIndex >= mVKSwapchainImages.size())
+  {
+    IGRAPHICS_VK_LOG("EnsureSwapchainImageView",
+                        "invalidIndex",
+                        vulkanlog::Severity::kError,
+                        vulkanlog::MakeField("imageIndex", imageIndex),
+                         vulkanlog::MakeField("imageCount", static_cast<uint64_t>(mVKSwapchainImages.size())));
+    return VK_NULL_HANDLE;
+  }
+
+  if (imageIndex >= mVKSwapchainImageViews.size())
+  {
+    mVKSwapchainImageViews.resize(mVKSwapchainImages.size(), VK_NULL_HANDLE);
+  }
+
+  auto& cachedView = mVKSwapchainImageViews[imageIndex];
+  if (cachedView != VK_NULL_HANDLE)
+    return cachedView;
+
+  if (mVKDevice == VK_NULL_HANDLE)
+    return VK_NULL_HANDLE;
+
+  VkImageViewCreateInfo viewInfo{};
+  viewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+  viewInfo.image = image;
+  viewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
+  viewInfo.format = mVKSwapchainFormat;
+  viewInfo.components.r = VK_COMPONENT_SWIZZLE_IDENTITY;
+  viewInfo.components.g = VK_COMPONENT_SWIZZLE_IDENTITY;
+  viewInfo.components.b = VK_COMPONENT_SWIZZLE_IDENTITY;
+  viewInfo.components.a = VK_COMPONENT_SWIZZLE_IDENTITY;
+  viewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+  viewInfo.subresourceRange.baseMipLevel = 0;
+  viewInfo.subresourceRange.levelCount = 1;
+  viewInfo.subresourceRange.baseArrayLayer = 0;
+  viewInfo.subresourceRange.layerCount = 1;
+
+  VkResult res = vkCreateImageView(mVKDevice, &viewInfo, nullptr, &cachedView);
+  if (res != VK_SUCCESS)
+  {
+    IGRAPHICS_VK_LOG("EnsureSwapchainImageView",
+                        "vkCreateImageView",
+                        vulkanlog::Severity::kError,
+                        vulkanlog::MakeField("vkResult", static_cast<int>(res)),
+                         vulkanlog::MakeField("imageIndex", imageIndex),
+                         vulkanlog::MakeHandleField("image", vulkanlog::HandleToUint64(image)));
+    cachedView = VK_NULL_HANDLE;
+  }
+  else
+  {
+    IGRAPHICS_VK_LOG("EnsureSwapchainImageView",
+                        "created",
+                        vulkanlog::Severity::kDebug,
+                        vulkanlog::MakeField("imageIndex", imageIndex),
+                         vulkanlog::MakeHandleField("image", vulkanlog::HandleToUint64(image)),
+                         vulkanlog::MakeHandleField("imageView", vulkanlog::HandleToUint64(cachedView)));
+  }
+
+  return cachedView;
+}
+
+sk_sp<SkSurface> IGraphicsSkia::EnsureSwapchainSurface(uint32_t imageIndex, int width, int height, GrVkImageInfo imageInfo)
 {
   if (imageIndex >= mVKSwapchainSurfaces.size())
   {
     mVKSwapchainSurfaces.resize(mVKSwapchainImages.size());
   }
+
+  VkImageView imageView = EnsureSwapchainImageView(imageIndex, imageInfo.fImage);
+  if (imageView == VK_NULL_HANDLE)
+    return nullptr;
+
+  imageInfo.fImageView = imageView;
 
   SkColorType colorType = kUnknown_SkColorType;
   switch (mVKSwapchainFormat)
@@ -255,6 +324,7 @@ sk_sp<SkSurface> IGraphicsSkia::EnsureSwapchainSurface(uint32_t imageIndex, int 
     IGRAPHICS_VK_LOG("EnsureSwapchainSurface", "validation", vulkanlog::Severity::kError,
                          vulkanlog::MakeField("imageIndex", imageIndex),
                           vulkanlog::MakeHandleField("image", vulkanlog::HandleToUint64(imageInfo.fImage)),
+                          vulkanlog::MakeHandleField("imageView", vulkanlog::HandleToUint64(imageInfo.fImageView)),
                           vulkanlog::MakeField("width", width),
                           vulkanlog::MakeField("height", height));
     return nullptr;
@@ -269,13 +339,15 @@ sk_sp<SkSurface> IGraphicsSkia::EnsureSwapchainSurface(uint32_t imageIndex, int 
   {
     IGRAPHICS_VK_LOG("EnsureSwapchainSurface", "WrapBackendRenderTarget", vulkanlog::Severity::kError,
                          vulkanlog::MakeField("imageIndex", imageIndex),
-                          vulkanlog::MakeHandleField("image", vulkanlog::HandleToUint64(imageInfo.fImage)));
+                          vulkanlog::MakeHandleField("image", vulkanlog::HandleToUint64(imageInfo.fImage)),
+                          vulkanlog::MakeHandleField("imageView", vulkanlog::HandleToUint64(imageInfo.fImageView)));
     return nullptr;
   }
 
   IGRAPHICS_VK_LOG("EnsureSwapchainSurface", "created", vulkanlog::Severity::kDebug,
                        vulkanlog::MakeField("imageIndex", imageIndex),
                         vulkanlog::MakeHandleField("image", vulkanlog::HandleToUint64(imageInfo.fImage)),
+                        vulkanlog::MakeHandleField("imageView", vulkanlog::HandleToUint64(imageInfo.fImageView)),
                         vulkanlog::MakeField("width", width),
                         vulkanlog::MakeField("height", height));
   return cachedSurface;
@@ -469,6 +541,17 @@ bool IGraphicsSkia::PrepareCurrentSwapchainImageForFlush()
     imageInfo.fLevelCount = 1;
     imageInfo.fCurrentQueueFamily = mVKQueueFamily;
 
+    imageInfo.fImageView = EnsureSwapchainImageView(mVKCurrentImage, swapImage);
+    if (imageInfo.fImageView == VK_NULL_HANDLE)
+    {
+      IGRAPHICS_VK_LOG("PrepareCurrentSwapchainImageForFlush",
+                          "ensureImageViewFailed",
+                          vulkanlog::Severity::kError,
+                          vulkanlog::MakeField("imageIndex", static_cast<uint32_t>(mVKCurrentImage)),
+                           vulkanlog::MakeHandleField("image", vulkanlog::HandleToUint64(swapImage)));
+      return false;
+    }
+
     const int width = mScreenSurface->width();
     const int height = mScreenSurface->height();
     auto backendRT = GrBackendRenderTargets::MakeVk(width, height, imageInfo);
@@ -492,6 +575,19 @@ bool IGraphicsSkia::PrepareCurrentSwapchainImageForFlush()
 
 void IGraphicsSkia::ResetVulkanSwapchainCaches()
 {
+  if (mVKDevice != VK_NULL_HANDLE)
+  {
+    for (auto& view : mVKSwapchainImageViews)
+    {
+      if (view != VK_NULL_HANDLE)
+      {
+        vkDestroyImageView(mVKDevice, view, nullptr);
+        view = VK_NULL_HANDLE;
+      }
+    }
+  }
+
+  mVKSwapchainImageViews.clear();
   mVKSwapchainSurfaces.clear();
   mScreenSurface.reset();
 }
@@ -990,6 +1086,7 @@ void IGraphicsSkia::OnViewInitialized(void* pContext)
     for (auto img : *ctx->swapchainImages)
       mVKSwapchainImages.push_back(img);
   }
+  mVKSwapchainImageViews.assign(mVKSwapchainImages.size(), VK_NULL_HANDLE);
   mVKCurrentImage = kInvalidImageIndex;
   mVKImageAvailableSemaphore = ctx->imageAvailableSemaphore;
   mVKRenderFinishedSemaphore = ctx->renderFinishedSemaphore;
@@ -1318,6 +1415,7 @@ void IGraphicsSkia::DrawResize()
         {
           mVKSwapchain = swapchain;
           mVKSwapchainImages = images;
+          mVKSwapchainImageViews.assign(mVKSwapchainImages.size(), VK_NULL_HANDLE);
           mVKSwapchainSurfaces.assign(mVKSwapchainImages.size(), nullptr);
           mVKImageLayouts.assign(mVKSwapchainImages.size(), VK_IMAGE_LAYOUT_UNDEFINED);
           mVKSwapchainFormat = format;
@@ -2005,6 +2103,19 @@ void IGraphicsSkia::EndFrame()
     imageInfo.fSampleCount = 1;
     imageInfo.fLevelCount = 1;
     imageInfo.fCurrentQueueFamily = mVKQueueFamily;
+
+    imageInfo.fImageView = EnsureSwapchainImageView(mVKCurrentImage, swapImage);
+    if (imageInfo.fImageView == VK_NULL_HANDLE)
+    {
+      IGRAPHICS_VK_LOG("EndFrame",
+                          "ensureImageViewFailed",
+                          vulkanlog::Severity::kError,
+                          vulkanlog::MakeField("imageIndex", static_cast<uint32_t>(mVKCurrentImage)),
+                           vulkanlog::MakeHandleField("image", vulkanlog::HandleToUint64(swapImage)));
+      mVKSkipFrame = true;
+      mVKCurrentImage = kInvalidImageIndex;
+      return;
+    }
 
     const int width = mScreenSurface->width();
     const int height = mScreenSurface->height();

--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -202,6 +202,43 @@ void ReleaseSkiaGpuResources(Context* context)
 
   ReleaseSkiaGpuResourcesImpl<Context>::Apply(context);
 }
+
+template <typename T, typename = void>
+struct HasImageViewField : std::false_type
+{
+};
+
+template <typename T>
+struct HasImageViewField<T, VoidT<decltype(std::declval<T&>().fImageView)>> : std::true_type
+{
+};
+
+template <typename ImageInfo>
+typename std::enable_if<HasImageViewField<ImageInfo>::value>::type
+SetImageView(ImageInfo& info, VkImageView view)
+{
+  info.fImageView = view;
+}
+
+template <typename ImageInfo>
+typename std::enable_if<!HasImageViewField<ImageInfo>::value>::type
+SetImageView(ImageInfo&, VkImageView)
+{
+}
+
+template <typename ImageInfo>
+typename std::enable_if<HasImageViewField<ImageInfo>::value, VkImageView>::type
+GetImageView(const ImageInfo& info)
+{
+  return info.fImageView;
+}
+
+template <typename ImageInfo>
+typename std::enable_if<!HasImageViewField<ImageInfo>::value, VkImageView>::type
+GetImageView(const ImageInfo&)
+{
+  return VK_NULL_HANDLE;
+}
 } // namespace
 #endif
 
@@ -273,8 +310,9 @@ VkImageView IGraphicsSkia::EnsureSwapchainImageView(uint32_t imageIndex, VkImage
   return cachedView;
 }
 
-sk_sp<SkSurface> IGraphicsSkia::EnsureSwapchainSurface(uint32_t imageIndex, int width, int height, GrVkImageInfo imageInfo)
+sk_sp<SkSurface> IGraphicsSkia::EnsureSwapchainSurface(uint32_t imageIndex, int width, int height, const GrVkImageInfo& baseImageInfo)
 {
+  GrVkImageInfo imageInfo = baseImageInfo;
   if (imageIndex >= mVKSwapchainSurfaces.size())
   {
     mVKSwapchainSurfaces.resize(mVKSwapchainImages.size());
@@ -284,7 +322,8 @@ sk_sp<SkSurface> IGraphicsSkia::EnsureSwapchainSurface(uint32_t imageIndex, int 
   if (imageView == VK_NULL_HANDLE)
     return nullptr;
 
-  imageInfo.fImageView = imageView;
+  SetImageView(imageInfo, imageView);
+  const VkImageView loggedImageView = GetImageView(imageInfo);
 
   SkColorType colorType = kUnknown_SkColorType;
   switch (mVKSwapchainFormat)
@@ -324,7 +363,7 @@ sk_sp<SkSurface> IGraphicsSkia::EnsureSwapchainSurface(uint32_t imageIndex, int 
     IGRAPHICS_VK_LOG("EnsureSwapchainSurface", "validation", vulkanlog::Severity::kError,
                          vulkanlog::MakeField("imageIndex", imageIndex),
                           vulkanlog::MakeHandleField("image", vulkanlog::HandleToUint64(imageInfo.fImage)),
-                          vulkanlog::MakeHandleField("imageView", vulkanlog::HandleToUint64(imageInfo.fImageView)),
+                          vulkanlog::MakeHandleField("imageView", vulkanlog::HandleToUint64(loggedImageView)),
                           vulkanlog::MakeField("width", width),
                           vulkanlog::MakeField("height", height));
     return nullptr;
@@ -340,14 +379,14 @@ sk_sp<SkSurface> IGraphicsSkia::EnsureSwapchainSurface(uint32_t imageIndex, int 
     IGRAPHICS_VK_LOG("EnsureSwapchainSurface", "WrapBackendRenderTarget", vulkanlog::Severity::kError,
                          vulkanlog::MakeField("imageIndex", imageIndex),
                           vulkanlog::MakeHandleField("image", vulkanlog::HandleToUint64(imageInfo.fImage)),
-                          vulkanlog::MakeHandleField("imageView", vulkanlog::HandleToUint64(imageInfo.fImageView)));
+                          vulkanlog::MakeHandleField("imageView", vulkanlog::HandleToUint64(loggedImageView)));
     return nullptr;
   }
 
   IGRAPHICS_VK_LOG("EnsureSwapchainSurface", "created", vulkanlog::Severity::kDebug,
                        vulkanlog::MakeField("imageIndex", imageIndex),
                         vulkanlog::MakeHandleField("image", vulkanlog::HandleToUint64(imageInfo.fImage)),
-                        vulkanlog::MakeHandleField("imageView", vulkanlog::HandleToUint64(imageInfo.fImageView)),
+                        vulkanlog::MakeHandleField("imageView", vulkanlog::HandleToUint64(loggedImageView)),
                         vulkanlog::MakeField("width", width),
                         vulkanlog::MakeField("height", height));
   return cachedSurface;
@@ -541,8 +580,8 @@ bool IGraphicsSkia::PrepareCurrentSwapchainImageForFlush()
     imageInfo.fLevelCount = 1;
     imageInfo.fCurrentQueueFamily = mVKQueueFamily;
 
-    imageInfo.fImageView = EnsureSwapchainImageView(mVKCurrentImage, swapImage);
-    if (imageInfo.fImageView == VK_NULL_HANDLE)
+    VkImageView imageView = EnsureSwapchainImageView(mVKCurrentImage, swapImage);
+    if (imageView == VK_NULL_HANDLE)
     {
       IGRAPHICS_VK_LOG("PrepareCurrentSwapchainImageForFlush",
                           "ensureImageViewFailed",
@@ -551,6 +590,8 @@ bool IGraphicsSkia::PrepareCurrentSwapchainImageForFlush()
                            vulkanlog::MakeHandleField("image", vulkanlog::HandleToUint64(swapImage)));
       return false;
     }
+
+    SetImageView(imageInfo, imageView);
 
     const int width = mScreenSurface->width();
     const int height = mScreenSurface->height();
@@ -2108,8 +2149,8 @@ void IGraphicsSkia::EndFrame()
     imageInfo.fLevelCount = 1;
     imageInfo.fCurrentQueueFamily = mVKQueueFamily;
 
-    imageInfo.fImageView = EnsureSwapchainImageView(mVKCurrentImage, swapImage);
-    if (imageInfo.fImageView == VK_NULL_HANDLE)
+    VkImageView imageView = EnsureSwapchainImageView(mVKCurrentImage, swapImage);
+    if (imageView == VK_NULL_HANDLE)
     {
       IGRAPHICS_VK_LOG("EndFrame",
                           "ensureImageViewFailed",
@@ -2120,6 +2161,8 @@ void IGraphicsSkia::EndFrame()
       mVKCurrentImage = kInvalidImageIndex;
       return;
     }
+
+    SetImageView(imageInfo, imageView);
 
     const int width = mScreenSurface->width();
     const int height = mScreenSurface->height();

--- a/IGraphics/Drawing/IGraphicsSkia.h
+++ b/IGraphics/Drawing/IGraphicsSkia.h
@@ -255,6 +255,7 @@ private:
   VkCommandBuffer mVKCommandBuffer = VK_NULL_HANDLE;
   uint32_t mVKQueueFamily = 0;
   std::vector<VkImage> mVKSwapchainImages;
+  std::vector<VkImageView> mVKSwapchainImageViews;
   std::vector<VkImageLayout> mVKImageLayouts;
   std::vector<sk_sp<SkSurface>> mVKSwapchainSurfaces;
   uint32_t mVKCurrentImage = kInvalidImageIndex;
@@ -272,7 +273,8 @@ private:
   bool PrepareCurrentSwapchainImageForFlush();
   void ResetVulkanSwapchainCaches();
   VkCommandBuffer EnsureVulkanCommandBuffer();
-  sk_sp<SkSurface> EnsureSwapchainSurface(uint32_t imageIndex, int width, int height, const GrVkImageInfo& imageInfo);
+  VkImageView EnsureSwapchainImageView(uint32_t imageIndex, VkImage image);
+  sk_sp<SkSurface> EnsureSwapchainSurface(uint32_t imageIndex, int width, int height, GrVkImageInfo imageInfo);
   bool AssertValidSwapchainImage(VkImage image, const char* context);
 #endif
 

--- a/IGraphics/Drawing/IGraphicsSkia.h
+++ b/IGraphics/Drawing/IGraphicsSkia.h
@@ -274,7 +274,7 @@ private:
   void ResetVulkanSwapchainCaches();
   VkCommandBuffer EnsureVulkanCommandBuffer();
   VkImageView EnsureSwapchainImageView(uint32_t imageIndex, VkImage image);
-  sk_sp<SkSurface> EnsureSwapchainSurface(uint32_t imageIndex, int width, int height, GrVkImageInfo imageInfo);
+  sk_sp<SkSurface> EnsureSwapchainSurface(uint32_t imageIndex, int width, int height, const GrVkImageInfo& imageInfo);
   bool AssertValidSwapchainImage(VkImage image, const char* context);
 #endif
 


### PR DESCRIPTION
## Summary
- ensure swapchain swapchain images have valid VkImageView handles before wrapping Skia surfaces
- destroy cached image views whenever swapchain caches are reset and recreate image view handles after resize/context init

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e67ee9a0608320ae8758c011850358