### PR TITLE
Fix Windows Vulkan screen scale rounding

### DIFF
--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -4205,8 +4205,11 @@ EMsgBoxResult IGraphicsWin::ShowMessageBox(const char* str, const char* title, E
 void* IGraphicsWin::OpenWindow(void* pParent)
 {
   mParentWnd = (HWND)pParent;
-  int screenScale = GetScaleForHWND(mParentWnd);
-  int x = 0, y = 0, w = WindowWidth() * screenScale, h = WindowHeight() * screenScale;
+  const float screenScale = GetScaleForHWND(mParentWnd);
+  int x = 0;
+  int y = 0;
+  int w = static_cast<int>(std::round(static_cast<float>(WindowWidth()) * screenScale));
+  int h = static_cast<int>(std::round(static_cast<float>(WindowHeight()) * screenScale));
 
   if (mPlugWnd)
   {


### PR DESCRIPTION
## Summary
- preserve fractional content-scale factors when opening the Windows editor window
- round the window dimensions after applying the host-provided scale factor so DPI scaling works with Vulkan/Skia

## Testing
- not run (Windows-specific change)


------
https://chatgpt.com/codex/tasks/task_b_68e76153e6a8832096b37759187f3297