### PR TITLE
Fix Windows Vulkan UI scaling when host resizes view

### DIFF
--- a/IGraphics/IGraphicsEditorDelegate.cpp
+++ b/IGraphics/IGraphicsEditorDelegate.cpp
@@ -12,6 +12,9 @@
 #include "IGraphics.h"
 #include "IControl.h"
 
+#include <algorithm>
+#include <cmath>
+
 using namespace iplug;
 using namespace igraphics;
 
@@ -61,10 +64,39 @@ void IGEditorDelegate::CloseWindow()
 
 void IGEditorDelegate::OnParentWindowResize(int width, int height)
 {
-  if (auto* pGraphics = GetUI()) 
+  if (auto* pGraphics = GetUI())
   {
-    const auto scale = pGraphics->GetPlatformWindowScale();
-    pGraphics->Resize(static_cast<int>(width / scale), static_cast<int>(height / scale), 1.0f, false);
+    const float screenScale = pGraphics->GetPlatformWindowScale();
+
+    if (screenScale <= 0.f)
+      return;
+
+    const float currentDrawScale = pGraphics->GetDrawScale();
+
+    if (pGraphics->GetResizerMode() == EUIResizerMode::Scale)
+    {
+      const int baseWidth = pGraphics->Width();
+      const int baseHeight = pGraphics->Height();
+
+      if (baseWidth <= 0 || baseHeight <= 0)
+        return;
+
+      if (width <= 0 || height <= 0)
+        return;
+
+      const float scaleX = static_cast<float>(width) / (static_cast<float>(baseWidth) * screenScale);
+      const float scaleY = static_cast<float>(height) / (static_cast<float>(baseHeight) * screenScale);
+      const float targetScale = std::max(0.f, std::min(scaleX, scaleY));
+
+      pGraphics->Resize(baseWidth, baseHeight, targetScale, false);
+    }
+    else
+    {
+      const int unscaledWidth = static_cast<int>(std::round(static_cast<float>(width) / screenScale));
+      const int unscaledHeight = static_cast<int>(std::round(static_cast<float>(height) / screenScale));
+
+      pGraphics->Resize(unscaledWidth, unscaledHeight, currentDrawScale, false);
+    }
   }
 }
 

--- a/IGraphics/IGraphicsEditorDelegate.cpp
+++ b/IGraphics/IGraphicsEditorDelegate.cpp
@@ -67,11 +67,10 @@ void IGEditorDelegate::OnParentWindowResize(int width, int height)
   if (auto* pGraphics = GetUI())
   {
     const float screenScale = pGraphics->GetPlatformWindowScale();
-
-    if (screenScale <= 0.f)
-      return;
-
     const float currentDrawScale = pGraphics->GetDrawScale();
+
+    if (screenScale <= 0.f || currentDrawScale <= 0.f)
+      return;
 
     if (pGraphics->GetResizerMode() == EUIResizerMode::Scale)
     {
@@ -84,18 +83,28 @@ void IGEditorDelegate::OnParentWindowResize(int width, int height)
       if (width <= 0 || height <= 0)
         return;
 
-      const float scaleX = static_cast<float>(width) / (static_cast<float>(baseWidth) * screenScale);
-      const float scaleY = static_cast<float>(height) / (static_cast<float>(baseHeight) * screenScale);
+      const float unscaledWidth = static_cast<float>(width) / screenScale;
+      const float unscaledHeight = static_cast<float>(height) / screenScale;
+      const float scaleX = unscaledWidth / static_cast<float>(baseWidth);
+      const float scaleY = unscaledHeight / static_cast<float>(baseHeight);
       const float targetScale = std::max(0.f, std::min(scaleX, scaleY));
 
       pGraphics->Resize(baseWidth, baseHeight, targetScale, false);
     }
     else
     {
-      const int unscaledWidth = static_cast<int>(std::round(static_cast<float>(width) / screenScale));
-      const int unscaledHeight = static_cast<int>(std::round(static_cast<float>(height) / screenScale));
+      const float invTotalScale = 1.f / (screenScale * currentDrawScale);
 
-      pGraphics->Resize(unscaledWidth, unscaledHeight, currentDrawScale, false);
+      if (!std::isfinite(invTotalScale))
+        return;
+
+      const int logicalWidth = static_cast<int>(std::round(static_cast<float>(width) * invTotalScale));
+      const int logicalHeight = static_cast<int>(std::round(static_cast<float>(height) * invTotalScale));
+
+      if (logicalWidth <= 0 || logicalHeight <= 0)
+        return;
+
+      pGraphics->Resize(logicalWidth, logicalHeight, currentDrawScale, false);
     }
   }
 }


### PR DESCRIPTION
## Summary
- keep the stored draw scale during host-driven resizes so UI scaling continues to work
- translate host resize notifications back into logical size or draw-scale changes based on the current resizer mode

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68e76153e6a8832096b37759187f3297