### PR TITLE
Fix Windows Vulkan DPI scaling

### DIFF
--- a/IGraphics/IGraphicsEditorDelegate.cpp
+++ b/IGraphics/IGraphicsEditorDelegate.cpp
@@ -12,6 +12,9 @@
 #include "IGraphics.h"
 #include "IControl.h"
 
+#include <algorithm>
+#include <cmath>
+
 using namespace iplug;
 using namespace igraphics;
 
@@ -61,7 +64,7 @@ void IGEditorDelegate::CloseWindow()
 
 void IGEditorDelegate::OnParentWindowResize(int width, int height)
 {
-  if (auto* pGraphics = GetUI()) 
+  if (auto* pGraphics = GetUI())
   {
     const auto scale = pGraphics->GetPlatformWindowScale();
     pGraphics->Resize(static_cast<int>(width / scale), static_cast<int>(height / scale), 1.0f, false);

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -4205,8 +4205,13 @@ EMsgBoxResult IGraphicsWin::ShowMessageBox(const char* str, const char* title, E
 void* IGraphicsWin::OpenWindow(void* pParent)
 {
   mParentWnd = (HWND)pParent;
-  int screenScale = GetScaleForHWND(mParentWnd);
-  int x = 0, y = 0, w = WindowWidth() * screenScale, h = WindowHeight() * screenScale;
+  const float screenScale = GetScaleForHWND(mParentWnd);
+  const int scaledWidth = static_cast<int>(std::round(static_cast<float>(WindowWidth()) * screenScale));
+  const int scaledHeight = static_cast<int>(std::round(static_cast<float>(WindowHeight()) * screenScale));
+  int x = 0;
+  int y = 0;
+  int w = scaledWidth;
+  int h = scaledHeight;
 
   if (mPlugWnd)
   {


### PR DESCRIPTION
## Summary
- restore the original host resize behaviour so draw scales are not forcefully recomputed
- preserve fractional Windows DPI factors when opening plugin windows so the Vulkan swapchain is created at the correct pixel resolution for sharp rendering

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e76153e6a8832096b37759187f3297