### PR TITLE
Force Skia Vulkan backend to use 1.5x DPI

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -147,6 +147,11 @@ float IGraphicsSkia::GetBackendPixelScale() const
 #endif
 }
 
+float IGraphicsSkia::GetBackingPixelScale() const
+{
+  return GetBackendPixelScale() * GetDrawScale();
+}
+
 #if defined IGRAPHICS_VULKAN
 namespace
 {
@@ -2778,6 +2783,8 @@ void IGraphicsSkia::SetClipRegion(const IRECT& r)
 
 APIBitmap* IGraphicsSkia::CreateAPIBitmap(int width, int height, float scale, double drawScale, bool cacheable, int MSAASampleCount)
 {
+  const float backendScale = GetBackendPixelScale();
+  (void) scale;
   sk_sp<SkSurface> surface;
   SkImageInfo info = SkImageInfo::MakeN32Premul(width, height);
 
@@ -2823,7 +2830,7 @@ APIBitmap* IGraphicsSkia::CreateAPIBitmap(int width, int height, float scale, do
 
   surface->getCanvas()->save();
 
-  return new Bitmap(std::move(surface), width, height, scale, drawScale);
+  return new Bitmap(std::move(surface), width, height, backendScale, drawScale);
 }
 
 void IGraphicsSkia::UpdateLayer() { mCanvas = mLayers.empty() ? mSurface->getCanvas() : mLayers.top()->GetAPIBitmap()->GetBitmap()->mSurface->getCanvas(); }

--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -138,6 +138,15 @@ using namespace igraphics;
 
 extern std::map<std::string, MTLTexturePtr> gTextureMap;
 
+float IGraphicsSkia::GetBackendPixelScale() const
+{
+#if defined IGRAPHICS_VULKAN
+  return 1.5f;
+#else
+  return GetScreenScale();
+#endif
+}
+
 #if defined IGRAPHICS_VULKAN
 namespace
 {
@@ -1306,8 +1315,8 @@ bool IGraphicsSkia::AssertValidSwapchainImage(VkImage image, const char* context
 void IGraphicsSkia::DrawResize()
 {
   ScopedGraphicsContext scopedGLContext{this};
-  auto w = static_cast<int>(std::ceil(static_cast<float>(WindowWidth()) * GetScreenScale()));
-  auto h = static_cast<int>(std::ceil(static_cast<float>(WindowHeight()) * GetScreenScale()));
+  auto w = static_cast<int>(std::ceil(static_cast<float>(WindowWidth()) * GetBackendPixelScale()));
+  auto h = static_cast<int>(std::ceil(static_cast<float>(WindowHeight()) * GetBackendPixelScale()));
 #if defined IGRAPHICS_VULKAN
   IGRAPHICS_VK_LOG("DrawResize",
                       "begin",
@@ -1581,8 +1590,8 @@ void IGraphicsSkia::BeginFrame()
 #if defined IGRAPHICS_GL
   if (mGrContext.get())
   {
-    int width = WindowWidth() * GetScreenScale();
-    int height = WindowHeight() * GetScreenScale();
+    int width = WindowWidth() * GetBackendPixelScale();
+    int height = WindowHeight() * GetBackendPixelScale();
 
     // Bind to the current main framebuffer
     int fbo = 0, samples = 0, stencilBits = 0;
@@ -1606,8 +1615,8 @@ void IGraphicsSkia::BeginFrame()
 #elif defined IGRAPHICS_METAL
   if (mGrContext.get())
   {
-    int width = WindowWidth() * GetScreenScale();
-    int height = WindowHeight() * GetScreenScale();
+    int width = WindowWidth() * GetBackendPixelScale();
+    int height = WindowHeight() * GetBackendPixelScale();
 
     id<CAMetalDrawable> drawable = [(CAMetalLayer*)mMTLLayer nextDrawable];
 
@@ -1635,8 +1644,8 @@ void IGraphicsSkia::BeginFrame()
       return;
     }
 
-    int width = WindowWidth() * GetScreenScale();
-    int height = WindowHeight() * GetScreenScale();
+    int width = WindowWidth() * GetBackendPixelScale();
+    int height = WindowHeight() * GetBackendPixelScale();
     if (mVKSubmissionPending)
     {
       IGRAPHICS_VK_LOG("BeginFrame",
@@ -2017,12 +2026,12 @@ void IGraphicsSkia::EndFrame()
   bmp.installPixels(pixmap);
   CGContext* pCGContext = (CGContextRef)GetPlatformContext();
   CGContextSaveGState(pCGContext);
-  CGContextScaleCTM(pCGContext, 1.0 / GetScreenScale(), 1.0 / GetScreenScale());
+  CGContextScaleCTM(pCGContext, 1.0 / GetBackendPixelScale(), 1.0 / GetBackendPixelScale());
   SkCGDrawBitmap(pCGContext, bmp, 0, 0);
   CGContextRestoreGState(pCGContext);
   #elif defined OS_WIN
-  auto w = WindowWidth() * GetScreenScale();
-  auto h = WindowHeight() * GetScreenScale();
+  auto w = WindowWidth() * GetBackendPixelScale();
+  auto h = WindowHeight() * GetBackendPixelScale();
   BITMAPINFO* bmpInfo = reinterpret_cast<BITMAPINFO*>(mSurfaceMemory.Get());
   HWND hWnd = (HWND)GetWindow();
   PAINTSTRUCT ps;

--- a/IGraphics/Drawing/IGraphicsSkia.h
+++ b/IGraphics/Drawing/IGraphicsSkia.h
@@ -197,6 +197,7 @@ protected:
   void DoDrawText(const IText& text, const char* str, const IRECT& bounds, const IBlend* pBlend) override;
 
   float GetBackendPixelScale() const;
+  float GetBackingPixelScale() const override;
 
   bool LoadAPIFont(const char* fontID, const PlatformFontPtr& font) override;
 

--- a/IGraphics/Drawing/IGraphicsSkia.h
+++ b/IGraphics/Drawing/IGraphicsSkia.h
@@ -196,6 +196,8 @@ protected:
   float DoMeasureText(const IText& text, const char* str, IRECT& bounds) const override;
   void DoDrawText(const IText& text, const char* str, const IRECT& bounds, const IBlend* pBlend) override;
 
+  float GetBackendPixelScale() const;
+
   bool LoadAPIFont(const char* fontID, const PlatformFontPtr& font) override;
 
   APIBitmap* LoadAPIBitmap(const char* fileNameOrResID, int scale, EResourceLocation location, const char* ext) override;


### PR DESCRIPTION
## Summary
- add a backend helper to override the pixel scale when the Skia renderer runs with Vulkan
- route all Skia drawing code paths through the helper so Vulkan rendering always uses a 1.5 device pixel ratio

## Testing
- not run (not supported on this platform)


------
https://chatgpt.com/codex/tasks/task_b_68e994e33c00832081938eeeae464e31