### PR TITLE
Prevent Vulkan draws during teardown

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -1169,16 +1169,26 @@ void IGraphicsSkia::OnViewDestroyed()
   mMTLDevice = nullptr;
 #elif defined IGRAPHICS_VULKAN
   std::unique_lock<std::mutex> lock(mVKSwapchainMutex);
+  const bool skipFlush = mVKTeardownPending;
+  mVKTeardownPending = false;
   if (mGrContext)
   {
-    bool preparedForFlush = PrepareCurrentSwapchainImageForFlush();
-    if (preparedForFlush)
+    bool preparedForFlush = false;
+    if (!skipFlush)
     {
-      mGrContext->flushAndSubmit();
+      preparedForFlush = PrepareCurrentSwapchainImageForFlush();
+      if (preparedForFlush)
+      {
+        mGrContext->flushAndSubmit();
+      }
+      else
+      {
+        IGRAPHICS_VK_LOG_SIMPLE("OnViewDestroyed", "skipFlushNoPreparedSwapchainImage", vulkanlog::Severity::kInfo);
+      }
     }
     else
     {
-      IGRAPHICS_VK_LOG_SIMPLE("OnViewDestroyed", "skipFlushNoPreparedSwapchainImage", vulkanlog::Severity::kInfo);
+      IGRAPHICS_VK_LOG_SIMPLE("OnViewDestroyed", "skipFlushTeardownPending", vulkanlog::Severity::kInfo);
     }
     ReleaseSkiaGpuResources(mGrContext.get());
     mGrContext->releaseResourcesAndAbandonContext();
@@ -1229,6 +1239,12 @@ void IGraphicsSkia::OnViewDestroyed()
 }
 
 #ifdef IGRAPHICS_VULKAN
+void IGraphicsSkia::BeginVulkanTeardown()
+{
+  std::lock_guard<std::mutex> lock(mVKSwapchainMutex);
+  mVKTeardownPending = true;
+}
+
 void IGraphicsSkia::SkipVKFrame()
 {
   IGRAPHICS_VK_LOG("SkipVKFrame",

--- a/IGraphics/Drawing/IGraphicsSkia.h
+++ b/IGraphics/Drawing/IGraphicsSkia.h
@@ -127,6 +127,9 @@ public:
   void EndFrame() override;
   void OnViewInitialized(void* pContext) override;
   void OnViewDestroyed() override;
+#if defined IGRAPHICS_VULKAN
+  void BeginVulkanTeardown();
+#endif
   void DrawResize() override;
 
   void DrawBitmap(const IBitmap& bitmap, const IRECT& dest, int srcX, int srcY, const IBlend* pBlend) override;
@@ -270,6 +273,7 @@ private:
   uint64_t mVKFrameVersion = 0;
   std::mutex mVKSwapchainMutex;
   std::unordered_set<VkImage> mVKDebugImages;
+  bool mVKTeardownPending = false;
   bool PrepareCurrentSwapchainImageForFlush();
   void ResetVulkanSwapchainCaches();
   VkCommandBuffer EnsureVulkanCommandBuffer();

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -4434,6 +4434,9 @@ void IGraphicsWin::CloseWindow()
 #if defined IGRAPHICS_VULKAN
     mVkBackendActive = false;
 #endif
+#if defined IGRAPHICS_VULKAN && defined IGRAPHICS_SKIA
+    BeginVulkanTeardown();
+#endif
     OnViewDestroyed();
 
 #if defined IGRAPHICS_GL

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -2835,7 +2835,8 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
         // When the Vulkan backend is shutting down (e.g. during CloseWindow), the device and
         // swap-chain handles are reset prior to the HWND being destroyed. Skip drawing in that
         // window to avoid dereferencing torn-down state while lingering WM_PAINT messages drain.
-        const bool hasVulkanContext = (pGraphics->mVkDevice != VK_NULL_HANDLE &&
+        const bool hasVulkanContext = (pGraphics->mVkBackendActive &&
+                                       pGraphics->mVkDevice != VK_NULL_HANDLE &&
                                        pGraphics->mVkSwapchain.handle != VK_NULL_HANDLE);
 #else
         const bool hasVulkanContext = true;
@@ -3850,6 +3851,7 @@ bool IGraphicsWin::CreateVulkanContext()
 
 void IGraphicsWin::DestroyVulkanContext()
 {
+  mVkBackendActive = false;
   if (mVkDevice)
     vkDeviceWaitIdle(mVkDevice);
 
@@ -3883,6 +3885,9 @@ void IGraphicsWin::DestroyVulkanContext()
 
 bool IGraphicsWin::RecreateVulkanContext()
 {
+#if defined IGRAPHICS_VULKAN
+  mVkBackendActive = false;
+#endif
   OnViewDestroyed();
   SkipVKFrame();
   DestroyVulkanContext();
@@ -3903,6 +3908,9 @@ bool IGraphicsWin::RecreateVulkanContext()
   ctx.format = mVkFormat;
   ctx.usageFlags = mVkSwapchainUsageFlags;
   OnViewInitialized(&ctx);
+#if defined IGRAPHICS_VULKAN
+  mVkBackendActive = true;
+#endif
   return true;
 }
 
@@ -4255,6 +4263,7 @@ void* IGraphicsWin::OpenWindow(void* pParent)
   ctx.format = mVkFormat;
   ctx.usageFlags = mVkSwapchainUsageFlags;
   OnViewInitialized(&ctx);
+  mVkBackendActive = true;
 #else
   HDC dc = GetDC(mPlugWnd);
   #ifdef IGRAPHICS_GL
@@ -4422,6 +4431,9 @@ void IGraphicsWin::CloseWindow()
     ActivateGLContext();
 #endif
 
+#if defined IGRAPHICS_VULKAN
+    mVkBackendActive = false;
+#endif
     OnViewDestroyed();
 
 #if defined IGRAPHICS_GL

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -2925,6 +2925,10 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
 
     return 0;
   }
+  case WM_DESTROY: {
+    pGraphics->ShutdownWindow(false);
+    return 0;
+  }
   case WM_CLOSE: {
     pGraphics->CloseWindow();
     return 0;
@@ -4444,99 +4448,92 @@ IRECT IGraphicsWin::GetWindowRECT()
 
 void IGraphicsWin::CloseWindow()
 {
-  if (mPlugWnd)
-  {
-    if (ControlIsCaptured() || GetCapture() == mPlugWnd)
-      ReleaseMouseCapture();
+  ShutdownWindow(true);
+}
 
-    if (mVSYNCEnabled)
-      StopVBlankThread();
-    else
-      KillTimer(mPlugWnd, IPLUG_TIMER_ID);
+void IGraphicsWin::ShutdownWindow(bool destroyWindowHandle)
+{
+  HWND plugWnd = mPlugWnd;
+  if (!plugWnd)
+    return;
+
+  if (ControlIsCaptured() || GetCapture() == plugWnd)
+    ReleaseMouseCapture();
+
+  if (mVSYNCEnabled)
+    StopVBlankThread();
+  else
+    KillTimer(plugWnd, IPLUG_TIMER_ID);
 
 #if defined IGRAPHICS_GL
-    HDC currentDC = wglGetCurrentDC();
-    HGLRC currentContext = wglGetCurrentContext();
+  HDC currentDC = wglGetCurrentDC();
+  HGLRC currentContext = wglGetCurrentContext();
 
-    if (currentContext != mHGLRC)
-    {
-      ActivateGLContext();
-    }
+  if (currentContext != mHGLRC)
+  {
+    ActivateGLContext();
+  }
 
-    OnViewDestroyed();
+  OnViewDestroyed();
 
-    DeactivateGLContext();
+  DeactivateGLContext();
 
-    DestroyGLContext();
+  DestroyGLContext();
 
-    if (mWindowDC)
-    {
-      ReleaseDC(mPlugWnd, mWindowDC);
-      mWindowDC = nullptr;
-    }
+  if (mWindowDC)
+  {
+    ReleaseDC(plugWnd, mWindowDC);
+    mWindowDC = nullptr;
+  }
 
 #elif defined IGRAPHICS_VULKAN
 
-    TeardownVulkanBackend();
+  TeardownVulkanBackend();
 
 #else
 
-    OnViewDestroyed();
+  OnViewDestroyed();
 
 #endif
 
-    SetPlatformContext(nullptr);
+  SetPlatformContext(nullptr);
 
-    if (mTooltipWnd)
-    {
-      DestroyWindow(mTooltipWnd);
-      mTooltipWnd = 0;
-      mShowingTooltip = false;
-      mTooltipIdx = -1;
-    }
+  if (mTooltipWnd)
+  {
+    DestroyWindow(mTooltipWnd);
+    mTooltipWnd = 0;
+    mShowingTooltip = false;
+    mTooltipIdx = -1;
+  }
 
+  // Unregister OLE drop target and uninitialize OLE if needed
 
-    // Unregister OLE drop target and uninitialize OLE if needed
+  if (mDropTarget)
+  {
+    RevokeDragDrop(plugWnd);
+    mDropTarget->Release();
+    mDropTarget = nullptr;
+  }
 
+  if (mOLEInited)
+  {
+    OleUninitialize();
+    mOLEInited = false;
+  }
 
-    if (mDropTarget)
+  if (destroyWindowHandle)
+  {
+    mPlugWnd = nullptr;
+    DestroyWindow(plugWnd);
+  }
+  else
+  {
+    mPlugWnd = nullptr;
+  }
 
-
-    {
-
-
-      RevokeDragDrop(mPlugWnd);
-
-
-      mDropTarget->Release();
-
-
-      mDropTarget = nullptr;
-    }
-
-
-    if (mOLEInited)
-
-
-    {
-
-
-      OleUninitialize();
-
-
-      mOLEInited = false;
-    }
-
-
-    DestroyWindow(mPlugWnd);
-
-
-    mPlugWnd = 0;
-
-    if (--nWndClassReg == 0)
-    {
-      UnregisterClassW(wndClassName, mHInstance);
-    }
+  if (--nWndClassReg == 0)
+  {
+    UnregisterClassW(wndClassName, mHInstance);
   }
 }
 

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -3073,6 +3073,9 @@ IGraphicsWin::~IGraphicsWin()
   }
   DestroyEditWindow();
   CloseWindow();
+#if defined IGRAPHICS_VULKAN
+  TeardownVulkanBackend();
+#endif
 }
 
 static void GetWindowSize(HWND pWnd, int* pW, int* pH)
@@ -3883,6 +3886,36 @@ void IGraphicsWin::DestroyVulkanContext()
   mVulkanDeviceGeneration = 0;
 }
 
+#if defined IGRAPHICS_VULKAN
+void IGraphicsWin::TeardownVulkanBackend()
+{
+  if (mVulkanTeardownStarted)
+    return;
+
+  const bool hasContext = mVkBackendActive || mVkInstance != VK_NULL_HANDLE || mVkDevice != VK_NULL_HANDLE
+                           || mVkSwapchain.handle != VK_NULL_HANDLE || mVulkanDeviceCoordinator.IsInitialized();
+
+  if (!hasContext)
+    return;
+
+  mVulkanTeardownStarted = true;
+
+  ActivateVulkanContext();
+
+  mVkBackendActive = false;
+
+#if defined IGRAPHICS_SKIA
+  BeginVulkanTeardown();
+#endif
+
+  OnViewDestroyed();
+
+  DeactivateVulkanContext();
+
+  DestroyVulkanContext();
+}
+#endif
+
 bool IGraphicsWin::RecreateVulkanContext()
 {
 #if defined IGRAPHICS_VULKAN
@@ -3910,6 +3943,7 @@ bool IGraphicsWin::RecreateVulkanContext()
   OnViewInitialized(&ctx);
 #if defined IGRAPHICS_VULKAN
   mVkBackendActive = true;
+  mVulkanTeardownStarted = false;
 #endif
   return true;
 }
@@ -4264,6 +4298,7 @@ void* IGraphicsWin::OpenWindow(void* pParent)
   ctx.usageFlags = mVkSwapchainUsageFlags;
   OnViewInitialized(&ctx);
   mVkBackendActive = true;
+  mVulkanTeardownStarted = false;
 #else
   HDC dc = GetDC(mPlugWnd);
   #ifdef IGRAPHICS_GL
@@ -4427,19 +4462,8 @@ void IGraphicsWin::CloseWindow()
     {
       ActivateGLContext();
     }
-#elif defined IGRAPHICS_VULKAN
-    ActivateGLContext();
-#endif
 
-#if defined IGRAPHICS_VULKAN
-    mVkBackendActive = false;
-#endif
-#if defined IGRAPHICS_VULKAN && defined IGRAPHICS_SKIA
-    BeginVulkanTeardown();
-#endif
     OnViewDestroyed();
-
-#if defined IGRAPHICS_GL
 
     DeactivateGLContext();
 
@@ -4453,9 +4477,11 @@ void IGraphicsWin::CloseWindow()
 
 #elif defined IGRAPHICS_VULKAN
 
-    DeactivateGLContext();
+    TeardownVulkanBackend();
 
-    DestroyVulkanContext();
+#else
+
+    OnViewDestroyed();
 
 #endif
 

--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -184,6 +184,8 @@ protected:
   IRECT GetWindowRECT();
 
 private:
+  void ShutdownWindow(bool destroyWindowHandle);
+
   // OLE drag & drop
   DragAndDropHelpers::DropTarget* mDropTarget = nullptr;
   bool mOLEInited = false;

--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -218,6 +218,7 @@ private:
   void DestroyVulkanContext();
   void ActivateVulkanContext();
   void DeactivateVulkanContext();
+  void TeardownVulkanBackend();
   bool mVkBackendActive = false;
   WinVulkanDeviceCoordinator mVulkanDeviceCoordinator;
   uint64_t mVulkanDeviceGeneration = 0;
@@ -234,6 +235,7 @@ private:
   std::vector<VkImage> mVkSwapchainImages;
   VkFormat mVkFormat = VK_FORMAT_B8G8R8A8_UNORM;
   VkImageUsageFlags mVkSwapchainUsageFlags = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+  bool mVulkanTeardownStarted = false;
 #endif
 
 #ifdef IGRAPHICS_GL

--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -218,6 +218,7 @@ private:
   void DestroyVulkanContext();
   void ActivateVulkanContext();
   void DeactivateVulkanContext();
+  bool mVkBackendActive = false;
   WinVulkanDeviceCoordinator mVulkanDeviceCoordinator;
   uint64_t mVulkanDeviceGeneration = 0;
   VkInstance mVkInstance = VK_NULL_HANDLE;


### PR DESCRIPTION
## Summary
- track whether the Windows Vulkan backend is active
- stop WM_PAINT from drawing once the backend starts tearing down
- reset the flag whenever the Vulkan context is destroyed and re-enable it after successful initialization

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68ee6884b0348320b7ca6a3548848f95