### PR TITLE
Add Vulkan descriptor pool shim for Skia

### DIFF
--- a/IGraphics/Drawing/IGraphicsSkia.cpp
+++ b/IGraphics/Drawing/IGraphicsSkia.cpp
@@ -1,7 +1,9 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdio>
+#include <cstring>
 #include <map>
+#include <mutex>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -202,6 +204,138 @@ void ReleaseSkiaGpuResources(Context* context)
 
   ReleaseSkiaGpuResourcesImpl<Context>::Apply(context);
 }
+
+class VulkanDescriptorPoolShim
+{
+public:
+  static VulkanDescriptorPoolShim& Instance()
+  {
+    static VulkanDescriptorPoolShim shim;
+    return shim;
+  }
+
+  PFN_vkVoidFunction WrapProc(const char* name, VkInstance instance, VkDevice device, PFN_vkVoidFunction proc)
+  {
+    if (!name || std::strcmp(name, "vkCreateDescriptorPool") != 0)
+      return proc;
+
+    RememberInstance(instance);
+
+    auto createProc = reinterpret_cast<PFN_vkCreateDescriptorPool>(proc);
+    if (!createProc)
+      createProc = Resolve(instance, device);
+
+    if (!createProc)
+      return proc;
+
+    Remember(device, createProc);
+    return reinterpret_cast<PFN_vkVoidFunction>(&VulkanDescriptorPoolShim::Dispatch);
+  }
+
+  void ForgetDevice(VkDevice device)
+  {
+    if (device == VK_NULL_HANDLE)
+      return;
+
+    std::lock_guard<std::mutex> lock(mMutex);
+    mDeviceCreate.erase(device);
+  }
+
+private:
+  VulkanDescriptorPoolShim() = default;
+  VulkanDescriptorPoolShim(const VulkanDescriptorPoolShim&) = delete;
+  VulkanDescriptorPoolShim& operator=(const VulkanDescriptorPoolShim&) = delete;
+
+  static VKAPI_ATTR VkResult VKAPI_CALL Dispatch(VkDevice device,
+                                                 const VkDescriptorPoolCreateInfo* pCreateInfo,
+                                                 const VkAllocationCallbacks* pAllocator,
+                                                 VkDescriptorPool* pDescriptorPool)
+  {
+    VulkanDescriptorPoolShim& shim = VulkanDescriptorPoolShim::Instance();
+    auto createProc = shim.Acquire(device);
+
+    if (!createProc)
+    {
+      createProc = shim.Resolve(VK_NULL_HANDLE, device);
+      if (createProc)
+        shim.Remember(device, createProc);
+      else
+        return VK_ERROR_INITIALIZATION_FAILED;
+    }
+
+    VkDescriptorPoolCreateInfo localInfo;
+    if (pCreateInfo)
+    {
+      localInfo = *pCreateInfo;
+      localInfo.flags |= VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
+      pCreateInfo = &localInfo;
+    }
+
+    return createProc(device, pCreateInfo, pAllocator, pDescriptorPool);
+  }
+
+  void RememberInstance(VkInstance instance)
+  {
+    if (instance == VK_NULL_HANDLE)
+      return;
+
+    std::lock_guard<std::mutex> lock(mMutex);
+    if (mInstance == VK_NULL_HANDLE)
+      mInstance = instance;
+  }
+
+  void Remember(VkDevice device, PFN_vkCreateDescriptorPool proc)
+  {
+    if (!proc)
+      return;
+
+    std::lock_guard<std::mutex> lock(mMutex);
+    if (device != VK_NULL_HANDLE)
+      mDeviceCreate[device] = proc;
+    if (!mFallback)
+      mFallback = proc;
+  }
+
+  PFN_vkCreateDescriptorPool Acquire(VkDevice device)
+  {
+    std::lock_guard<std::mutex> lock(mMutex);
+    auto it = mDeviceCreate.find(device);
+    if (it != mDeviceCreate.end())
+      return it->second;
+    return mFallback;
+  }
+
+  PFN_vkCreateDescriptorPool Resolve(VkInstance instance, VkDevice device)
+  {
+    PFN_vkCreateDescriptorPool proc = nullptr;
+
+    if (device != VK_NULL_HANDLE)
+      proc = reinterpret_cast<PFN_vkCreateDescriptorPool>(vkGetDeviceProcAddr(device, "vkCreateDescriptorPool"));
+
+    if (!proc)
+    {
+      VkInstance lookupInstance = instance;
+      if (lookupInstance == VK_NULL_HANDLE)
+      {
+        std::lock_guard<std::mutex> lock(mMutex);
+        lookupInstance = mInstance;
+      }
+
+      if (lookupInstance != VK_NULL_HANDLE)
+        proc = reinterpret_cast<PFN_vkCreateDescriptorPool>(vkGetInstanceProcAddr(lookupInstance, "vkCreateDescriptorPool"));
+    }
+
+    if (!proc)
+      proc = reinterpret_cast<PFN_vkCreateDescriptorPool>(vkGetInstanceProcAddr(VK_NULL_HANDLE, "vkCreateDescriptorPool"));
+
+    return proc;
+  }
+
+  std::mutex mMutex;
+  std::map<VkDevice, PFN_vkCreateDescriptorPool> mDeviceCreate;
+  PFN_vkCreateDescriptorPool mFallback = nullptr;
+  VkInstance mInstance = VK_NULL_HANDLE;
+};
 
 template <typename T, typename = void>
 struct HasImageViewField : std::false_type
@@ -1138,9 +1272,18 @@ void IGraphicsSkia::OnViewInitialized(void* pContext)
 
   skgpu::VulkanBackendContext backendContext = {};
   backendContext.fGetProc = [](const char* name, VkInstance instance, VkDevice device) {
+    PFN_vkVoidFunction proc = nullptr;
+
     if (device)
-      return vkGetDeviceProcAddr(device, name);
-    return vkGetInstanceProcAddr(instance, name);
+      proc = vkGetDeviceProcAddr(device, name);
+
+    if (!proc && instance)
+      proc = vkGetInstanceProcAddr(instance, name);
+
+    if (!proc)
+      proc = vkGetInstanceProcAddr(VK_NULL_HANDLE, name);
+
+    return VulkanDescriptorPoolShim::Instance().WrapProc(name, instance, device, proc);
   };
   backendContext.fInstance = mVKInstance;
   backendContext.fPhysicalDevice = mVKPhysicalDevice;
@@ -1202,6 +1345,8 @@ void IGraphicsSkia::OnViewDestroyed()
       vkDestroyCommandPool(mVKDevice, mVKCommandPool, nullptr);
     }
   }
+
+  VulkanDescriptorPoolShim::Instance().ForgetDevice(mVKDevice);
 
   mVKCommandBuffer = VK_NULL_HANDLE;
   mVKCommandPool = VK_NULL_HANDLE;


### PR DESCRIPTION
## Summary
- introduce VulkanDescriptorPoolShim to intercept vkCreateDescriptorPool and enable free-descriptor-set flag
- update Vulkan backend proc resolution to use the shim and provide fallbacks for global lookups
- ensure descriptor pool shim releases per-device state when Vulkan view is destroyed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68ef89f55ad08320bfa0b0e98c124e19