### PR TITLE
Force plugin idle after every legacy WM_PAINT frame

### DIFF
--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -1139,6 +1139,13 @@ public:
   /** @return Current idle pacing configuration requested by the host */
   EIdlePacingMode GetIdlePacingMode() const { return mIdlePacingMode; }
 
+  /** Force processing of any pending idle tasks in the connected delegate. */
+  void ForceProcessIdleTasks()
+  {
+    if (mDelegate)
+      mDelegate->ForceProcessIdleTasks();
+  }
+
   /** @return Human-readable string for an idle pacing mode */
   static const char* IdlePacingModeToString(EIdlePacingMode mode);
 

--- a/IGraphics/IGraphicsEditorDelegate.h
+++ b/IGraphics/IGraphicsEditorDelegate.h
@@ -83,6 +83,9 @@ public:
   /** Called when the idle pacing mode changes via configuration or console command */
   virtual void OnIdlePacingChanged(EIdlePacingMode) {}
 
+  /** Force the delegate to process any pending idle tasks immediately. */
+  virtual void ForceProcessIdleTasks() {}
+
   /** Serializes the size and scale of the IGraphics.
    * @param chunk The output chunk to serialize to. Will append data if the chunk has already been started.
    * @return \c true if the serialization was successful */

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -2876,6 +2876,11 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
       pGraphics->FlushDeferredInvalidations();
     }
 
+    if (pGraphics->GetIdlePacingMode() == EIdlePacingMode::Legacy)
+    {
+      pGraphics->ForceProcessIdleTasks();
+    }
+
     DeleteObject(region);
 
     return 0;

--- a/IPlug/IPlugAPIBase.cpp
+++ b/IPlug/IPlugAPIBase.cpp
@@ -158,6 +158,35 @@ void IPlugAPIBase::SendParameterValueFromAPI(int paramIdx, double value, bool no
 
 void IPlugAPIBase::OnTimer(Timer& t)
 {
+  (void) t;
+  ProcessIdleTasks();
+}
+
+void IPlugAPIBase::ForceProcessIdleTasks()
+{
+  ProcessIdleTasks();
+}
+
+void IPlugAPIBase::ProcessIdleTasks()
+{
+  bool expected = false;
+  if (!mProcessingIdleTasks.compare_exchange_strong(expected, true, std::memory_order_acq_rel))
+    return;
+
+  struct ProcessingGuard
+  {
+    std::atomic<bool>& flag;
+    ProcessingGuard(std::atomic<bool>& f)
+      : flag(f)
+    {
+    }
+
+    ~ProcessingGuard()
+    {
+      flag.store(false, std::memory_order_release);
+    }
+  } guard(mProcessingIdleTasks);
+
 #if !defined(NO_IGRAPHICS)
   iplug::igraphics::IGraphics* pGraphics = nullptr;
   iplug::igraphics::IGraphics::HostIdleTickInfo idleInfo{};

--- a/IPlug/IPlugAPIBase.h
+++ b/IPlug/IPlugAPIBase.h
@@ -14,6 +14,7 @@
 #include <cstdint>
 #include <memory>
 #include <chrono>
+#include <atomic>
 
 #include "ptrlist.h"
 #include "mutex.h"
@@ -211,6 +212,7 @@ private:
   virtual void TransmitSysExDataFromProcessor(const SysExData& data) {}
 
   void OnTimer(Timer& t);
+  void ForceProcessIdleTasks() override;
 
   friend class IPlugAPP;
   friend class IPlugAAX;
@@ -225,9 +227,12 @@ private:
   friend class IPlugWEB;
 
 private:
+  void ProcessIdleTasks();
+
   WDL_String mParamDisplayStr;
   std::unique_ptr<Timer> mTimer;
   std::chrono::steady_clock::time_point mLastUIIdleTick;
+  std::atomic<bool> mProcessingIdleTasks{false};
 
   IPlugQueue<ParamTuple> mParamChangeFromProcessor {PARAM_TRANSFER_SIZE};
   IPlugQueue<IMidiMsg> mMidiMsgsFromEditor {MIDI_TRANSFER_SIZE}; // a queue of midi messages generated in the editor by clicking keyboard UI etc


### PR DESCRIPTION
## Summary
- expose a delegate hook to immediately process pending idle tasks and wire it through IGraphics
- refactor IPlugAPIBase idle processing so it can be driven both by the timer and by forced UI requests
- call the forced idle processing after each WM_PAINT in legacy pacing mode to guarantee an OnIdle run per frame

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68f1046b54f8832084a28a8f54e4b1af