### PR TITLE
Defer forced idle processing until after paint

### DIFF
--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -1139,6 +1139,13 @@ public:
   /** @return Current idle pacing configuration requested by the host */
   EIdlePacingMode GetIdlePacingMode() const { return mIdlePacingMode; }
 
+  /** Force processing of any pending idle tasks in the connected delegate. */
+  void ForceProcessIdleTasks()
+  {
+    if (mDelegate)
+      mDelegate->ForceProcessIdleTasks();
+  }
+
   /** @return Human-readable string for an idle pacing mode */
   static const char* IdlePacingModeToString(EIdlePacingMode mode);
 

--- a/IGraphics/IGraphicsEditorDelegate.h
+++ b/IGraphics/IGraphicsEditorDelegate.h
@@ -83,6 +83,9 @@ public:
   /** Called when the idle pacing mode changes via configuration or console command */
   virtual void OnIdlePacingChanged(EIdlePacingMode) {}
 
+  /** Force the delegate to process any pending idle tasks immediately. */
+  virtual void ForceProcessIdleTasks() {}
+
   /** Serializes the size and scale of the IGraphics.
    * @param chunk The output chunk to serialize to. Will append data if the chunk has already been started.
    * @return \c true if the serialization was successful */

--- a/IGraphics/Platforms/IGraphicsWin.cpp
+++ b/IGraphics/Platforms/IGraphicsWin.cpp
@@ -2387,6 +2387,18 @@ void IGraphicsWin::OnDisplayTimer(DWORD vBlankCount, bool fromVBlankMessage)
   return;
 }
 
+void IGraphicsWin::RequestIdleFlush()
+{
+  if (!mPlugWnd)
+    return;
+
+  if (!mIdleFlushPosted)
+  {
+    mIdleFlushPosted = true;
+    PostMessageW(mPlugWnd, kForceIdleMessage, 0, 0);
+  }
+}
+
 // static
 LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
@@ -2442,6 +2454,12 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
 
   switch (msg)
   {
+  case IGraphicsWin::kForceIdleMessage:
+    pGraphics->mIdleFlushPosted = false;
+    if (pGraphics->GetIdlePacingMode() == EIdlePacingMode::Legacy)
+      pGraphics->ForceProcessIdleTasks();
+    return 0;
+
   case WM_VBLANK:
     pGraphics->OnDisplayTimer(static_cast<DWORD>(wParam), true);
     return 0;
@@ -2874,6 +2892,11 @@ LRESULT CALLBACK IGraphicsWin::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
       pGraphics->OnIdleDrainComplete(nowTick, drainedRegionCount);
 #endif
       pGraphics->FlushDeferredInvalidations();
+    }
+
+    if (pGraphics->GetIdlePacingMode() == EIdlePacingMode::Legacy)
+    {
+      pGraphics->RequestIdleFlush();
     }
 
     DeleteObject(region);
@@ -4402,6 +4425,8 @@ void IGraphicsWin::CloseWindow()
 {
   if (mPlugWnd)
   {
+    mIdleFlushPosted = false;
+
     if (ControlIsCaptured() || GetCapture() == mPlugWnd)
       ReleaseMouseCapture();
 

--- a/IGraphics/Platforms/IGraphicsWin.h
+++ b/IGraphics/Platforms/IGraphicsWin.h
@@ -188,10 +188,14 @@ private:
   DragAndDropHelpers::DropTarget* mDropTarget = nullptr;
   bool mOLEInited = false;
 
+  static constexpr UINT kForceIdleMessage = WM_APP + 0x642;
+
   /** Called either in response to WM_TIMER tick or user message WM_VBLANK, triggered by VSYNC thread
    * @param vBlankCount will allow redraws to get paced by the vblank message. Passing 0 is a WM_TIMER fallback.
    * @param fromVBlankMessage distinguishes real WM_VBLANK deliveries from the WM_TIMER fallback. */
   void OnDisplayTimer(DWORD vBlankCount = 0, bool fromVBlankMessage = false);
+
+  void RequestIdleFlush();
 
   enum EParamEditMsg
   {
@@ -438,6 +442,7 @@ private:
   std::array<std::atomic<uint64_t>, kVBlankLatencySampleCount> mVBlankLatencyMicros{};
   bool mVSYNCEnabled = false;
   bool mDeferInvalidation = false;
+  bool mIdleFlushPosted = false;
   static SchedulerTelemetrySnapshot GetSchedulerTelemetrySnapshot();
   static void ResetSchedulerTelemetrySnapshot();
 

--- a/IPlug/IPlugAPIBase.cpp
+++ b/IPlug/IPlugAPIBase.cpp
@@ -158,6 +158,35 @@ void IPlugAPIBase::SendParameterValueFromAPI(int paramIdx, double value, bool no
 
 void IPlugAPIBase::OnTimer(Timer& t)
 {
+  (void) t;
+  ProcessIdleTasks();
+}
+
+void IPlugAPIBase::ForceProcessIdleTasks()
+{
+  ProcessIdleTasks();
+}
+
+void IPlugAPIBase::ProcessIdleTasks()
+{
+  bool expected = false;
+  if (!mProcessingIdleTasks.compare_exchange_strong(expected, true, std::memory_order_acq_rel))
+    return;
+
+  struct ProcessingGuard
+  {
+    std::atomic<bool>& flag;
+    ProcessingGuard(std::atomic<bool>& f)
+      : flag(f)
+    {
+    }
+
+    ~ProcessingGuard()
+    {
+      flag.store(false, std::memory_order_release);
+    }
+  } guard(mProcessingIdleTasks);
+
 #if !defined(NO_IGRAPHICS)
   iplug::igraphics::IGraphics* pGraphics = nullptr;
   iplug::igraphics::IGraphics::HostIdleTickInfo idleInfo{};

--- a/IPlug/IPlugAPIBase.h
+++ b/IPlug/IPlugAPIBase.h
@@ -14,6 +14,7 @@
 #include <cstdint>
 #include <memory>
 #include <chrono>
+#include <atomic>
 
 #include "ptrlist.h"
 #include "mutex.h"
@@ -211,6 +212,7 @@ private:
   virtual void TransmitSysExDataFromProcessor(const SysExData& data) {}
 
   void OnTimer(Timer& t);
+  void ForceProcessIdleTasks() override;
 
   friend class IPlugAPP;
   friend class IPlugAAX;
@@ -225,9 +227,12 @@ private:
   friend class IPlugWEB;
 
 private:
+  void ProcessIdleTasks();
+
   WDL_String mParamDisplayStr;
   std::unique_ptr<Timer> mTimer;
   std::chrono::steady_clock::time_point mLastUIIdleTick;
+  std::atomic<bool> mProcessingIdleTasks{false};
 
   IPlugQueue<ParamTuple> mParamChangeFromProcessor {PARAM_TRANSFER_SIZE};
   IPlugQueue<IMidiMsg> mMidiMsgsFromEditor {MIDI_TRANSFER_SIZE}; // a queue of midi messages generated in the editor by clicking keyboard UI etc

--- a/chat.md
+++ b/chat.md
@@ -1,0 +1,13 @@
+# Idle call starvation explanation
+
+Before we added the forced post-paint idle processing, the only way `OnIdle()` could run on Windows was when the hidden timer window received the custom timer message and invoked `IPlugAPIBase::OnTimer()`, which immediately forwards to `ProcessIdleTasks()` and then `OnIdle()`.
+
+That timer message is delivered by `Timer_impl` via `PostMessageW()` to the shared message window on the UI thread. Because Windows only dispatches the timer callback when the UI thread actually drains that message, anything that keeps the queue from reaching it will starve idle processing. A plugin editor that keeps invalidating itself (for example while streaming resources during its first paints) can monopolize the message pump with back-to-back `WM_PAINT` work; if a second instance is open on the same thread the heavy painter can prevent the timer message for the other instance from ever being handled, so `OnIdle()` never fires there.
+
+By explicitly calling `ForceProcessIdleTasks()` as soon as `WM_PAINT` finishes in legacy pacing mode we guarantee that the starvation window closes every frame, even if the timer message is still stuck behind more paint work.
+
+## Ableton duplication state-change issue
+
+Duplicating a track in Live instantiates the new editor, which immediately runs through its first `WM_PAINT`. Because the legacy pacing path used to call `ForceProcessIdleTasks()` synchronously from inside the paint handler, the plug-in hit `OnIdle()` before Live had a chance to deliver the copied chunk via `effSetChunk`. Any plug-in that nudged parameters from `OnIdle()` (for instance to emit host change notifications after async asset loads) would therefore report fresh automation before the incoming state arrived. Live reacts by asking for a serialize of the untouched instance, so you observe `SerializeState()` before `UnserializeState()`, and it also flags the session dirty even right after saving.
+
+The fix keeps the “once per frame” guarantee but defers the work out of `WM_PAINT`: we now post a private `WM_APP` message after each paint, and only when that message runs do we clear the guard and call back into `ForceProcessIdleTasks()`.【F:IGraphics/Platforms/IGraphicsWin.cpp†L2390-L2400】【F:IGraphics/Platforms/IGraphicsWin.cpp†L2457-L2461】【F:IGraphics/Platforms/IGraphicsWin.cpp†L2897-L2900】 That lets the host finish delivering any pending chunk traffic before we process idle callbacks, so duplication and project saves no longer get an unsolicited state change.


### PR DESCRIPTION
## Summary
- post a private message from WM_PAINT so legacy pacing forces idle only after the paint handler unwinds
- guard against duplicate posts and clear the pending flag when the window closes
- document the Ableton duplication dirty-state investigation in chat.md

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68f1046b54f8832084a28a8f54e4b1af