### PR TITLE
Add per-button mouse ignore controls

### DIFF
--- a/IGraphics/IControl.h
+++ b/IGraphics/IControl.h
@@ -400,6 +400,48 @@ public:
   /** Specify whether the control should respond to mouse events
    * @param ignore \c true if it should ignore mouse events */
   virtual void SetIgnoreMouse(bool ignore) { mIgnoreMouse = ignore; }
+
+  /** @return \c true if the control ignores left mouse clicks */
+  bool GetIgnoreMouseLeftClick() const { return mIgnoreMouseLeftClick; }
+
+  /** @return \c true if the control ignores right mouse clicks */
+  bool GetIgnoreMouseRightClick() const { return mIgnoreMouseRightClick; }
+
+  /** @return \c true if the control ignores mouse scroll wheel events */
+  bool GetIgnoreMouseScroll() const { return mIgnoreMouseScroll; }
+
+  /** Specify whether the control should ignore left mouse clicks
+   * @param ignore \c true if it should ignore left mouse clicks */
+  virtual void SetIgnoreMouseLeftClick(bool ignore) { mIgnoreMouseLeftClick = ignore; }
+
+  /** Specify whether the control should ignore right mouse clicks
+   * @param ignore \c true if it should ignore right mouse clicks */
+  virtual void SetIgnoreMouseRightClick(bool ignore) { mIgnoreMouseRightClick = ignore; }
+
+  /** Specify whether the control should ignore mouse scroll wheel events
+   * @param ignore \c true if it should ignore mouse scroll wheel events */
+  virtual void SetIgnoreMouseScroll(bool ignore) { mIgnoreMouseScroll = ignore; }
+
+  /** @return \c true if the control should ignore a specific mouse event */
+  bool ShouldIgnoreMouse(const IMouseMod* pMod = nullptr, bool isWheel = false) const
+  {
+    if (mIgnoreMouse)
+      return true;
+
+    if (!pMod)
+      return false;
+
+    if (isWheel)
+      return mIgnoreMouseScroll;
+
+    if (pMod->L && mIgnoreMouseLeftClick)
+      return true;
+
+    if (pMod->R && mIgnoreMouseRightClick)
+      return true;
+
+    return false;
+  }
   
   /** @return \c true if the control should show parameter labels/units e.g. "Hz" in text entry prompts */
   bool GetPromptShowsParamLabel() const { return mPromptShowsParamLabel; }
@@ -578,6 +620,9 @@ protected:
   bool mMouseOverWhenDisabled = false;
   bool mMouseEventsWhenDisabled = false;
   bool mIgnoreMouse = false;
+  bool mIgnoreMouseLeftClick = false;
+  bool mIgnoreMouseRightClick = false;
+  bool mIgnoreMouseScroll = false;
   bool mWantsMidi = false;
   bool mWantsMultiTouch = false;
   bool mPromptShowsParamLabel = false;

--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -1071,7 +1071,7 @@ void IGraphics::OnMouseDown(const std::vector<IMouseInfo>& points)
     float y = point.y;
     const IMouseMod& mod = point.ms;
     
-    IControl* pCapturedControl = GetMouseControl(x, y, true, false, mod.touchID);
+    IControl* pCapturedControl = GetMouseControl(x, y, true, false, mod.touchID, &mod);
     auto captureItr = mCapturedMap.find(mod.touchID);
     CapturedControl* pCaptureInfo = captureItr != mCapturedMap.end() ? &captureItr->second : nullptr;
 
@@ -1333,7 +1333,7 @@ bool IGraphics::OnMouseDblClick(float x, float y, const IMouseMod& mod)
   Trace("IGraphics::OnMouseDblClick", __LINE__, "x:%0.2f, y:%0.2f, mod:LRSCA: %i%i%i%i%i",
         x, y, mod.L, mod.R, mod.S, mod.C, mod.A);
   
-  IControl* pControl = GetMouseControl(x, y, true);
+  IControl* pControl = GetMouseControl(x, y, true, false, 0, &mod);
     
   if (pControl)
   {
@@ -1358,7 +1358,7 @@ bool IGraphics::OnMouseDblClick(float x, float y, const IMouseMod& mod)
 
 bool IGraphics::OnMouseWheel(float x, float y, const IMouseMod& mod, float d)
 {
-  IControl* pControl = GetMouseControl(x, y, false);
+  IControl* pControl = GetMouseControl(x, y, false, false, 0, &mod, true);
   
   if (pControl)
     pControl->OnMouseWheel(x, y, mod, d);
@@ -1441,7 +1441,7 @@ void IGraphics::ReleaseMouseCapture()
 #endif
 }
 
-int IGraphics::GetMouseControlIdx(float x, float y, bool mouseOver)
+int IGraphics::GetMouseControlIdx(float x, float y, bool mouseOver, const IMouseMod* pMod, bool isWheel)
 {
   if (!mouseOver || mEnableMouseOver)
   {
@@ -1454,7 +1454,7 @@ int IGraphics::GetMouseControlIdx(float x, float y, bool mouseOver)
       if(!mLiveEdit)
       {
 #endif
-        if (!pControl->IsHidden() && !pControl->GetIgnoreMouse())
+        if (!pControl->IsHidden() && !pControl->ShouldIgnoreMouse(pMod, isWheel))
         {
           if ((!pControl->IsDisabled() || (mouseOver ? pControl->GetMouseOverWhenDisabled() : pControl->GetMouseEventsWhenDisabled())))
           {
@@ -1477,7 +1477,7 @@ int IGraphics::GetMouseControlIdx(float x, float y, bool mouseOver)
   return -1;
 }
 
-IControl* IGraphics::GetMouseControl(float x, float y, bool capture, bool mouseOver, ITouchID touchID)
+IControl* IGraphics::GetMouseControl(float x, float y, bool capture, bool mouseOver, ITouchID touchID, const IMouseMod* pMod, bool isWheel)
 {
   IControl* pControl = nullptr;
 
@@ -1513,7 +1513,7 @@ IControl* IGraphics::GetMouseControl(float x, float y, bool capture, bool mouseO
   
   if (!pControl)
   {
-    controlIdx = GetMouseControlIdx(x, y, mouseOver);
+    controlIdx = GetMouseControlIdx(x, y, mouseOver, pMod, isWheel);
     pControl = (controlIdx >= 0) ? GetControl(controlIdx) : nullptr;
   }
   

--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -1563,7 +1563,7 @@ private:
    * @param y The Y coordinate to test
    * @param mouseOver Is this initiated from mouse over event
    * @return int the index of the hit control in the control stack */
-  int GetMouseControlIdx(float x, float y, bool mouseOver = false);
+  int GetMouseControlIdx(float x, float y, bool mouseOver = false, const IMouseMod* pMod = nullptr, bool isWheel = false);
   
   /** Get the control at x and y coordinates on mouse event
    * @param x The X coordinate to test
@@ -1572,7 +1572,7 @@ private:
    * @param mouseOver Is this initiated from mouse over event
    * @param touchID The ITouchID relating to the event (multi-touch only)
    * @return IControl* The hit control in the control stack */
-  IControl* GetMouseControl(float x, float y, bool capture, bool mouseOver = false, ITouchID touchID = 0);
+  IControl* GetMouseControl(float x, float y, bool capture, bool mouseOver = false, ITouchID touchID = 0, const IMouseMod* pMod = nullptr, bool isWheel = false);
   
 #pragma mark - Event handling
 public:


### PR DESCRIPTION
### Motivation
- Provide finer-grained control over which mouse interactions a control should ignore (left click, right click, scroll) so events can be passed through to underlying controls when desired.
- Avoid the coarse `SetIgnoreMouse(bool)` which disabled all mouse activity for a control and prevent use-cases where only specific buttons should be ignored.

### Description
- Added per-button flags and accessors to `IControl` (`mIgnoreMouseLeftClick`, `mIgnoreMouseRightClick`, `mIgnoreMouseScroll`) with getters `GetIgnoreMouseLeftClick`, `GetIgnoreMouseRightClick`, `GetIgnoreMouseScroll` and setters `SetIgnoreMouseLeftClick`, `SetIgnoreMouseRightClick`, `SetIgnoreMouseScroll` in `IGraphics/IControl.h`.
- Added `ShouldIgnoreMouse(const IMouseMod* pMod = nullptr, bool isWheel = false)` helper to `IControl` which evaluates `mIgnoreMouse` and the new per-button flags against an incoming `IMouseMod` or wheel context.
- Threaded `IMouseMod` and wheel context through hit-testing by extending `IGraphics::GetMouseControlIdx` and `IGraphics::GetMouseControl` signatures to accept `const IMouseMod* pMod` and `bool isWheel` in `IGraphics/IGraphics.h`.
- Updated `IGraphics::OnMouseDown`, `OnMouseDblClick`, and `OnMouseWheel` to pass relevant `IMouseMod`/wheel context into `GetMouseControl`, and changed `GetMouseControlIdx` to use `IControl::ShouldIgnoreMouse` when deciding whether to consider a control hit in `IGraphics/IGraphics.cpp`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697efaa278e0832a8c179ad81580c65a)