### PR TITLE
Add deferred control Z-index updates

### DIFF
--- a/IGraphics/IControl.h
+++ b/IGraphics/IControl.h
@@ -486,6 +486,14 @@ public:
   
   /** Get the control's tag. @see Control Tags */
   int GetTag() const { return GetUI()->GetControlTag(this); }
+
+  /** Get the control's Z index in the control stack */
+  int GetZIndex() const { return GetUI()->GetControlIdx(this); }
+
+  /** Request a new Z index in the control stack
+   * @param zIndex The position in the control stack to move the control to. Use a negative value to move to the top of the stack.
+   * @param defer Set \c true to defer the change until the graphics context processes pending Z order updates. */
+  void SetZIndex(int zIndex, bool defer = true) { GetUI()->SetControlZIndex(this, zIndex, defer); }
   
   /** Specify whether this control wants to know about MIDI messages sent to the UI. See OnMIDIMsg() */
   void SetWantsMidi(bool enable = true) { mWantsMidi = enable; }

--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -389,6 +389,61 @@ IControl* IGraphics::AttachControl(IControl* pControl, int ctrlTag, const char* 
   return pControl;
 }
 
+void IGraphics::SetControlZIndex(IControl* pControl, int zIndex, bool defer)
+{
+  if (!pControl)
+    return;
+
+  if (defer)
+  {
+    for (auto& change : mPendingZIndexChanges)
+    {
+      if (change.pControl == pControl)
+      {
+        change.zIndex = zIndex;
+        return;
+      }
+    }
+
+    mPendingZIndexChanges.push_back({pControl, zIndex});
+    return;
+  }
+
+  ApplyControlZIndex(pControl, zIndex);
+}
+
+void IGraphics::ProcessControlZIndexChanges()
+{
+  if (mPendingZIndexChanges.empty())
+    return;
+
+  for (const auto& change : mPendingZIndexChanges)
+    ApplyControlZIndex(change.pControl, change.zIndex);
+
+  mPendingZIndexChanges.clear();
+}
+
+void IGraphics::ApplyControlZIndex(IControl* pControl, int zIndex)
+{
+  if (!pControl)
+    return;
+
+  const int currentIdx = mControls.Find(pControl);
+  if (currentIdx < 0)
+    return;
+
+  const int newSize = mControls.GetSize() - 1;
+  if (newSize < 0)
+    return;
+
+  const int targetIdx = (zIndex < 0) ? newSize : std::clamp(zIndex, 0, newSize);
+  if (targetIdx == currentIdx)
+    return;
+
+  mControls.Delete(currentIdx, false);
+  mControls.Insert(targetIdx, pControl);
+}
+
 void IGraphics::AttachCornerResizer(EUIResizerMode sizeMode, bool layoutOnResize, const IColor& color, const IColor& mouseOverColor, const IColor& dragColor, float size)
 {
   AttachCornerResizer(new ICornerResizerControl(GetBounds(), size, color, mouseOverColor, dragColor), sizeMode, layoutOnResize);
@@ -909,6 +964,8 @@ void IGraphics::PathRadialLine(float cx, float cy, float angle, float rMin, floa
 
 bool IGraphics::IsDirty(IRECTList& rects)
 {
+  ProcessControlZIndexChanges();
+
   if (mDisplayTickFunc)
     mDisplayTickFunc();
 

--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -1427,6 +1427,17 @@ public:
    * @param pControl Pointer to the control to get
    * @return integer index of the control in mControls array or -1 if not found */
   int GetControlIdx(IControl* pControl) const { return mControls.Find(pControl); }
+
+  /** Get the index of a particular IControl in the control stack (const overload)
+   * @param pControl Pointer to the control to get
+   * @return integer index of the control in mControls array or -1 if not found */
+  int GetControlIdx(const IControl* pControl) const { return mControls.Find(pControl); }
+
+  /** Set the Z index of a control in the control stack
+   * @param pControl Pointer to the control to move
+   * @param zIndex The position in the control stack to move the control to. Use a negative value to move to the top of the stack.
+   * @param defer Set \c true to defer the change until the graphics context processes pending Z order updates. */
+  void SetControlZIndex(IControl* pControl, int zIndex, bool defer = true);
   
   /** Gets the index of a tagged control
    * @param ctrlTag The tag to look for
@@ -1859,14 +1870,24 @@ protected:
 #pragma mark -
 
 private:
+  struct ControlZIndexChange
+  {
+    IControl* pControl = nullptr;
+    int zIndex = -1;
+  };
+
   void ClearMouseOver()
   {
     mMouseOver = nullptr;
     mMouseOverIdx = -1;
   }
+
+  void ProcessControlZIndexChanges();
+  void ApplyControlZIndex(IControl* pControl, int zIndex);
   
   WDL_PtrList<IControl> mControls;
   std::unordered_map<int, IControl*> mCtrlTags;
+  std::vector<ControlZIndexChange> mPendingZIndexChanges;
 
   // Order (front-to-back) ToolTip / PopUp / TextEntry / LiveEdit / Corner / PerfDisplay
   std::unique_ptr<ICornerResizerControl> mCornerResizer;


### PR DESCRIPTION
### Motivation
- Allow IControls to change their Z order at runtime without having to detach/reattach or reorder immediately, preventing mid-iteration side effects.  
- Provide a safe default that defers reordering to the graphics idle/draw pass so callers can request changes from anywhere without breaking iteration invariants.  

### Description
- Added `IControl::GetZIndex()` and `IControl::SetZIndex(int zIndex, bool defer = true)` helpers that forward to the graphics context API.  
- Added `IGraphics::SetControlZIndex(IControl* pControl, int zIndex, bool defer = true)` and a const overload `GetControlIdx(const IControl* pControl) const`, declared in `IGraphics.h`.  
- Implemented an internal `ControlZIndexChange` struct and `mPendingZIndexChanges` queue in `IGraphics`, plus `ProcessControlZIndexChanges()` and `ApplyControlZIndex()` in `IGraphics.cpp` which perform safe `Delete`/`Insert` moves on the `WDL_PtrList`.  
- Process pending Z-index changes at the start of `IGraphics::IsDirty()` so deferred updates are applied during the GUI idle/draw flow; default behavior defers changes to avoid unwanted side effects.  
- Modified files: `IGraphics/IControl.h`, `IGraphics/IGraphics.h`, `IGraphics/IGraphics.cpp`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f1aaccc1c832abb5f07cf77aac450)