### PR TITLE
Rename ignore-mouse APIs to pass-down variants

### DIFF
--- a/IGraphics/Controls/IAboutBoxControl.h
+++ b/IGraphics/Controls/IAboutBoxControl.h
@@ -69,7 +69,7 @@ public:
   : IPanelControl(bounds, color, false, attachFunc, resizeFunc)
   , mAnimationTime(animationTime)
   {
-    mIgnoreMouse = false;
+    mPassDownMouse = false;
   }
   
   bool OnKeyDown(float x, float y, const IKeyPress& key) override

--- a/IGraphics/Controls/IBubbleControl.h
+++ b/IGraphics/Controls/IBubbleControl.h
@@ -56,7 +56,7 @@ public:
   {
     mText = text;
     mHide = true;
-    mIgnoreMouse = true;
+    mPassDownMouse = true;
     
     auto animationFunc = [&](IControl* pCaller) {
       auto progress = pCaller->GetAnimationProgress();

--- a/IGraphics/Controls/IControls.cpp
+++ b/IGraphics/Controls/IControls.cpp
@@ -1221,7 +1221,7 @@ IVGroupControl::IVGroupControl(const IRECT& bounds, const char* label, float lab
 , mLabelOffset(labelOffset)
 {
   AttachIControl(this, label);
-  mIgnoreMouse = true;
+  mPassDownMouse = true;
 }
 
 IVGroupControl::IVGroupControl(const char* label, const char* groupName, float padL, float padT, float padR, float padB, const IVStyle& style)
@@ -1234,7 +1234,7 @@ IVGroupControl::IVGroupControl(const char* label, const char* groupName, float p
 , mPadB(padB)
 {
   AttachIControl(this, label);
-  mIgnoreMouse = true;
+  mPassDownMouse = true;
 }
 
 void IVGroupControl::OnInit()

--- a/IGraphics/Controls/IControls.h
+++ b/IGraphics/Controls/IControls.h
@@ -501,7 +501,7 @@ public:
   : IContainerBase(bounds)
   , IVectorBase(style)
   {
-    mIgnoreMouse = true;
+    mPassDownMouse = true;
     AttachIControl(this, label);
   }
   

--- a/IGraphics/Controls/IVPresetManagerControls.h
+++ b/IGraphics/Controls/IVPresetManagerControls.h
@@ -43,7 +43,7 @@ public:
   , IVectorBase(style)
   {
     AttachIControl(this, label);
-    mIgnoreMouse = true;
+    mPassDownMouse = true;
   }
   
   void Draw(IGraphics& g) override 
@@ -190,7 +190,7 @@ public:
   , mOnLoadFunc(onLoadFunc)
   {
     AttachIControl(this, label);
-    mIgnoreMouse = true;
+    mPassDownMouse = true;
     AddPath(presetPath, "");
     SetupMenu();
   }

--- a/IGraphics/Controls/IWebViewControl.h
+++ b/IGraphics/Controls/IWebViewControl.h
@@ -51,7 +51,7 @@ public:
   {
     // The IControl itself should never receive mouse messages
     // they need to go to the webview
-    mIgnoreMouse = true;
+    mPassDownMouse = true;
   }
   
   ~IWebViewControl()
@@ -100,11 +100,11 @@ public:
     UpdateWebViewBounds();
   }
   
-  void SetIgnoreMouse(bool ignore) override
+  void SetPassDownMouse(bool passDown) override
   {
     // The IControl itself should never receive mouse messages
     // they need to go to the webview
-    mEnableInteraction = !ignore;
+    mEnableInteraction = !passDown;
     EnableInteraction(mEnableInteraction);
   }
   
@@ -134,4 +134,3 @@ private:
 
 END_IGRAPHICS_NAMESPACE
 END_IPLUG_NAMESPACE
-

--- a/IGraphics/Controls/Test/TestGFXLabel.h
+++ b/IGraphics/Controls/Test/TestGFXLabel.h
@@ -25,7 +25,7 @@ public:
   GFXLabelControl(const IRECT& rect)
   : IControl(rect)
   {
-    mIgnoreMouse = true;
+    mPassDownMouse = true;
   }
   
   void Draw(IGraphics& g) override

--- a/IGraphics/Controls/Test/TestGesturesControl.h
+++ b/IGraphics/Controls/Test/TestGesturesControl.h
@@ -25,7 +25,7 @@ public:
   TestGesturesControl(IRECT bounds)
    : ITextControl(bounds, "Do a gesture...")
   {
-    mIgnoreMouse = false;
+    mPassDownMouse = false;
     #ifdef OS_IOS
     mText = IText(60.f);
     #endif

--- a/IGraphics/Controls/Test/TestSizeControl.h
+++ b/IGraphics/Controls/Test/TestSizeControl.h
@@ -25,7 +25,7 @@ public:
   TestSizeControl(const IRECT& bounds)
   : IControl(bounds)
   {
-    mIgnoreMouse = true;
+    mPassDownMouse = true;
     mText = IText(15, COLOR_BLACK, nullptr, EAlign::Near);
   }
 

--- a/IGraphics/IControl.cpp
+++ b/IGraphics/IControl.cpp
@@ -461,7 +461,7 @@ ITextControl::ITextControl(const IRECT& bounds, const char* str, const IText& te
 , mBGColor(BGColor)
 , mSetBoundsBasedOnStr(setBoundsBasedOnStr)
 {
-  mIgnoreMouse = true;
+  mPassDownMouse = true;
   mText = text;
 }
 
@@ -516,7 +516,7 @@ IURLControl::IURLControl(const IRECT& bounds, const char* str, const char* urlSt
 , mMOColor(MOColor)
 , mCLColor(CLColor)
 {
-  mIgnoreMouse = false;
+  mPassDownMouse = false;
 }
 
 void IURLControl::Draw(IGraphics& g)
@@ -585,7 +585,7 @@ ITextToggleControl::ITextToggleControl(const IRECT& bounds, int paramIdx, const 
 {
   SetParamIdx(paramIdx);
   //TODO: assert boolean?
-  mIgnoreMouse = false;
+  mPassDownMouse = false;
   mDblAsSingleClick = true;
 }
 
@@ -596,7 +596,7 @@ ITextToggleControl::ITextToggleControl(const IRECT& bounds, IActionFunction aF, 
 {
   SetActionFunction(aF);
   mDblAsSingleClick = true;
-  mIgnoreMouse = false;
+  mPassDownMouse = false;
 }
 
 void ITextToggleControl::OnMouseDown(float x, float y, const IMouseMod& mod)
@@ -627,7 +627,7 @@ ICaptionControl::ICaptionControl(const IRECT& bounds, int paramIdx, const IText&
   SetParamIdx(paramIdx);
   mDblAsSingleClick = true;
   mDisablePrompt = false;
-  mIgnoreMouse = false;
+  mPassDownMouse = false;
 }
 
 void ICaptionControl::OnMouseDown(float x, float y, const IMouseMod& mod)
@@ -687,7 +687,7 @@ PlaceHolder::PlaceHolder(const IRECT& bounds, const char* str)
   mBGColor = COLOR_WHITE;
   mDisablePrompt = false;
   mDblAsSingleClick = false;
-  mIgnoreMouse = false;
+  mPassDownMouse = false;
 }
 
 void PlaceHolder::Draw(IGraphics& g)

--- a/IGraphics/IControl.h
+++ b/IGraphics/IControl.h
@@ -394,50 +394,57 @@ public:
   /** @return \c true if the control responds to other mouse events when disabled */
   bool GetMouseEventsWhenDisabled() const { return mMouseEventsWhenDisabled; }
   
-  /** @return \c true if the control ignores mouse events */
-  bool GetIgnoreMouse() const { return mIgnoreMouse; }
+  /** @return \c true if the control passes mouse events down to controls underneath */
+  bool GetPassDownMouse() const { return mPassDownMouse; }
   
-  /** Specify whether the control should respond to mouse events
-   * @param ignore \c true if it should ignore mouse events */
-  virtual void SetIgnoreMouse(bool ignore) { mIgnoreMouse = ignore; }
+  /** Specify whether the control should pass mouse events down to controls underneath
+   * @param passDown \c true if it should pass mouse events down to controls underneath */
+  virtual void SetPassDownMouse(bool passDown) { mPassDownMouse = passDown; }
 
-  /** @return \c true if the control ignores left mouse clicks */
-  bool GetIgnoreMouseLeftClick() const { return mIgnoreMouseLeftClick; }
+  /** @return \c true if the control passes mouse over events down to controls underneath */
+  bool GetPassDownMouseOver() const { return mPassDownMouseOver; }
 
-  /** @return \c true if the control ignores right mouse clicks */
-  bool GetIgnoreMouseRightClick() const { return mIgnoreMouseRightClick; }
+  /** Specify whether the control should pass mouse over events down to controls underneath
+   * @param passDown \c true if it should pass mouse over events down to controls underneath */
+  virtual void SetPassDownMouseOver(bool passDown) { mPassDownMouseOver = passDown; }
 
-  /** @return \c true if the control ignores mouse scroll wheel events */
-  bool GetIgnoreMouseScroll() const { return mIgnoreMouseScroll; }
+  /** @return \c true if the control passes down left mouse clicks */
+  bool GetPassDownMouseLeftClick() const { return mPassDownMouseLeftClick; }
 
-  /** Specify whether the control should ignore left mouse clicks
-   * @param ignore \c true if it should ignore left mouse clicks */
-  virtual void SetIgnoreMouseLeftClick(bool ignore) { mIgnoreMouseLeftClick = ignore; }
+  /** @return \c true if the control passes down right mouse clicks */
+  bool GetPassDownMouseRightClick() const { return mPassDownMouseRightClick; }
 
-  /** Specify whether the control should ignore right mouse clicks
-   * @param ignore \c true if it should ignore right mouse clicks */
-  virtual void SetIgnoreMouseRightClick(bool ignore) { mIgnoreMouseRightClick = ignore; }
+  /** @return \c true if the control passes down mouse scroll wheel events */
+  bool GetPassDownMouseScroll() const { return mPassDownMouseScroll; }
 
-  /** Specify whether the control should ignore mouse scroll wheel events
-   * @param ignore \c true if it should ignore mouse scroll wheel events */
-  virtual void SetIgnoreMouseScroll(bool ignore) { mIgnoreMouseScroll = ignore; }
+  /** Specify whether the control should pass down left mouse clicks
+   * @param passDown \c true if it should pass down left mouse clicks */
+  virtual void SetPassDownMouseLeftClick(bool passDown) { mPassDownMouseLeftClick = passDown; }
 
-  /** @return \c true if the control should ignore a specific mouse event */
-  bool ShouldIgnoreMouse(const IMouseMod* pMod = nullptr, bool isWheel = false) const
+  /** Specify whether the control should pass down right mouse clicks
+   * @param passDown \c true if it should pass down right mouse clicks */
+  virtual void SetPassDownMouseRightClick(bool passDown) { mPassDownMouseRightClick = passDown; }
+
+  /** Specify whether the control should pass down mouse scroll wheel events
+   * @param passDown \c true if it should pass down mouse scroll wheel events */
+  virtual void SetPassDownMouseScroll(bool passDown) { mPassDownMouseScroll = passDown; }
+
+  /** @return \c true if the control should pass down a specific mouse event */
+  bool ShouldPassDownMouse(const IMouseMod* pMod = nullptr, bool isWheel = false) const
   {
-    if (mIgnoreMouse)
+    if (mPassDownMouse)
       return true;
 
     if (!pMod)
       return false;
 
     if (isWheel)
-      return mIgnoreMouseScroll;
+      return mPassDownMouseScroll;
 
-    if (pMod->L && mIgnoreMouseLeftClick)
+    if (pMod->L && mPassDownMouseLeftClick)
       return true;
 
-    if (pMod->R && mIgnoreMouseRightClick)
+    if (pMod->R && mPassDownMouseRightClick)
       return true;
 
     return false;
@@ -627,10 +634,11 @@ protected:
   bool mDblAsSingleClick = false;
   bool mMouseOverWhenDisabled = false;
   bool mMouseEventsWhenDisabled = false;
-  bool mIgnoreMouse = false;
-  bool mIgnoreMouseLeftClick = false;
-  bool mIgnoreMouseRightClick = false;
-  bool mIgnoreMouseScroll = false;
+  bool mPassDownMouse = false;
+  bool mPassDownMouseOver = false;
+  bool mPassDownMouseLeftClick = false;
+  bool mPassDownMouseRightClick = false;
+  bool mPassDownMouseScroll = false;
   bool mWantsMidi = false;
   bool mWantsMultiTouch = false;
   bool mPromptShowsParamLabel = false;
@@ -707,7 +715,7 @@ public:
   , mAttachFunc(attachFunc)
   , mResizeFunc(resizeFunc)
   {
-    mIgnoreMouse = true;
+    mPassDownMouse = true;
   }
   
   void SetAttachFunc(AttachFunc attachFunc)
@@ -2056,7 +2064,7 @@ public:
   , mPattern(color)
   , mDrawFrame(drawFrame)
   {
-    mIgnoreMouse = true;
+    mPassDownMouse = true;
   }
   
   IPanelControl(const IRECT& bounds, const IPattern& pattern, bool drawFrame = false,
@@ -2065,7 +2073,7 @@ public:
   , mPattern(pattern)
   , mDrawFrame(drawFrame)
   {
-    mIgnoreMouse = true;
+    mPassDownMouse = true;
   }
 
   void Draw(IGraphics& g) override
@@ -2104,7 +2112,7 @@ public:
     if (startImmediately)
       SetAnimation(DefaultAnimationFunc, mAnimationDuration);
     
-    mIgnoreMouse = ignoreMouse;
+    mPassDownMouse = ignoreMouse;
     mDblAsSingleClick = true;
   }
   
@@ -2268,7 +2276,7 @@ public:
   IEditableTextControl(const IRECT& bounds, const char* str, const IText& text = DEFAULT_TEXT, const IColor& BGColor = DEFAULT_BGCOLOR)
   : ITextControl(bounds, str, text, BGColor)
   {
-    mIgnoreMouse = false;
+    mPassDownMouse = false;
   }
   
   void OnMouseDown(float x, float y, const IMouseMod& mod) override

--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -1511,7 +1511,9 @@ int IGraphics::GetMouseControlIdx(float x, float y, bool mouseOver, const IMouse
       if(!mLiveEdit)
       {
 #endif
-        if (!pControl->IsHidden() && !pControl->ShouldIgnoreMouse(pMod, isWheel))
+        if (!pControl->IsHidden()
+            && !pControl->ShouldPassDownMouse(pMod, isWheel)
+            && !(mouseOver && pControl->GetPassDownMouseOver()))
         {
           if ((!pControl->IsDisabled() || (mouseOver ? pControl->GetMouseOverWhenDisabled() : pControl->GetMouseEventsWhenDisabled())))
           {


### PR DESCRIPTION
### Motivation
- Clarify semantics by replacing ambiguous "ignore" wording with explicit "pass down" naming so controls can opt to pass mouse events through to underlying controls. 
- Generalize the pass-down behavior across all mouse event types (mouse-over, left/right clicks, scroll, and general mouse) to provide a consistent API and hit-testing behavior.

### Description
- Renamed control flags and accessors from `Ignore*` to `PassDown*` including `mPassDownMouse`, `mPassDownMouseOver`, `mPassDownMouseLeftClick`, `mPassDownMouseRightClick`, `mPassDownMouseScroll` and accessors such as `GetPassDownMouse*`/`SetPassDownMouse*` and the helper `ShouldPassDownMouse()` in `IGraphics/IControl.h` and related source.`
- Updated hit testing in `IGraphics::GetMouseControlIdx` to consult `ShouldPassDownMouse()` and `GetPassDownMouseOver()` so controls that pass events down will no longer be chosen as hit targets for matching event types (`IGraphics/IGraphics.cpp`).
- Adjusted control implementations and initializers to use the new naming, including `IWebViewControl` override of `SetPassDownMouse()` (and its internal logic), container/panel defaults, and various test and utility controls to set `mPassDownMouse` consistently (multiple files under `IGraphics/Controls/` and `IGraphics/`).
- Updated documentation comments to reflect the new pass-down semantics and changed parameter names in setters from `ignore` to `passDown` for clarity in APIs.

### Testing
- No automated tests were run for this change.
- A local pass to update usages and compile-time renames was performed as part of the edits; no runtime or unit test validation was executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988a26b2628832ab1afdab9abb0f271)