### PR TITLE
Restore IgnoreMouse checks in GetMouseControlIdx

### DIFF
--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -1526,8 +1526,9 @@ int IGraphics::GetMouseControlIdx(float x, float y, bool mouseOver, const IMouse
       {
 #endif
         if (!pControl->IsHidden()
+            && !pControl->GetIgnoreMouse()
             && !pControl->ShouldPassDownMouse(pMod, isWheel)
-            && !(mouseOver && pControl->GetPassDownMouseOver()))
+            && !(mouseOver && (pControl->GetPassDownMouseOver() || pControl->GetIgnoreMouseOver())))
         {
           if ((!pControl->IsDisabled() || (mouseOver ? pControl->GetMouseOverWhenDisabled() : pControl->GetMouseEventsWhenDisabled())))
           {


### PR DESCRIPTION
### Motivation
- Restore backward compatibility because the new PassDown mouse system accidentally dropped `GetIgnoreMouse()`/`GetIgnoreMouseOver()` checks from hit testing, causing `SetIgnoreMouse(true)` to stop working.

### Description
- Add `!pControl->GetIgnoreMouse()` and include `pControl->GetIgnoreMouseOver()` in the `mouseOver` pass-down conditional within `IGraphics::GetMouseControlIdx()` in `IGraphics/IGraphics.cpp` so ignored controls are skipped during hit testing.

### Testing
- No automated tests were run for this focused logic change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b2d8a5044832aadf32793030b258b)